### PR TITLE
Fix zero div when there is no module

### DIFF
--- a/ppanggolin/formats/writeBinaries.py
+++ b/ppanggolin/formats/writeBinaries.py
@@ -526,6 +526,7 @@ def write_info_modules(pangenome: Pangenome, h5f: tables.File):
 
 
     mod_fam = [len(module) for module in pangenome.modules]
+    sum_mod_fam = sum(mod_fam)
     
     info_group._v_attrs.StatOfFamiliesInModules = {"min": getmin(mod_fam),
                                                     "max": getmax(mod_fam),
@@ -536,19 +537,19 @@ def write_info_modules(pangenome: Pangenome, h5f: tables.File):
     spec_shell = part_spec(part='shell')
     spec_cloud = part_spec(part='cloud')
 
-    info_group._v_attrs.PersistentSpecInModules = {"percent": round((sum(spec_pers) / sum(mod_fam)) * 100, 2),
+    info_group._v_attrs.PersistentSpecInModules = {"percent": round((sum(spec_pers) / sum_mod_fam) * 100, 2) if sum_mod_fam > 0 else 0,
                                                     "min": getmin(spec_pers),
                                                     "max": getmax(spec_pers),
                                                     "sd": getstdev(spec_pers),
                                                     "mean": getmean(spec_pers)}
     
-    info_group._v_attrs.ShellSpecInModules = {"percent": round((sum(spec_shell) / sum(mod_fam)) * 100, 2),
+    info_group._v_attrs.ShellSpecInModules = {"percent": round((sum(spec_shell) / sum_mod_fam) * 100, 2) if sum_mod_fam > 0 else 0,
                                                 "min": getmin(spec_shell),
                                                 "max": getmax(spec_shell),
                                                 "sd": getstdev(spec_shell),
                                                 "mean": getmean(spec_shell)}
     
-    info_group._v_attrs.CloudSpecInModules = {"percent": round((sum(spec_cloud) / sum(mod_fam)) * 100, 2),
+    info_group._v_attrs.CloudSpecInModules = {"percent": round((sum(spec_cloud) / sum_mod_fam) * 100, 2) if sum_mod_fam > 0 else 0,
                                                 "min": getmin(spec_cloud),
                                                 "max": getmax(spec_cloud),
                                                 "sd": getstdev(spec_cloud),


### PR DESCRIPTION
Small bug detected when no module is predicted, there is a DivisionbyZero error when calculating module info and writing it to the pangenome file.

Not having a module is quite rare, but it can happen and should be handled. To fix the problem, I simply added a test to prevent the division.

The error:
```
Traceback (most recent call last):
  File "/usr/local/bin/ppanggolin", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/ppanggolin/main.py", line 219, in main
    ppanggolin.workflow.all.launch(args)
  File "/usr/local/lib/python3.10/site-packages/ppanggolin/workflow/all.py", line 288, in launch
    launch_workflow(args, panrgp=True, panmodule=True)
  File "/usr/local/lib/python3.10/site-packages/ppanggolin/workflow/all.py", line 164, in launch_workflow
    write_pangenome(pangenome, filename, args.force, disable_bar=args.disable_prog_bar)
  File "/usr/local/lib/python3.10/site-packages/ppanggolin/formats/writeBinaries.py", line 755, in write_pangenome
    write_modules(pangenome, h5f, force, disable_bar=disable_bar)
  File "/usr/local/lib/python3.10/site-packages/ppanggolin/formats/writeBinaries.py", line 402, in write_modules
    write_info_modules(pangenome, h5f)
  File "/usr/local/lib/python3.10/site-packages/ppanggolin/formats/writeBinaries.py", line 539, in write_info_modules
    info_group._v_attrs.PersistentSpecInModules = {"percent": round((sum(spec_pers) / sum(mod_fam)) * 100, 2),
ZeroDivisionError: division by zero
/usr/local/lib/python3.10/site-packages/tables/file.py:113: UnclosedFileWarning:

```