### PR TITLE
non deterministic clustering

### DIFF
--- a/ppanggolin/formats/writeBinaries.py
+++ b/ppanggolin/formats/writeBinaries.py
@@ -266,7 +266,7 @@ def write_gene_sequences(pangenome: Pangenome, h5f: tables.File, disable_bar: bo
     seq2seqid = {}
     id_counter = 0
     gene_row = gene_seq.row
-    for gene in tqdm(pangenome.genes, total=pangenome.number_of_gene(), unit="gene", disable=disable_bar):
+    for gene in tqdm(sorted(pangenome.genes, key=lambda x: x.ID), total=pangenome.number_of_gene(), unit="gene", disable=disable_bar):
         curr_seq_id = seq2seqid.get(gene.dna)
         if curr_seq_id is None:
             curr_seq_id = id_counter

--- a/ppanggolin/formats/writeSequences.py
+++ b/ppanggolin/formats/writeSequences.py
@@ -37,7 +37,7 @@ def write_gene_sequences_from_annotations(pangenome: Pangenome, file_obj: TextIO
     if list_cds is None:
         list_cds = pangenome.genes
     logging.getLogger().info("Writing all of the CDS sequences...")
-    for gene in tqdm(list_cds, unit="gene", disable=disable_bar):
+    for gene in tqdm(sorted(list_cds, key=lambda x: x.ID), unit="gene", disable=disable_bar):
         if gene.type == "CDS":
             counter += 1
             file_obj.write('>' + add + gene.ID + "\n")


### PR DESCRIPTION
Following the suggestions in #116, this simple solution highly reduces the variability in clustering results (tested on the test dataset, by shuffling genome order).

While it's highly reduced (almost all runs are identical vs all runs yield a slightly different results with the older version of the code), there is still some variability observed, so it does not solve everything, but I guess more consistency it still better?

