### PR TITLE
Fix api reference in readthedoc

### DIFF
--- a/.github/workflows/check_doc.yml
+++ b/.github/workflows/check_doc.yml
@@ -5,7 +5,8 @@ on:
     paths:
       - 'docs/**'
       - '.readthedocs.yaml'
-
+      - '.github/workflows/check_doc.yml'
+      
 jobs:
   build:
 
@@ -14,15 +15,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      name: install ppanggolin with python deps and doc deps
       with:
         python-version: '3.8'
     - run: pip install .[doc,python_deps]
 
-    # Standard drop-in approach that should work for most people.
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: "docs/"
-        build-command: "sphinx-build -b html . build/"
+    - name: Complete workflow
+      shell: bash -l {0}
+      run: |
+        cd docs/
+        sphinx-build -b html . build/
     # Great extra actions to compose with:
     # Create an artifact of the html output.
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/check_doc.yml
+++ b/.github/workflows/check_doc.yml
@@ -6,7 +6,7 @@ on:
       - 'docs/**'
       - '.readthedocs.yaml'
       - '.github/workflows/check_doc.yml'
-      
+
 jobs:
   build:
 
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-      name: install ppanggolin with python deps and doc deps
       with:
         python-version: '3.8'
-    - run: pip install .[doc,python_deps]
+    - name: install ppanggolin with python deps and doc deps
+      run: pip install .[doc,python_deps]
 
     - name: Complete workflow
       shell: bash -l {0}

--- a/.github/workflows/check_doc.yml
+++ b/.github/workflows/check_doc.yml
@@ -11,7 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.8'
+    - run: pip install .[doc,python_deps]
+
     # Standard drop-in approach that should work for most people.
     - uses: ammaraskar/sphinx-action@master
       with:

--- a/.github/workflows/check_doc.yml
+++ b/.github/workflows/check_doc.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'docs/**'
+      - '.readthedocs.yaml'
 
 jobs:
   build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,7 @@ python:
       path: .
       extra_requirements:
         - doc
+        - python_deps
 
 # Set the OS, Python version and other tools you might need
 build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,8 +5,12 @@
 # Required
 version: 2
 python:
+  version: 3.8
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
 
 # Set the OS, Python version and other tools you might need
 build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,10 +17,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
-#     python: "mambaforge-22.9"
-
-# conda:
-#   environment: ppanggolin_env.yaml
 
   
 # Build documentation in the "docs/" directory with Sphinx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,11 +14,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
+    python: "mambaforge-22.9"
 
+conda:
+  environment: ppanggolin_env.yaml
+
+  
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,8 +16,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
-  commands:
-    - pip install .[doc]
 #     python: "mambaforge-22.9"
 
 # conda:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,12 +4,12 @@
 
 # Required
 version: 2
-# python:
-#   install:
-#     - method: pip
-#       path: .
-#       extra_requirements:
-#         - doc
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc
 
 # Set the OS, Python version and other tools you might need
 build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,6 @@
 # Required
 version: 2
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-#     python: "3.8"
+     python: "3.8"
 #     python: "mambaforge-22.9"
 
 # conda:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,17 +7,19 @@ version: 2
 python:
   install:
     - method: pip
-      path: .[doc]
+      path: .
+      extra_requirements:
+        - doc
 
 # Set the OS, Python version and other tools you might need
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.8"
-    python: "mambaforge-22.9"
+# build:
+#   os: ubuntu-22.04
+#   tools:
+#     python: "3.8"
+#     python: "mambaforge-22.9"
 
-conda:
-  environment: ppanggolin_env.yaml
+# conda:
+#   environment: ppanggolin_env.yaml
 
   
 # Build documentation in the "docs/" directory with Sphinx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,7 @@ version: 2
 python:
   install:
     - method: pip
-      path: .
-      extra_requirements:
-        - docs
+      path: .[doc]
 
 # Set the OS, Python version and other tools you might need
 build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,18 +4,20 @@
 
 # Required
 version: 2
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - doc
+# python:
+#   install:
+#     - method: pip
+#       path: .
+#       extra_requirements:
+#         - doc
 
 # Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
