### PR TITLE
Update  readthedocs-sphinx-search version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ license = {file="LICENCE.txt"}
 doc = [
     "sphinx==6.2.1",
     "sphinx_rtd_theme==1.2.2",
-    "readthedocs-sphinx-search==0.3.1",
+    "readthedocs-sphinx-search==0.3.2",
     "sphinx-autobuild==2021.3.14",
     "myst-parser==2",
     "docutils==0.18.1",


### PR DESCRIPTION
Update readthedocs-sphinx-search version to address a security vulnerability.

See here for more info on the security vulnerability: https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj