### PR TITLE
Fix rgp circularity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-        channels: conda-forge,bioconda,defaults
+        channels: defaults,bioconda,conda-forge
         environment-file: ppanggolin_env.yaml
         activate-environment: ppanggolin
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-        channels: defaults,bioconda,conda-forge
+        channels: conda-forge,bioconda,defaults
         environment-file: ppanggolin_env.yaml
         activate-environment: ppanggolin
 

--- a/ppanggolin/RGP/genomicIsland.py
+++ b/ppanggolin/RGP/genomicIsland.py
@@ -119,6 +119,10 @@ def init_matrices(contig: Contig, multi: set, persistent_penalty: int = 3, varia
         if prev.state == 0:
             zero_ind = prev
         mat.append(prev)
+        logging.getLogger("PPanGGOLiN").debug(f"gene:{gene.ID};zero_ind:{zero_ind};curr_state:{curr_state};curr_score:{curr_score}.")
+    
+    if zero_ind is None:
+        zero_ind = prev#don't go further than the current node, if no node were at 0.
 
     # if the contig is circular, and we're in a rgp state,
     # we need to continue from the "starting" gene until we leave rgp state.
@@ -131,6 +135,7 @@ def init_matrices(contig: Contig, multi: set, persistent_penalty: int = 3, varia
             mat_node = mat[c]
             if mat_node == zero_ind:
                 # then we've parsed the entire contig twice.
+                logging.getLogger("PPanGGOLiN").debug(f"{contig.name} was parsed entirely twice.")
                 # The whole sequence is a rgp, so we're stopping the iteration now, otherwise we'll loop indefinitely
                 break
 
@@ -141,9 +146,10 @@ def init_matrices(contig: Contig, multi: set, persistent_penalty: int = 3, varia
                 modif = variable_gain
                 nb_perc = 0
 
-            curr_score = modif + prev.score
+            curr_score = modif + mat_node.prev.score
             curr_state = 1 if curr_score >= 0 else 0
             mat_node.changes(curr_score)
+            logging.getLogger("PPanGGOLiN").debug(f"gene:{mat_node.gene.ID};curr_state:{curr_state};curr_score:{curr_score}.")
             c += 1
     return mat
 

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -345,10 +345,11 @@ def read_org_gff(organism: str, gff_file_path: Path, circular_contigs: List[str]
                 pseudogene = False
 
                 if fields_gff[gff_type] == 'region':
-                    if fields_gff[gff_seqname] in circular_contigs or ('Is_circular' in attributes and
-                                                                       attributes['Is_circular']):
+                    if fields_gff[gff_seqname] in circular_contigs or ('IS_CIRCULAR' in attributes and
+                                                                       attributes['IS_CIRCULAR']=="true"):
                         # WARNING: In case we have prodigal gff with is_circular attributes. 
                         # This would fail as contig is not defined. However is_circular should not be found in prodigal gff
+                        logging.getLogger("PPanGGOLiN").debug(f"Contig {contig.name} is circular.")
                         contig.is_circular = True
                         assert contig.name == fields_gff[gff_seqname]
 


### PR DESCRIPTION
This PR fixes two related problems:

- read "Is_circular" properly from gff files. They were not read as they should've and this attribute was ignored previously.
- Force the RGP "looping" around circular contigs in the specific case where a contig does not have a single node at score 0. Previously the looping was not done in that case, and scores were not recomputed with the information of circularity.