-     python: "3.8"
+    python: "3.8"
+  commands:
+    - pip install .[doc]
 #     python: "mambaforge-22.9"
 
 # conda:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,9 +12,9 @@ python:
         - doc
 
 # Set the OS, Python version and other tools you might need
-# build:
-#   os: ubuntu-22.04
-#   tools:
+build:
+  os: ubuntu-22.04
+  tools:
 #     python: "3.8"
 #     python: "mambaforge-22.9"
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,7 @@
 # from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = source
+SOURCEDIR     = .
 BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".

--- a/docs/api/api_ref.md
+++ b/docs/api/api_ref.md
@@ -1,0 +1,8 @@
+# API Reference
+
+```{toctree}
+:maxdepth: 2
+ppanggolin
+indice_and_table
+```
+

--- a/docs/api/indice_and_table.md
+++ b/docs/api/indice_and_table.md
@@ -1,0 +1,7 @@
+# Indices and tables
+
+- {ref}`genindex`
+- {ref}`modindex`
+- {ref}`search`
+
+

--- a/docs/api/modules.md
+++ b/docs/api/modules.md
@@ -1,8 +1,0 @@
-# API Reference
-
-```{toctree}
-:maxdepth: 2
-ppanggolin
-indice_and_table
-```
-

--- a/docs/api/modules.md
+++ b/docs/api/modules.md
@@ -1,0 +1,18 @@
+# ppanggolin
+
+
+
+
+```{toctree}
+:maxdepth: 2
+
+ppanggolin
+```
+
+
+# Indices and tables
+
+- {ref}`genindex`
+- {ref}`modindex`
+- {ref}`search`
+

--- a/docs/api/modules.md
+++ b/docs/api/modules.md
@@ -1,18 +1,8 @@
-# ppanggolin
-
-
-
+# API Reference
 
 ```{toctree}
 :maxdepth: 2
-
 ppanggolin
+indice_and_table
 ```
-
-
-# Indices and tables
-
-- {ref}`genindex`
-- {ref}`modindex`
-- {ref}`search`
 

--- a/docs/api/ppanggolin.formats.md
+++ b/docs/api/ppanggolin.formats.md
@@ -29,10 +29,19 @@
    :show-inheritance:
 ```
 
-## ppanggolin.formats.writeFlat module
+## ppanggolin.formats.writeFlatGenomes module
 
 ```{eval-rst}
-.. automodule:: ppanggolin.formats.writeFlat
+.. automodule:: ppanggolin.formats.writeFlatGenomes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+## ppanggolin.formats.writeFlatPangenome module
+
+```{eval-rst}
+.. automodule:: ppanggolin.formats.writeFlatPangenome
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,9 +86,11 @@ user/metadata
 
 dev/contribute
 dev/buildDoc
+api/modules
 ```
 
