### PR TITLE
 Fixing Issues in ppanggolin Fasta Command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,10 @@ jobs:
         ppanggolin write_pangenome -p stepbystep/pangenome.h5 --output stepbystep -f --soft_core 0.9 --dup_margin 0.06  --gexf --light_gexf --csv --Rtab --stats --partitions --compress --json --spots --regions --borders --families_tsv --cpu 1 
         ppanggolin write_genomes  -p stepbystep/pangenome.h5 --output stepbystep -f --fasta genomes.fasta.list --gff --proksee --table
         ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families all --gene_families shell --regions all --fasta genomes.fasta.list
+        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families rgp --fasta genomes.fasta.list
+        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families softcore --fasta genomes.fasta.list
+        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families module_1 --fasta genomes.fasta.list
+
         ppanggolin draw -p stepbystep/pangenome.h5 --draw_spots --spots all -o stepbystep -f
         ppanggolin metrics -p stepbystep/pangenome.h5 --genome_fluidity --no_print_info --recompute_metrics --log metrics.log
         cd - 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,9 +72,11 @@ jobs:
         ppanggolin write_pangenome -p stepbystep/pangenome.h5 --output stepbystep -f --soft_core 0.9 --dup_margin 0.06  --gexf --light_gexf --csv --Rtab --stats --partitions --compress --json --spots --regions --borders --families_tsv --cpu 1 
         ppanggolin write_genomes  -p stepbystep/pangenome.h5 --output stepbystep -f --fasta genomes.fasta.list --gff --proksee --table
         ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families all --gene_families shell --regions all --fasta genomes.fasta.list
-        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families rgp --fasta genomes.fasta.list
-        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families softcore --fasta genomes.fasta.list
-        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families module_1 --fasta genomes.fasta.list
+        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families rgp --gene_families rgp 
+        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families softcore --gene_families softcore 
+        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families module_0
+        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --prot_families core
+        ppanggolin fasta -p stepbystep/pangenome.h5 --output stepbystep -f --gene_families module_0 --genes module_0
 
         ppanggolin draw -p stepbystep/pangenome.h5 --draw_spots --spots all -o stepbystep -f
         ppanggolin metrics -p stepbystep/pangenome.h5 --genome_fluidity --no_print_info --recompute_metrics --log metrics.log

--- a/ppanggolin/geneFamily.py
+++ b/ppanggolin/geneFamily.py
@@ -386,12 +386,12 @@ class GeneFamily(MetaFeatures):
     def get_org_dict(self) -> Dict[Organism, Set[Gene]]:
         """Returns the organisms and the genes belonging to the gene family
 
-        :return: A dictionnary of organism as key and set of genes as values
+        :return: A dictionary of organism as key and set of genes as values
         """
         if len(self._genePerOrg) == 0:
             for gene in self.genes:
                 if gene.organism is None:
-                    raise AttributeError(f"Gene: {gene.name} is not fill with organism")
+                    raise AttributeError(f"Gene: {gene.name} is not fill with genome")
                 self._genePerOrg[gene.organism].add(gene)
         return self._genePerOrg
 


### PR DESCRIPTION
This pull request addresses an issue with the `ppanggolin fasta` command, specifically when attempting to output core, softcore and rgp protein families (refer to #179).

The problem stemmed from the fact that annotation data from the pangenome.h5 file was not loaded when writing protein families, even though it is crucial for determining whether a family belongs to the core or not.

Additionally, I identified a problem with module filtering. It was not possible to write genes, protein families, or gene families of a module when giving a module id because argparse expected a regex pattern while it was processing string. To fix this, I added a type function to validate the input value that use the regex to validate module format.

I also incorporated some `ppanggolin fasta`  commands into the GitHub CI to check that everything run smoothly. 