### PR TITLE
Use mmseqs createdb-mode 1 to reduce clustering tmpdir size

### DIFF
--- a/ppanggolin/cluster/cluster.py
+++ b/ppanggolin/cluster/cluster.py
@@ -85,7 +85,7 @@ def first_clustering(sequences: TextIO, tmpdir: Path, cpu: int = 1, code: int = 
     :return: path to representative sequence file and path to tsv clustering result
     """
     seq_nucdb = tmpdir / 'nucleotid_sequences_db'
-    cmd = list(map(str, ["mmseqs", "createdb", sequences.name, seq_nucdb]))
+    cmd = list(map(str, ["mmseqs", "createdb", "--createdb-mode", 1, sequences.name, seq_nucdb]))
     logging.getLogger("PPanGGOLiN").debug(" ".join(cmd))
     logging.getLogger("PPanGGOLiN").info("Creating sequence database...")
     subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
@@ -150,7 +150,7 @@ def align_rep(faa_file: Path, tmpdir: Path, cpu: int = 1, coverage: float = 0.8,
     """
     logging.getLogger("PPanGGOLiN").debug("Create database")
     seqdb = tmpdir / 'rep_sequence_db'
-    cmd = list(map(str, ["mmseqs", "createdb", faa_file, seqdb]))
+    cmd = list(map(str, ["mmseqs", "createdb", "--createdb-mode", 1, faa_file, seqdb]))
     logging.getLogger("PPanGGOLiN").debug(" ".join(cmd))
     subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
     logging.getLogger("PPanGGOLiN").info("Aligning cluster representatives...")


### PR DESCRIPTION
When running ppanggolin on a large collection of genomes, the temporary file generated by the clustering step can become very large. For instance, when constructing a pangenome of E. coli made of ~33k genomes, the temporary directory was 404GB in size. This size can quickly become a bottleneck and may exceed the capacity of the temporary directory.

This large temporary file is primarily caused by the duplication of CDS sequences from all genomes in the temporary directory. Initially, ppanggolin writes these sequences to the temporary directory, and then mmseqs copies them to create its database file.

To address this issue, the solution implemented in this PR is to use the `createdb-mode 1` option of mmseqs `createdb` command. This option enables mmseqs to utilize symbolic links instead of copying the data. 

I have tested this option on test pangenomes and observed a 40% reduction in the size of the temporary directory.