-# API Reference
+
+# Indices and tables
 [//]: # (- {ref}`ppanggolin package`)
 
 - {ref}`genindex`

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,15 +86,5 @@ user/metadata
 
 dev/contribute
 dev/buildDoc
-api/modules
+api/api_ref
 ```
-
-
-# Indices and tables
-[//]: # (- {ref}`ppanggolin package`)
-
-- {ref}`genindex`
-
-- {ref}`modindex`
-
-- {ref}`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,0 @@
-sphinx==6.2.1
-sphinx_rtd_theme==1.2.2
-readthedocs-sphinx-search==0.3.1
-sphinx-autobuild==2021.3.14
-myst-parser==1.0.0
-docutils==0.18.1
-sphinxcontrib.mermaid==0.9.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,18 @@
 requires = [
     "setuptools",
     "setuptools-scm",
-    "cython"
+    "cython",
+    tqdm>=4.64,
+    tables>=3.7,
+    pyrodigal>=3.0.1,
+    networkx>=3.0,
+    scipy>=1.10.0,
+    plotly>=4.14.3,
+    gmpy2>=2.1.2,
+    pandas>=2.0,
+    colorlover>=0.3,
+    numpy>=1.24,
+    bokeh>=2.4.2,<3,
 ]
 build-backend = "setuptools.build_meta"
 py_modules=["ppanggolin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,18 @@ doc = [
     "sphinx-autobuild==2021.3.14",
     "myst-parser==2",
     "docutils==0.18.1",
-    "sphinxcontrib.mermaid==0.9.2"
+    "sphinxcontrib.mermaid==0.9.2",
+    "tqdm>=4.64",
+    "tables>=3.7",
+    "pyrodigal>=3.0.1",
+    "networkx>=3.0",
+    "scipy>=1.10.0",
+    "plotly>=4.14.3",
+    "gmpy2>=2.1.2",
+    "pandas>=2.0",
+    "colorlover>=0.3",
+    "numpy>=1.24",
+    "bokeh>=2.4.2,<3"
 ]
 test = [
     "pytest>=7.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,18 +2,7 @@
 requires = [
     "setuptools",
     "setuptools-scm",
-    "cython",
-    "tqdm>=4.64",
-    "tables>=3.7",
-    "pyrodigal>=3.0.1",
-    "networkx>=3.0",
-    "scipy>=1.10.0",
-    "plotly>=4.14.3",
-    "gmpy2>=2.1.2",
-    "pandas>=2.0",
-    "colorlover>=0.3",
-    "numpy>=1.24",
-    "bokeh>=2.4.2,<3"
+    "cython"
 ]
 build-backend = "setuptools.build_meta"
 py_modules=["ppanggolin"]
@@ -57,6 +46,11 @@ doc = [
     "myst-parser==2",
     "docutils==0.18.1",
     "sphinxcontrib.mermaid==0.9.2",
+]
+test = [
+    "pytest>=7.0.0"
+]
+python_deps = [
     "tqdm>=4.64",
     "tables>=3.7",
     "pyrodigal>=3.0.1",
@@ -68,9 +62,6 @@ doc = [
     "colorlover>=0.3",
     "numpy>=1.24",
     "bokeh>=2.4.2,<3"
-]
-test = [
-    "pytest>=7.0.0"
 ]
 #
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,17 @@ requires = [
     "setuptools",
     "setuptools-scm",
     "cython",
-    tqdm>=4.64,
-    tables>=3.7,
-    pyrodigal>=3.0.1,
-    networkx>=3.0,
-    scipy>=1.10.0,
-    plotly>=4.14.3,
-    gmpy2>=2.1.2,
-    pandas>=2.0,
-    colorlover>=0.3,
-    numpy>=1.24,
-    bokeh>=2.4.2,<3,
+    "tqdm>=4.64",
+    "tables>=3.7",
+    "pyrodigal>=3.0.1",
+    "networkx>=3.0",
+    "scipy>=1.10.0",
+    "plotly>=4.14.3",
+    "gmpy2>=2.1.2",
+    "pandas>=2.0",
+    "colorlover>=0.3",
+    "numpy>=1.24",
+    "bokeh>=2.4.2,<3"
 ]
 build-backend = "setuptools.build_meta"
 py_modules=["ppanggolin"]


### PR DESCRIPTION
The API reference generated by sphinx-apidoc was missing in our ReadTheDocs-hosted documentation. This problem occurred because ppanggolin and all Python dependencies weren't installed during the documentation build process. For more details, refer to this [Stack Overflow](https://stackoverflow.com/questions/64697264/genindex-and-modindex-footer-links-dont-work-in-readthedocs-io).

To fix the problem:

- Added all Python dependencies in a specific category within the toml file.
- Modified the installation process in `.readthedocs.yaml`  to install ppanggolin with the documentation and Python dependencies.
- Remove requirements.txt in docs folder as it was not used anymore
- Added the API Reference to the TOC tree of the Dev documentation section.


