### PR TITLE
Update install documentation

### DIFF
--- a/docs/dev/buildDoc.md
+++ b/docs/dev/buildDoc.md
@@ -6,13 +6,7 @@ This section provides guidelines for building the PPanGGOLiN documentation local
 
 Before proceeding, ensure that you have installed PPanGGOLiN from the source code. For detailed instructions, refer to [this section](../user/install.md#installing-from-source-code-github).
 
-The necessary packages to build the documentation are listed in the 'requirements.txt' file located in the `doc/` folder.
-
-```bash
-pip install -r docs/requirements.txt
-```
-
-Alternatively, the same list of requirements is available in the [pyproject.toml file](../../pyproject.toml), which allows for automatic installation using `pip`.
+The necessary packages to build the documentation are listed in the [pyproject.toml file](../../pyproject.toml), which allows for automatic installation using `pip`.
 
 ```shell
 # Replace '/path/to/ppanggolin/' with your actual path

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -71,9 +71,7 @@ cd PPanGGOLiN
 
 To ensure the tool functions correctly, you need to install all dependencies listed in the [ppanggolin_env.yaml](../../ppanggolin_env.yaml) file.
 
-**2.1. Installing Required Software**
-
-Install the following non-Python software:
+Next, install the following non-Python software:
 
 - [MMSeqs2>=13.45111](https://github.com/soedinglab/MMseqs2/wiki#installation)
 - [Aragorn>=1.2.41](http://www.ansikte.se/ARAGORN/Downloads/)

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -71,35 +71,7 @@ cd PPanGGOLiN
 
 To ensure the tool functions correctly, you need to install all dependencies listed in the [ppanggolin_env.yaml](../../ppanggolin_env.yaml) file.
 
-**2.1. Installing Python Dependencies**
-
-Create a file named `requirements.txt` and add the following contents:
-
-```text
-tqdm>=4.64
-tables>=3.7
-pyrodigal>=3.0.1
-networkx>=3.0
-scipy>=1.10.0
-plotly>=4.14.3
-gmpy2>=2.1.2
-pandas>=2.0
-colorlover>=0.3
-numpy>=1.24
-bokeh>=2.4.2,<3
-```
-
-Then, use **pip** to install these dependencies:
-
-```bash
-python3 -m pip install -r requirements.txt
-```
-
-```{warning}
-Ensure you are using Python version 3.8 or higher.
-```
-
-**2.2. Installing Required Software**
+**2.1. Installing Required Software**
 
 Install the following non-Python software:
 
@@ -114,13 +86,16 @@ Install the following non-Python software:
 - Skip installing Aragorn, Infernal, or MAFFT if you do not require their specific features.
 ```
 
-**3. Installing PPanGGOLiN**
+**3. Installing PPanGGOLiN with its Python Dependencies**
 
-Finally, install PPanGGOLiN using **pip**:
+PPanGGOLiN's Python dependencies are specified in the `pyproject.toml` file under the optional dependencies category named `python_deps`. This configuration file is situated at the root of the PPanGGOLiN repository.
+
+To install PPanGGOLiN along with its Python dependencies, you can use the following pip command:
 
 ```bash
-pip install .
+pip install .[python_deps]
 ```
+
 
 ## Development Version
 


### PR DESCRIPTION
This Pull Request addresses recent changes in the repository to ensure alignment with the updated structure of the repo.

1. The `requirements.txt` file in the `docs` folder has been removed. Documentation dependencies are now only specified in the `pyproject.toml` file, categorized as optional dependencies under the name `docs`. Previously, the `docs/requirements.txt` file was used by readthedocs for building the documentation. However, the `.readthedocs.yaml` file has been modified in PR #156 to only rely on dependencies listed in `pyproject.toml`. The documentation has been updated accordingly. 


2. The manual installation process for PPanGGOLiN included a list of Python dependencies to be placed in a `requirements.txt` file. These dependencies are now defined in the `pyproject.toml` file,  file under the optional dependencies category `python_deps`. The documentation no longer includes a specific list of dependencies; instead, it directs users to install dependencies from the `pyproject.toml`.  This ensure to not have to update the list of deps in multiple location. 