### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ RGPs from different genomes are next grouped in spots of insertion based on thei
 
 Those RGPs can be further divided in conserved modules by panModule ([Bazin et al. 2021](https://doi.org/10.1101/2021.12.06.471380)). Those conserved modules correspond to groups of cooccurring and colocalized genes that are gained or lost together in the variable regions of the pangenome.
 
-A complete documentation is avaialble [here](https://ppanggolin.readthedocs.io).
+A complete documentation is available [here](https://ppanggolin.readthedocs.io).
 
 <!-- ![PPanGGOLiN logo](docs/_static/logo.png) -->
 

--- a/docs/user/PangenomeAnalyses/pangenomeFigures.md
+++ b/docs/user/PangenomeAnalyses/pangenomeFigures.md
@@ -65,33 +65,3 @@ ppanggolin rarefaction -p pangenome.h5 --min 5 --max 50 --depth 30
 ```
 
 Will draw a rarefaction curve with sample sizes between 5 and 50 (between 5 and 50 genomes will be used), and with 30 samples at each point (so 30 samples of 5 genomes, 30 samples or 6 genomes ... up to 50 genomes).
-
-
-#### Spot plots
-
-The 'draw' command can draw specific spots of interest, whose ID are provided, or all the spots if you wish.
-It will also write a graph file in GEXF format, which corresponds to the gene families and their organization within the spots. It is basically a subgraph of the pangenome, consisting of the spot itself.
-
-The command can be utilized as follows:
-
-- To generate an interactive .html figure and a corresponding gexf file for all spots:
-```bash
-ppanggolin draw -p pangenome.h5 --draw_spots --spots all
-```
-
-- If your focus is on a particular spot, you can utilize its identifier to draw it. For example, to draw spot_34:
-```bash
-ppanggolin draw -p pangenome.h5 --draw_spots --spots spot_34 
-```
-
-
-The interactive figures that are drawn look like this:
-
-
-![spot plot figure](../../_static/drawspot_example.png)
-
-The plot represents the different gene organizations that are found in the spot. If there are RGPs with identical gene organization, the organization is represented only once (the represented RGP is picked at random among all identical RGPs). The list of RGPs with the same organization is accessible in the file written alongside the figure called 'spot_X_identical_rgps.tsv', with X the spot_id.
-
-They can be edited using the sliders and the radio buttons, to change various graphical parameters, and then the plot itself can be saved using the save button on the right of the screen, if need be.
-
-For the gexf file, you can see how to visualize it in the section about the [pangenome gexf](./pangenomeGraphOut.md#pangenome-graph-output).

--- a/docs/user/RGP/rgpOutputs.md
+++ b/docs/user/RGP/rgpOutputs.md
@@ -80,7 +80,7 @@ The flag `--borders` also creates a file call `border_protein_genes.fasta` that 
 
 In addition, the `--borders` option also generates a file named `border_protein_genes.fasta`, containing protein sequences corresponding to the gene families of the spot borders.
 
-## Draw spots
+### Draw spots
 
 The `draw` command with the option `--draw_spots` can draw specific spots of interest, whose ID are provided, or all the spots if you wish.
 It will also write a gexf file, which corresponds to the gene families and their organization within the spots. It is basically a subgraph of the pangenome, consisting of the spot itself.


### PR DESCRIPTION
- Remove duplicate documentation about "draw spot" found in the PangenomeAnalyses section when it should only be in the Regions of genome plasticity analyses section. 
- Fix header  "draw spot"  section in RGP/rgpAnalyses.html#rgp-outputs section. 