### PR TITLE
Fix workflow checking the bioconda recipe

### DIFF
--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -26,13 +26,12 @@ jobs:
       # Setting up miniconda
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          condarc-file: .condarc.yml
           activate-environment: test
           python-version: ${{ matrix.python-version }}
       - name: Set up test environment
         shell: bash -l {0}
         run: |
-            conda install -y ppanggolin
+            conda install -c conda-forge -c bioconda -y ppanggolin
       - name: check installation
         shell: bash -l {0}
         run: |

--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -26,8 +26,8 @@ jobs:
       # Setting up miniconda
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: test
           python-version: ${{ matrix.python-version }}
+          channels: conda-forge,bioconda,defaults
       - name: Set up test environment
         shell: bash -l {0}
         run: |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To ensure a smoother installation and avoid conflicting dependencies, it's highl
 
 ```bash
 # Install PPanGGOLiN into a new conda environment
-conda create -n ppanggolin -c conda-forge -c bioconda ppanggolin
+conda create -n ppanggolin -c defaults -c conda-forge -c bioconda ppanggolin
 
 # Check PPanGGOLiN install
 conda activate ppanggolin

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -11,7 +11,7 @@ To ensure a smoother installation and avoid conflicting dependencies, it's highl
 
 ```bash
 # Install into a new conda environment
-conda create -n ppanggo -c conda-forge -c bioconda ppanggolin
+conda create -n ppanggo -c defaults -c conda-forge -c bioconda ppanggolin
 
 # Check PPanGGOLiN install
 conda activate ppanggo


### PR DESCRIPTION
The bioconda recipe-checking workflow (`.github/workflows/check_recipes.yml`) was failling due to the use of an outdated `.condarc` file for configuring conda channels, which has been removed since version 2.0.0. 

To address this issue, we update the workflow to use the 'channels' argument of the conda-incubator/setup-miniconda@v2 action to replace the `.condarc` file.