### PR TITLE
Add version check between pangenome file (h5) and the installed ppanggolin

### DIFF
--- a/ppanggolin/formats/readBinaries.py
+++ b/ppanggolin/formats/readBinaries.py
@@ -105,6 +105,13 @@ def get_status(pangenome: Pangenome, pangenome_file: Path):
         pangenome.status["geneFamilySequences"] = "inFile"
     if status_group._v_attrs.NeighborsGraph:
         pangenome.status["neighborsGraph"] = "inFile"
+    
+    if hasattr(status_group._v_attrs, "version"):
+        pangenome.status["ppanggolin_version"] = str(status_group._v_attrs.version)
+    else:
+        logging.getLogger("PPanGGOLiN").error(f'The provided pangenome file {pangenome_file} does not have a version stored in its status.'
+                         ' This issue may indicate that the file is corrupted.')
+        pangenome.status["ppanggolin_version"] = None
 
     if status_group._v_attrs.Partitioned:
         pangenome.status["partitioned"] = "inFile"

--- a/ppanggolin/pangenome.py
+++ b/ppanggolin/pangenome.py
@@ -66,19 +66,25 @@ class Pangenome:
         }
         self.parameters = {}
 
-    def add_file(self, pangenome_file: Path):
-        """Links an HDF5 file to the pangenome. If needed elements will be loaded from this file,
+    def add_file(self, pangenome_file: Path, check_version:bool=True):
+        """
+        Links an HDF5 file to the pangenome. If needed elements will be loaded from this file,
         and anything that is computed will be saved to this file when
         :func:`ppanggolin.formats.writeBinaries.writePangenome` is called.
 
         :param pangenome_file: A string representing filepath to hdf5 pangenome file to be either used or created
-
+        :param check_version: Check ppanggolin version of the pangenome file to be compatible with the current version of ppaggolin being used.
         :raises AssertionError: If the `pangenome_file` is not an instance of the Path class
         """
         assert isinstance(pangenome_file, Path), "pangenome file should be a Path object type"
         from ppanggolin.formats.readBinaries import get_status
+        from ppanggolin.utils import check_version_compatibility
         # importing on call instead of importing on top to avoid cross-reference problems.
+
         get_status(self, pangenome_file)
+
+        check_version_compatibility(self.status["ppanggolin_version"])
+
         self.file = pangenome_file.absolute().as_posix()
 
     """ Gene Methods"""

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -1065,3 +1065,41 @@ def flatten_nested_dict(nested_dict: Dict[str, Union[Dict, int, str, float]]) ->
 
     flatten(nested_dict)
     return flat_dict
+
+def get_major_version(version: str) -> int:
+    """
+    Extracts the major version number from a version string.
+
+    :param version: A string representing the version number.
+    :return: The major version extracted from the input version string.
+    :raises ValueError: If the input version does not have the expected format.
+    """
+    try:
+        major_version = int(version.split('.')[0])
+    except ValueError:
+        raise ValueError(f"Version {version} does not have the expected format.")
+
+    return major_version
+
+
+def check_version_compatibility(file_version: str) -> None:
+    """
+    Checks the compatibility of the provided pangenome file version with the current PPanGGOLiN version.
+
+    :param file_version: A string representing the version of the pangenome file.
+    """
+    # Get the current PPanGGOLiN version
+    current_version = distribution('ppanggolin').version
+
+    current_version_major = get_major_version(current_version)
+    file_major_version = get_major_version(file_version)
+
+    # Check for compatibility issues
+    if file_major_version != current_version_major:
+        logging.getLogger("PPanGGOLiN").error('Your pangenome file has been created with a different major version '
+                                              'of PPanGGOLiN than the one installed in the system. This mismatch may lead to compatibility issues.')
+
+    if file_major_version < 2 and current_version_major >= 2:
+        raise ValueError(f'The provided pangenome file was created by PPanGGOLiN version {file_version}, which is '
+                         f'incompatible with the current PPanGGOLiN version {current_version}.')
+


### PR DESCRIPTION
**Overview:**

Version 2 introduces changes that break the compatibility with pangenome files created using Version 1. 

This PR addresses the check of the PPanGGOLiN versions that have been used to create the pangenome file and the current version that parses this file. 🛠️

**Error Handling:**

1. **Scenario 1 (Incompatibility):**
   - When the installed PPanGGOLiN version is >= 2 and the pangenome file was created by a version < 2:
     PPanGGOLiN will fail and raise the following error:
     `ValueError: The provided pangenome file was created by PPanGGOLiN version 1.2.105, which is incompatible with the current PPanGGOLiN version 2.0.0a1.`

2. **Scenario 2 (Version Mismatch):**
   - In any other case where the major version between the pangenome file and the current installation differs:
     The following logging error is generated:
     `2023-12-22 10:23:13 utils.py:l1099 ERROR	Your pangenome file has been created with a different major version of PPanGGOLiN than the one installed in the system. This mismatch may lead to compatibility issues.` 
     No exception will be raised. This approach allows for compatibility between versions, enabling the use of Version 2 with Version 3 files in case Version 3 doesn't break compatibility with Version 2.