### PR TITLE
Handle multiple spots per RGP in projection command

### DIFF
--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -652,6 +652,10 @@ def predict_RGP(pangenome: Pangenome, input_organisms: List[Organism], persisten
     for input_organism in input_organisms:
         rgps = compute_org_rgp(input_organism, multigenics, persistent_penalty, variable_gain, min_length,
                                min_score, naming=name_scheme, disable_bar=disable_bar)
+        # turn on projected attribut in rgp objects
+        # useful when associating spot to prevent failure when multiple spot are associated to a projected RGP
+        for rgp in rgps:
+            rgp.projected = True
 
         logging.getLogger('PPanGGOLiN').info(f"{len(rgps)} RGPs have been predicted in the input genomes.")
 

--- a/ppanggolin/region.py
+++ b/ppanggolin/region.py
@@ -393,7 +393,10 @@ class Spot(MetaFeatures):
         if name in self._region_getter and self[name] != region:
             raise KeyError("A Region with the same name already exist in spot")
         if region.spot is not None and region.spot != self:
-            raise ValueError("The region is already with a different spot. A region belongs to only one spot.")
+            logging.getLogger("PPanGGOLiN").warning(f"The region '{region.name}' is already associated with spot '{region.spot.ID}' while being associated with spot '{self.ID}'. "
+                                            "A region should only belong to one spot. The exception to this rule occurs in the projection command, where a projected RGP "
+                                            "can link two spots in the spot graph.")
+
         self._region_getter[name] = region
         region.spot = self
 

--- a/ppanggolin/region.py
+++ b/ppanggolin/region.py
@@ -52,6 +52,7 @@ class Region(MetaFeatures):
         self.stopper = None
         self.ID = Region.id_counter
         self._spot = None
+        self.projected = False # If the rgp is from a projected genome. If true can have multiple spots
         Region.id_counter += 1
 
     def __str__(self):
@@ -392,10 +393,14 @@ class Spot(MetaFeatures):
         """
         if name in self._region_getter and self[name] != region:
             raise KeyError("A Region with the same name already exist in spot")
-        if region.spot is not None and region.spot != self:
-            logging.getLogger("PPanGGOLiN").warning(f"The region '{region.name}' is already associated with spot '{region.spot.ID}' while being associated with spot '{self.ID}'. "
-                                            "A region should only belong to one spot. The exception to this rule occurs in the projection command, where a projected RGP "
-                                            "can link two spots in the spot graph.")
+        
+        if not region.projected and region.spot is not None and region.spot != self:
+            # In normal cases, a region should only belong to one spot. However, an exception arises in the projection command, 
+            # where a projected RGP might link two spots in the spot graph.
+            # To handle this scenario without triggering failure, we check the 'projected' attribute of the given region.
+                     
+            raise ValueError(f"The region '{region.name}' is already associated with spot '{region.spot.ID}' while being associated with spot '{self.ID}'. "
+                                            "A region should only belong to one spot.")
 
         self._region_getter[name] = region
         region.spot = self


### PR DESCRIPTION
This PR fixes another rare issue with the projection command's spot prediction.

## Problem context
In the projection, we reproduce the spot graph and check that the original RGPs are in their spots. Then we add the new RGPs from this spot graph and find their spots. In some cases, a new RGP may be connected to two spots (technically, the RGP in the graph is connected to two connected components). If the projected genome was first used in the pangenome, these two spots would be a unique spot. 
The choice made in the projection command is not to change the previous spot result, but simply to report the two spots for this particular RGP in the output of the projection. 

## Problem encountered
This situation was initially handled.  Reporting multiple spots in the projection output is enabled and works fine. But the spot class has been strengthened to add some test when an RGP is added to a spot, it checks that the RGP does not already have another spot assigned. and raise an error. When an RGP is assigned to multiple spot in projection, this error is raised. 
This situation is quite rare, but I recently encountered it in the pangenome of Vibrio dialbolicus.

## Implemented fix
To fix this problem, I added a projected attribute in the Region class to set it to True when in projection in order to be able to prevent the error in this context where multiple spots per RGP is legit. 