### PR TITLE
Making tmpdir name truly unique in clustering step

### DIFF
--- a/ppanggolin/cluster/cluster.py
+++ b/ppanggolin/cluster/cluster.py
@@ -303,7 +303,9 @@ def clustering(pangenome: Pangenome, tmpdir: Path, cpu: int = 1, defrag: bool = 
     """
 
     if keep_tmp_files:
-        dir_name = 'clustering_tmpdir' + time.strftime("_%Y-%m-%d_%H.%M.%S", time.localtime())
+        date = time.strftime("_%Y-%m-%d_%H-%M-%S", time.localtime())
+
+        dir_name = f'clustering_tmpdir_{date}_PID{os.getpid()}'
         tmp_path = Path(tmpdir) / dir_name
         mk_outdir(tmp_path, force=True)
     else:

--- a/ppanggolin/workflow/all.py
+++ b/ppanggolin/workflow/all.py
@@ -79,7 +79,8 @@ def launch_workflow(args: argparse.Namespace, panrgp: bool = True,
             clustering(pangenome, tmpdir=args.tmpdir, cpu=args.cluster.cpu, force=args.force,
                        disable_bar=args.disable_prog_bar,
                        defrag=not args.cluster.no_defrag, code=args.cluster.translation_table,
-                       coverage=args.cluster.coverage, identity=args.cluster.identity, mode=args.cluster.mode)
+                       coverage=args.cluster.coverage, identity=args.cluster.identity, mode=args.cluster.mode,
+                       keep_tmp_files=args.cluster.keep_tmp)
         clust_time = time.time() - start_clust
 
     elif args.fasta is not None:
@@ -101,7 +102,8 @@ def launch_workflow(args: argparse.Namespace, panrgp: bool = True,
         clustering(pangenome, tmpdir=args.tmpdir, cpu=args.cluster.cpu, force=args.force,
                    disable_bar=args.disable_prog_bar,
                    defrag=not args.cluster.no_defrag, code=args.cluster.translation_table,
-                   coverage=args.cluster.coverage, identity=args.cluster.identity, mode=args.cluster.mode)
+                   coverage=args.cluster.coverage, identity=args.cluster.identity, mode=args.cluster.mode,
+                   keep_tmp_files=args.cluster.keep_tmp)
         clust_time = time.time() - start_clust
 
     write_pangenome(pangenome, filename, args.force, disable_bar=args.disable_prog_bar)


### PR DESCRIPTION
Subject: PR: Unique tmpdir Names for Clustering

Previously, temporaty directory names in the clustering step were based on the date and hour, like `/tmp/clustering_tmpdir_2024-02-12_11.02.20/`. This caused problems when PPanGGOLiN ran simultaneously (in a pipeline for example), potentially creating the same tmpdir for different executions and causing errors.

To fix this, I just added the Process ID (PID) to the tmpdir name. Now, each tmpdir is unique, avoiding conflicts.

Additionally, I noticed and fixed a small bug: the keep_tmp_files argument was missing from the clustering function in workflow mode. This made it impossible to save tmpdir with a config file in a workflow.