### PR TITLE
Test ppanggolin outputs consistency 

### DIFF
--- a/.github/workflows/check_doc.yml
+++ b/.github/workflows/check_doc.yml
@@ -27,7 +27,7 @@ jobs:
         sphinx-build -b html . build/
     # Great extra actions to compose with:
     # Create an artifact of the html output.
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: DocumentationHTML
         path: docs/build/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,4 +193,10 @@ jobs:
       shell: bash -l {0}
       run: |
         cd testingDataset
-        python compare_results.py -e expected_info_files/ -t info_to_test/
+        python compare_results.py -e expected_info_files/ -t info_to_test/ -o diff_output
+
+    - name: Archive diff files
+      uses: actions/upload-artifact@v4
+      with:
+        name: comparison-results
+        path: testingDataset/diff_output/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,15 +188,20 @@ jobs:
         # Pipe separatore is found in metadata source db1. if we don't require this source then the writting with pipe is work fine. 
         ppanggolin write_genomes -p mybasicpangenome/pangenome.h5 --output mybasicpangenome/genomes_outputs_with_metadata -f --gff --proksee --table --add_metadata  --metadata_sources db2 db3 db4 
 
-
     - name: testing info output
       shell: bash -l {0}
       run: |
         cd testingDataset
         python compare_results.py -e expected_info_files/ -t info_to_test/ -o diff_output
 
-    - name: Archive diff files
-      uses: actions/upload-artifact@v4
-      with:
-        name: comparison-results
-        path: testingDataset/diff_output/*
+  archive_diff:
+    name: archive diff results
+    needs: test
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Archive diff files
+        uses: actions/upload-artifact@v4
+        with:
+          name: comparison-results
+          path: testingDataset/info_to_test/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     # Check that unit tests are all passing
     - name: Unit tests
       shell: bash -l {0}
-      run: pytest
+      run: pytest   
 
     # Test the complete workflow
     - name: Complete workflow
@@ -59,8 +59,8 @@ jobs:
       shell: bash -l {0}
       run: |
         cd testingDataset
-        ppanggolin annotate --fasta genomes.fasta.list --output stepbystep --kingdom bacteria
-        ppanggolin cluster -p stepbystep/pangenome.h5 --coverage 0.8 --identity 0.8
+        ppanggolin annotate --fasta genomes.fasta.list --output stepbystep --kingdom bacteria --cpu 1
+        ppanggolin cluster -p stepbystep/pangenome.h5 --coverage 0.8 --identity 0.8 --cpu 1
         ppanggolin graph -p stepbystep/pangenome.h5 -r 10
         ppanggolin partition --output stepbystep -f -p stepbystep/pangenome.h5 --cpu 1 -b 2.6 -ms 10 -fd -ck 500 -Kmm 3 12 -im 0.04 --draw_ICL -se $RANDOM
         ppanggolin rarefaction --output stepbystep -f -p stepbystep/pangenome.h5 --depth 5 --min 1 --max 50 -ms 10 -fd -ck 30 -K 3 --soft_core 0.9 -se $RANDOM
@@ -86,16 +86,16 @@ jobs:
       run: |
         cd testingDataset
         ppanggolin workflow --cpu 1 --anno genomes.gbff.list --output myannopang
-        ppanggolin msa --pangenome myannopang/pangenome.h5 --source dna --partition core -o myannopang/ -f --use_gene_id --phylo --single_copy
+        ppanggolin msa --pangenome myannopang/pangenome.h5 --source dna --partition core -o myannopang/ -f --use_gene_id --phylo --single_copy --cpu 1
         cd -
     - name: clusters reading from external file
       shell: bash -l {0}
       run: |
         cd testingDataset
-        ppanggolin panrgp --anno genomes.gbff.list --cluster clusters.tsv --output readclusterpang
-        ppanggolin annotate --anno genomes.gbff.list --output readclusters
-        ppanggolin cluster --clusters clusters.tsv -p readclusters/pangenome.h5
-        ppanggolin msa --pangenome readclusterpang/pangenome.h5 --partition persistent --phylo -o readclusterpang/msa/ -f
+        ppanggolin panrgp --anno genomes.gbff.list --cluster clusters.tsv --output readclusterpang --cpu 1
+        ppanggolin annotate --anno genomes.gbff.list --output readclusters --cpu 1
+        ppanggolin cluster --clusters clusters.tsv -p readclusters/pangenome.h5 --cpu 1 
+        ppanggolin msa --pangenome readclusterpang/pangenome.h5 --partition persistent --phylo -o readclusterpang/msa/ -f --cpu 1
         cd -
     - name: testing rgp_cluster command
       shell: bash -l {0}
@@ -110,17 +110,17 @@ jobs:
       run: |
         cd testingDataset
         ppanggolin align --pangenome mybasicpangenome/pangenome.h5 --sequences some_chlam_proteins.fasta \
-                         --output test_align --draw_related --getinfo --fast
+                         --output test_align --draw_related --getinfo --fast --cpu 1
         cd -
     - name: testing context command
       shell: bash -l {0}
       run: |
         cd testingDataset
-        ppanggolin context --pangenome myannopang/pangenome.h5 --sequences some_chlam_proteins.fasta --output test_context --fast
+        ppanggolin context --pangenome myannopang/pangenome.h5 --sequences some_chlam_proteins.fasta --output test_context --fast --cpu 1
 
         # test from gene family ids. Test here with one family of module 1. The context should find all families of module 1
         echo AP288_RS05055 > one_family_of_module_1.txt 
-        ppanggolin context --pangenome myannopang/pangenome.h5 --family one_family_of_module_1.txt  --output test_context_from_id
+        ppanggolin context --pangenome myannopang/pangenome.h5 --family one_family_of_module_1.txt  --output test_context_from_id --cpu 1
         cd -
     - name: testing metadata command
       shell: bash -l {0}
@@ -143,23 +143,23 @@ jobs:
       run: |
         cd testingDataset
         ppanggolin utils --default_config panrgp -o panrgp_default_config.yaml
-        ppanggolin panrgp  --anno genomes.gbff.list --cluster clusters.tsv -o test_config --config panrgp_default_config.yaml
+        ppanggolin panrgp  --anno genomes.gbff.list --cluster clusters.tsv -o test_config --config panrgp_default_config.yaml --cpu 1
         cd -
     - name: testing projection cmd
       shell: bash -l {0}
       run: |
         cd testingDataset
         head genomes.gbff.list | sed 's/^/input_genome_/g' > genomes.gbff.head.list
-        ppanggolin projection --pangenome stepbystep/pangenome.h5  -o projection_from_list_of_gbff --anno genomes.gbff.head.list --gff --proksee
+        ppanggolin projection --pangenome stepbystep/pangenome.h5  -o projection_from_list_of_gbff --anno genomes.gbff.head.list --gff --proksee --cpu 1
 
 
         ppanggolin projection --pangenome mybasicpangenome/pangenome.h5  -o projection_from_single_fasta \
                               --genome_name chlam_A --fasta FASTA/GCF_002776845.1_ASM277684v1_genomic.fna.gz \
-                              --spot_graph --graph_formats graphml --fast --keep_tmp -f --add_sequences --gff --proksee --table --add_metadata
+                              --spot_graph --graph_formats graphml --fast --keep_tmp -f --add_sequences --gff --proksee --table --add_metadata --cpu 1
 
         ppanggolin projection --pangenome mybasicpangenome/pangenome.h5  -o projection_from_gff_prodigal \
                               --genome_name chlam_annotated_with_prodigal --anno GBFF/GCF_003788785.1_ct114V1_genomic_prodigal_annotation.gff.gz \
-                               --gff  --table
+                               --gff  --table --cpu 1
 
     - name: testing write_genome_cmds
       shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v3
     # Install requirements with miniconda
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         channels: conda-forge,bioconda,defaults

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,10 @@ jobs:
       shell: bash -l {0}
       run: |
         cd testingDataset
+        mkdir info_to_test
         ppanggolin all --cpu 1 --fasta genomes.fasta.list --output mybasicpangenome
-        ppanggolin info --pangenome mybasicpangenome/pangenome.h5 --content --parameters --status
+        ppanggolin info --pangenome mybasicpangenome/pangenome.h5 --content --parameters --status > info_to_test/mybasicpangenome_info.yaml
+        cat info_to_test/mybasicpangenome_info.yaml
         cd -
     # test most options calls. If there is a change in the API somewhere that was not taken into account (whether in the options for the users, or the classes for the devs), this should fail, otherwise everything is probably good.
     #--draw_hotspots option is problematic on macOS.
@@ -80,6 +82,8 @@ jobs:
 
         ppanggolin draw -p stepbystep/pangenome.h5 --draw_spots --spots all -o stepbystep -f
         ppanggolin metrics -p stepbystep/pangenome.h5 --genome_fluidity --no_print_info --recompute_metrics --log metrics.log
+        ppanggolin info --pangenome stepbystep/pangenome.h5 > info_to_test/stepbystep_info.yaml
+        cat info_to_test/stepbystep_info.yaml
         cd - 
     - name: gbff parsing and MSA computing
       shell: bash -l {0}
@@ -87,6 +91,8 @@ jobs:
         cd testingDataset
         ppanggolin workflow --cpu 1 --anno genomes.gbff.list --output myannopang
         ppanggolin msa --pangenome myannopang/pangenome.h5 --source dna --partition core -o myannopang/ -f --use_gene_id --phylo --single_copy --cpu 1
+        ppanggolin info --pangenome myannopang/pangenome.h5 > info_to_test/myannopang_info.yaml
+        cat info_to_test/myannopang_info.yaml
         cd -
     - name: clusters reading from external file
       shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
         ppanggolin annotate --fasta genomes.fasta.list --output stepbystep --kingdom bacteria --cpu 1
         ppanggolin cluster -p stepbystep/pangenome.h5 --coverage 0.8 --identity 0.8 --cpu 1
         ppanggolin graph -p stepbystep/pangenome.h5 -r 10
-        ppanggolin partition --output stepbystep -f -p stepbystep/pangenome.h5 --cpu 1 -b 2.6 -ms 10 -fd -ck 500 -Kmm 3 12 -im 0.04 --draw_ICL -se $RANDOM
+        ppanggolin partition --output stepbystep -f -p stepbystep/pangenome.h5 --cpu 1 -b 2.6 -ms 10 -fd -ck 500 -Kmm 3 12 -im 0.04 --draw_ICL
         ppanggolin rarefaction --output stepbystep -f -p stepbystep/pangenome.h5 --depth 5 --min 1 --max 50 -ms 10 -fd -ck 30 -K 3 --soft_core 0.9 -se $RANDOM
         ppanggolin draw -p stepbystep/pangenome.h5 --tile_plot --nocloud --soft_core 0.92 --ucurve --output stepbystep -f
         ppanggolin rgp -p stepbystep/pangenome.h5 --persistent_penalty 2 --variable_gain 1 --min_score 3 --dup_margin 0.05
@@ -189,3 +189,8 @@ jobs:
         ppanggolin write_genomes -p mybasicpangenome/pangenome.h5 --output mybasicpangenome/genomes_outputs_with_metadata -f --gff --proksee --table --add_metadata  --metadata_sources db2 db3 db4 
 
 
+    - name: testing info output
+      shell: bash -l {0}
+      run: |
+        cd testingDataset
+        python compare_results.py -e expected_info_files/ -t info_to_test/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       shell: bash -l {0}
       run: |
         pip install .[test]
-        conda list
+        mmseqs version
 
     # Check that it is installed and displays help without error
     - name: Check that PPanGGOLiN is installed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,21 +187,15 @@ jobs:
 
         # Pipe separatore is found in metadata source db1. if we don't require this source then the writting with pipe is work fine. 
         ppanggolin write_genomes -p mybasicpangenome/pangenome.h5 --output mybasicpangenome/genomes_outputs_with_metadata -f --gff --proksee --table --add_metadata  --metadata_sources db2 db3 db4 
-
+      
+    - name: Archive diff files
+      uses: actions/upload-artifact@v4
+      with:
+        name: comparison-results
+        path: testingDataset/info_to_test/*
+    
     - name: testing info output
       shell: bash -l {0}
       run: |
         cd testingDataset
         python compare_results.py -e expected_info_files/ -t info_to_test/ -o diff_output
-
-  archive_diff:
-    name: archive diff results
-    needs: test
-    if: failure()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Archive diff files
-        uses: actions/upload-artifact@v4
-        with:
-          name: comparison-results
-          path: testingDataset/info_to_test/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
       shell: bash -l {0}
       run: |
         pip install .[test]
+        conda list
 
     # Check that it is installed and displays help without error
     - name: Check that PPanGGOLiN is installed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,8 +192,9 @@ jobs:
     - name: Archive diff files
       uses: actions/upload-artifact@v4
       with:
-        name: comparison-results
+        name: comparison-results_${{ matrix.os }}_python${{ matrix.python-version }}
         path: testingDataset/info_to_test/*
+        
     
     - name: testing info output
       shell: bash -l {0}

--- a/docs/dev/contribute.md
+++ b/docs/dev/contribute.md
@@ -42,7 +42,23 @@ It's essential to update the documentation to reflect your changes. Provide clea
 
 ### Continuous Integration (CI) Workflow
 
-We've set up a CI workflow in the Actions tab, which executes a series of PPanGGOLiN commands to validate their functionality. If you've introduced a new feature, consider adding a command line to the CI YAML file to test it and ensure its seamless integration.
+We've set up a CI workflow in the Actions tab that executes a series of PPanGGOLiN commands to validate their functionality, and also compares the contents of the PPanGGOLiN info files generated during the workflow with the expected ones stored in the `testingDataset` directory. If you've introduced a new feature, consider adding a command line to the CI YAML file to test it and ensure its seamless integration.
+
+The CI workflow can be launched locally using the Python script `launch_test_locally.py` located in the `testingDataset` directory. This script reads the CI pipeline file and creates a bash script to facilitate local execution of the pipeline.
+
+
+To setup the local execution with 10 CPUs in the local_CI directory, execute the following command:
+
+```bash
+python testingDataset/launch_test_locally.py -o local_CI -c 10 
+
+```
+
+Then, run the local CI using the following command:
+
+```bash
+(cd local_CI; bash launch_test_command.sh)
+```
 
 ### Unit Tests
 

--- a/ppanggolin/cluster/cluster.py
+++ b/ppanggolin/cluster/cluster.py
@@ -214,9 +214,9 @@ def refine_clustering(tsv: Path, aln_file: Path,
                 simgraph.nodes[line[0]]["length"] = int(line[2])
                 simgraph.nodes[line[1]]["length"] = int(line[3])
 
-    for node, nodedata in simgraph.nodes(data=True):
+    for node, nodedata in sorted(simgraph.nodes(data=True)):
         choice = (None, 0, 0, 0)
-        for neighbor in simgraph.neighbors(node):
+        for neighbor in sorted(simgraph.neighbors(node)):
             nei = simgraph.nodes[neighbor]
             score = simgraph[neighbor][node]["score"]
             if nei["length"] > nodedata["length"] and nei["nbgenes"] >= nodedata["nbgenes"] and choice[3] < score:

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -54,7 +54,7 @@ def write_json_header(json: TextIO):
         orgstr.append('"' + org.name + '": {')
         contigstr = []
         for contig in org.contigs:
-            contigstr.append(f'"{contig.name}": ' + '{"is_circular: ' +
+            contigstr.append(f'"{contig.name}": ' + '{"is_circular": ' +
                              ('true' if contig.is_circular else 'false') + '}')
         orgstr[-1] += ', '.join(contigstr) + "}"
 
@@ -70,7 +70,7 @@ def write_json_gene_fam(gene_fam: GeneFamily, json: TextIO):
     :param json: file-like object, compressed or not
     """
     json.write('{' + f'"id": "{gene_fam.name}", "nb_genes": {len(gene_fam)}, '
-                     f'"partition": "{gene_fam.named_partition}", "subpartition": "{gene_fam.partition}"' + '}')
+                     f'"partition": "{gene_fam.named_partition}", "subpartition": "{gene_fam.partition}"' )
     org_dict = {}
     name_counts = Counter()
     product_counts = Counter()

--- a/ppanggolin/formats/write_proksee.py
+++ b/ppanggolin/formats/write_proksee.py
@@ -316,4 +316,4 @@ def write_proksee_organism(organism: Organism, output_file: Path,
 
     logging.debug(f"Write ProkSee for {organism.name}")
     with write_compressed_or_not(output_file, compress=compress) as out_json:
-        json.dump(proksee_data, out_json, indent=2)
+        json.dump(proksee_data, out_json, indent=2, sort_keys=True)

--- a/testingDataset/compare_results.py
+++ b/testingDataset/compare_results.py
@@ -1,0 +1,236 @@
+import filecmp
+import difflib
+import os
+
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+import logging
+from pathlib import Path
+
+from rich.console import Console
+from rich.syntax import Syntax
+from rich.panel import Panel
+
+from rich.logging import RichHandler
+
+from rich import box
+from rich.theme import Theme
+from collections import Counter
+import json
+
+custom_theme = Theme({
+    "identical": "bold green",
+    "neutral": "bold yellow",
+    "difference": "bold red"
+})
+console = Console(theme=custom_theme)
+
+
+def are_json_files_identical(file1, file2):
+    a = json.dumps(file1.as_posix(), sort_keys=True)
+    b = json.dumps(file2.as_posix(), sort_keys=True)
+    return a == b,[] # a normal string comparison
+
+
+def are_text_files_identical(expected_file, file2, outdir=Path("./")):
+    diff_details = []
+    common_file = expected_file.name
+    # max_lines_to_display = 10
+
+    if filecmp.cmp(expected_file, file2, shallow=False):
+        return True, diff_details
+
+
+    # console.print(f"\n[bold red]{common_file} is different.[/bold red].")
+
+    # Compare file content
+    with open(expected_file, 'r') as f1, open(file2, 'r') as f2:
+
+        f1_content, f2_content = sorted(f1.readlines()), sorted(f2.readlines())
+        f1_line_count = len(f1_content)
+        f2_line_count = len(f2_content)
+
+        diff = difflib.unified_diff(f1_content, f2_content, fromfile=expected_file.as_posix(), tofile=file2.as_posix())
+        diff = [line.rstrip() for line in diff]
+        if len(diff) == 0:
+            return True, diff_details
+        # diff_lines_to_display = []
+        diff_event_counter = {"+":0, "-":0}
+        # truncated_diff_lines = 0
+        
+        diff_file = outdir / f"{common_file}.diff"
+        with open(diff_file, 'w') as out:
+            out.write('\n'.join(diff) + '\n')
+
+        # gather stat on diff
+        diff_event_counter = Counter((line[0] for line in diff[2:] if line[0] in ['+', '-']))
+        
+        prct_inserted = 100 * diff_event_counter["+"] / f1_line_count
+        prct_deleted = 100 * diff_event_counter["-"] / f2_line_count
+        diff_prct = max(prct_inserted, prct_deleted)
+        diff_details.append(f'{diff_event_counter["+"]} insertions(+), {diff_event_counter["-"]} deletions(-) - {diff_prct:.1f}% difference')
+        diff_details.append(f'code {diff_file}')
+        diff_details.append(f'code --diff {expected_file} {file2}')
+        # display=False
+        # if display:
+        #     # Display the n first line of diff with rich
+        #     diff_lines_to_display = diff[:max_lines_to_display]
+        #     truncated_diff_lines = len(diff_lines_to_display) - len(diff)
+        
+        #     if truncated_diff_lines:
+        #         diff_lines_to_display.append(f'... {truncated_diff_lines} more diff lines ....')
+
+        #     diff_content = '\n'.join( diff_lines_to_display ) 
+
+        #     syntax = Syntax(diff_content, "diff", line_numbers=False, theme="ansi_dark")
+        #     console.print(Panel(syntax, title=f"Differences in file {common_file}", expand=True, box=box.HORIZONTALS), overflow="ellipsis")
+    
+    return False, diff_details
+
+def add_subdir_to_files(subdir, files):
+    return [os.path.join(subdir, file) for file in  files]
+
+def compare_dir_recursively(expected_dir, tested_dir, ignored_files):
+    dcmp_result = filecmp.dircmp(expected_dir, tested_dir)
+
+    for subdir  in dcmp_result.common_dirs:
+        sub_dcmp_result = compare_dir_recursively(expected_dir/subdir, tested_dir/subdir, ignored_files)
+        for files_attr in ['right_only', 'left_only', 'common_files', "same_files", "diff_files"]:
+            files_list = getattr(dcmp_result, files_attr)
+            files_list += add_subdir_to_files(subdir, getattr(sub_dcmp_result, files_attr))
+            
+        
+    return dcmp_result
+
+def compare_directories(expected_dir, tested_dir, ignored_files, diff_outdir, extension_to_compare=[".tsv"]): #, ".json", '.gff', '.txt', '.csv']):
+
+    # Define directory information with color
+    expected_dir_info = f"- Expected directory: [bold green]{expected_dir}[/bold green]"
+    tested_dir_info = f"- Tested directory: [bold blue]{tested_dir}[/bold blue]"
+
+    # Create the panel
+    panel_title = "[bold cyan]Comparison of Directories:[/bold cyan]"
+    panel_content = "\n".join([expected_dir_info, tested_dir_info])
+    comparison_panel = Panel(panel_content, title=panel_title, title_align="center", expand=False)
+    console.print(comparison_panel)
+
+    # Compare directories
+    dcmp = compare_dir_recursively(expected_dir, tested_dir, ignored_files=ignored_files)
+    ignored_files_ext = [common_file for common_file in dcmp.common_files if Path(common_file).suffix not in extension_to_compare]
+
+    if ignored_files:
+        console.print("\nFiles ignored for comparison:", style="bold")
+        for ignored_file in ignored_files:
+            console.print(f"  - {ignored_file}")
+
+    if ignored_files_ext:
+        console.print("\nFiles ignored for comparison due to their extensions:", style="bold")
+        for ignored_file in ignored_files_ext:
+            console.print(f"  - {ignored_file}")
+
+    # Report missing files
+    if dcmp.left_only:
+        console.print("\nMissing files or directories in Tested results:", style='neutral')
+        for file in dcmp.left_only:
+            console.print(f"  - {file}")
+
+    if dcmp.right_only:
+        console.print("\nUnexpected files or directories found in Tested results:", style='neutral')
+        for file in dcmp.right_only:
+            console.print(f"  - {file}")
+
+    different_files = []
+    identical_files = []
+
+    
+    files_to_compare = list( set(dcmp.common_files) - set(ignored_files_ext))
+
+    for common_file in files_to_compare:
+        file1 = expected_dir / common_file
+        file2 = tested_dir / common_file
+
+        # if Path(common_file).suffix == ".json":
+        #     identical_tables, details = are_json_files_identical(file1, file2)
+        # else:
+        identical_tables, details = are_text_files_identical(file1, file2, outdir=diff_outdir)
+
+        if identical_tables:
+            identical_files.append(common_file)
+        else:
+            different_files.append((common_file, details))
+    
+    # if identical_files:
+    #     console.print("\nIdentical files:", style='identical')
+    #     for file in identical_files:
+    #         console.print(f"  - {file}")
+
+    if different_files:
+        console.print("\nDifferent files:", style='difference')
+        for file, details  in different_files:
+            console.print(f"  - {file}")
+            for detail in details:
+                console.print(f"{detail}")
+            print()
+
+    # Generate summary report
+    console.print("\n[bold]Summary:[/bold]")
+
+    console.print(f"{len(identical_files)} file(s) identical.")
+
+    console.print(f"{len(ignored_files_ext)} file(s) ignored because of their extension.")
+
+    console.print(f"{len(dcmp.left_only)} file(s) unexpected in Tested results.", )
+    console.print(f"{len(dcmp.right_only)} file(s) missing in Tested results.")
+
+    console.print(f"{len(different_files)} file(s) different.")
+
+
+
+    # Suggest updating expected directory if changes seem legitimate
+    # if missing_files or different_files:
+    #     code_snippet_update = f"\ncp -r {tested_dir}/* {expected_dir}\n"
+
+    #     console.print("\nIf changes in tested directory seem legitimate, please update the expected directory with the following command:")
+    #     syntax = Syntax(code_snippet_update, "bash", theme="ansi_dark")
+    #     console.print(Panel(syntax, title="Update expected results", expand=False, box=box.HORIZONTALS))
+
+
+    if different_files or dcmp.left_only or dcmp.right_only:
+        console.print('\nSome difference exist between the tested and the expected result directories', style="difference")
+        exit(1)
+
+    else:
+        console.print('\nNo difference have been found between the tested and the expected result directories', style="identical")
+
+def parse_arguments():
+    """Parse script arguments."""
+    parser = ArgumentParser(description="...",
+                            formatter_class=ArgumentDefaultsHelpFormatter)
+
+
+    parser.add_argument('-e', '--expected_dir', help="Expected result directory", required=True, type=Path)
+    
+    parser.add_argument('-t', '--tested_dir', help="Tested result directory", required=True, type=Path)
+
+    parser.add_argument('-o', '--outdir', help="Directories where to write diff files", default='out_diff', type=Path)
+
+    parser.add_argument('-i', '--ignored_files', nargs="+", help="File to ignore for the comparison", default=['pangenomeGraph.json'])
+
+
+    
+    args = parser.parse_args()
+    return args
+
+def main():
+
+    args = parse_arguments()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
+    
+    Path.mkdir(args.outdir, exist_ok=True)
+
+
+    compare_directories(expected_dir=args.expected_dir, tested_dir=args.tested_dir, diff_outdir=args.outdir, ignored_files=args.ignored_files)
+
+if __name__ == '__main__':
+    main()
+

--- a/testingDataset/compare_results.py
+++ b/testingDataset/compare_results.py
@@ -34,19 +34,18 @@ def ordered(obj):
     else:
         return obj
     
+def read_json_file(json_file):
+    proper_open_1 = gzip.open if json_file.suffix == ".gz" else open
+
+    with proper_open_1(json_file.as_posix(), 'rt') as f1:
+        return json.load(f1)
+
 
 def are_json_files_identical(file1, file2):
 
-    proper_open_1 = gzip.open if file1.suffix == ".gz" else open
-
-    with proper_open_1(file1.as_posix(), 'rt') as f1:
-        data1 = json.load(f1)
-    
+    data1 = read_json_file(file1)
+    data2 = read_json_file(file2)
     # Load data from the second file
-
-    proper_open_2 = gzip.open if file2.suffix == ".gz" else open
-    with proper_open_2(file2.as_posix(), 'rt') as fl2:
-        data2 = json.load(fl2)
     
     return ordered(data1) == ordered(data2), []
 
@@ -100,7 +99,7 @@ def add_subdir_to_files(subdir, files):
     return [os.path.join(subdir, file) for file in  files]
 
 def compare_dir_recursively(expected_dir, tested_dir, ignored_files):
-    dcmp_result = filecmp.dircmp(expected_dir, tested_dir)
+    dcmp_result = filecmp.dircmp(expected_dir, tested_dir, ignore=ignored_files)
 
     for subdir  in dcmp_result.common_dirs:
         sub_dcmp_result = compare_dir_recursively(expected_dir/subdir, tested_dir/subdir, ignored_files)
@@ -116,7 +115,7 @@ def get_suffix_except_gz(path: Path):
             return ext
         
 
-def compare_directories(expected_dir, tested_dir, ignored_files, diff_outdir, extension_to_compare=[".tsv", ".json", '.gff', '.txt', '.csv', 'faa', 'fasta']):
+def compare_directories(expected_dir, tested_dir, ignored_files, diff_outdir, extension_to_compare=[".tsv", ".json", '.gff', '.txt', '.csv', '.faa', '.fasta', ".yaml"]):
 
     # Define directory information with color
     expected_dir_info = f"- Expected directory: [bold green]{expected_dir}[/bold green]"
@@ -227,7 +226,7 @@ def parse_arguments():
 
     parser.add_argument('-o', '--outdir', help="Directories where to write diff files", default='out_diff', type=Path)
 
-    parser.add_argument('-i', '--ignored_files', nargs="+", help="File to ignore for the comparison", default=['pangenomeGraph.json'])
+    parser.add_argument('-i', '--ignored_files', nargs="+", help="File to ignore for the comparison", default=['pangenomeGraph.json', "pangenomeGraph.json.gz"])
 
 
     

--- a/testingDataset/expected_info_files/myannopang_info.yaml
+++ b/testingDataset/expected_info_files/myannopang_info.yaml
@@ -1,0 +1,64 @@
+Status:
+    Genomes_Annotated: true
+    Genes_Clustered: true
+    Genes_with_Sequences: true
+    Gene_Families_with_Sequences: true
+    Neighbors_Graph: true
+    Pangenome_Partitioned: true
+    RGP_Predicted: false
+    Spots_Predicted: false
+    Modules_Predicted: false
+    PPanGGOLiN_Version: 2.0.5
+
+Content:
+    Genes: 47930
+    Genomes: 53
+    Families: 1085
+    Edges: 1321
+    Persistent:
+        Family_count: 871
+        min_genomes_frequency: 0.85
+        max_genomes_frequency: 1.0
+        sd_genomes_frequency: 0.02
+        mean_genomes_frequency: 1.0
+    Shell:
+        Family_count: 55
+        min_genomes_frequency: 0.23
+        max_genomes_frequency: 0.83
+        sd_genomes_frequency: 0.18
+        mean_genomes_frequency: 0.51
+    Cloud:
+        Family_count: 159
+        min_genomes_frequency: 0.02
+        max_genomes_frequency: 0.23
+        sd_genomes_frequency: 0.04
+        mean_genomes_frequency: 0.04
+    Number_of_partitions: 3
+
+Parameters:
+    annotate:
+        # used_local_identifiers: True
+        use_pseudo: False
+        # read_annotations_from_file: True
+    cluster:
+        coverage: 0.8
+        identity: 0.8
+        mode: 1
+        # defragmentation: True
+        no_defrag: False
+        translation_table: 11
+        # read_clustering_from_file: False
+    graph:
+    partition:
+        beta: 2.5
+        max_degree_smoothing: 10
+        free_dispersion: False
+        ICL_margin: 0.05
+        seed: 42
+        # computed nb of partitions: True
+        nb_of_partitions: -1
+        # final nb of partitions: 3
+        krange: [3, 20]
+
+Metadata: null
+

--- a/testingDataset/expected_info_files/myannopang_info.yaml
+++ b/testingDataset/expected_info_files/myannopang_info.yaml
@@ -13,8 +13,8 @@ Status:
 Content:
     Genes: 47930
     Genomes: 53
-    Families: 1085
-    Edges: 1321
+    Families: 1084
+    Edges: 1319
     Persistent:
         Family_count: 871
         min_genomes_frequency: 0.85
@@ -28,7 +28,7 @@ Content:
         sd_genomes_frequency: 0.18
         mean_genomes_frequency: 0.51
     Cloud:
-        Family_count: 159
+        Family_count: 158
         min_genomes_frequency: 0.02
         max_genomes_frequency: 0.23
         sd_genomes_frequency: 0.04

--- a/testingDataset/expected_info_files/mybasicpangenome_info.yaml
+++ b/testingDataset/expected_info_files/mybasicpangenome_info.yaml
@@ -1,0 +1,90 @@
+Status:
+    Genomes_Annotated: true
+    Genes_Clustered: true
+    Genes_with_Sequences: true
+    Gene_Families_with_Sequences: true
+    Neighbors_Graph: true
+    Pangenome_Partitioned: true
+    RGP_Predicted: true
+    Spots_Predicted: true
+    Modules_Predicted: true
+    PPanGGOLiN_Version: 2.0.5
+
+Content:
+    Genes: 45429
+    Genomes: 51
+    Families: 1010
+    Edges: 1074
+    Persistent:
+        Family_count: 874
+        min_genomes_frequency: 0.86
+        max_genomes_frequency: 1.0
+        sd_genomes_frequency: 0.01
+        mean_genomes_frequency: 0.99
+    Shell:
+        Family_count: 34
+        min_genomes_frequency: 0.22
+        max_genomes_frequency: 0.78
+        sd_genomes_frequency: 0.16
+        mean_genomes_frequency: 0.45
+    Cloud:
+        Family_count: 102
+        min_genomes_frequency: 0.02
+        max_genomes_frequency: 0.22
+        sd_genomes_frequency: 0.05
+        mean_genomes_frequency: 0.05
+    Number_of_partitions: 3
+    RGP: 45
+    Spots: 2
+    Modules:
+        Number_of_modules: 4
+        Families_in_Modules: 19
+        Partition_composition:
+            Persistent: 0.0
+            Shell: 42.11
+            Cloud: 57.89
+
+Parameters:
+    annotate:
+        norna: False
+        kingdom: bacteria
+        translation_table: 11
+        prodigal_procedure: None
+        allow_overlap: False
+        # read_annotations_from_file: False
+    cluster:
+        coverage: 0.8
+        identity: 0.8
+        mode: 1
+        # defragmentation: True
+        no_defrag: False
+        translation_table: 11
+        # read_clustering_from_file: False
+    graph:
+    partition:
+        beta: 2.5
+        max_degree_smoothing: 10
+        free_dispersion: False
+        ICL_margin: 0.05
+        seed: 42
+        # computed nb of partitions: True
+        nb_of_partitions: -1
+        # final nb of partitions: 3
+        krange: [3, 20]
+    rgp:
+        persistent_penalty: 3
+        variable_gain: 1
+        min_length: 3000
+        min_score: 4
+        dup_margin: 0.05
+    spot:
+        set_size: 3
+        overlapping_match: 2
+        exact_match_size: 1
+    module:
+        size: 3
+        min_presence: 2
+        transitive: 4
+        jaccard: 0.85
+        dup_margin: 0.05
+

--- a/testingDataset/expected_info_files/mybasicpangenome_info.yaml
+++ b/testingDataset/expected_info_files/mybasicpangenome_info.yaml
@@ -14,7 +14,7 @@ Content:
     Genes: 45429
     Genomes: 51
     Families: 1010
-    Edges: 1074
+    Edges: 1075
     Persistent:
         Family_count: 874
         min_genomes_frequency: 0.86
@@ -25,8 +25,8 @@ Content:
         Family_count: 34
         min_genomes_frequency: 0.22
         max_genomes_frequency: 0.78
-        sd_genomes_frequency: 0.16
-        mean_genomes_frequency: 0.45
+        sd_genomes_frequency: 0.15
+        mean_genomes_frequency: 0.46
     Cloud:
         Family_count: 102
         min_genomes_frequency: 0.02

--- a/testingDataset/expected_info_files/stepbystep_info.yaml
+++ b/testingDataset/expected_info_files/stepbystep_info.yaml
@@ -1,0 +1,98 @@
+Status:
+    Genomes_Annotated: true
+    Genes_Clustered: true
+    Genes_with_Sequences: true
+    Gene_Families_with_Sequences: true
+    Neighbors_Graph: true
+    Pangenome_Partitioned: true
+    RGP_Predicted: true
+    Spots_Predicted: true
+    Modules_Predicted: true
+    PPanGGOLiN_Version: 2.0.5
+
+Content:
+    Genes: 45429
+    Genomes: 51
+    Families: 1010
+    Edges: 1074
+    Persistent:
+        Family_count: 874
+        min_genomes_frequency: 0.86
+        max_genomes_frequency: 1.0
+        sd_genomes_frequency: 0.01
+        mean_genomes_frequency: 0.99
+    Shell:
+        Family_count: 37
+        min_genomes_frequency: 0.18
+        max_genomes_frequency: 0.78
+        sd_genomes_frequency: 0.17
+        mean_genomes_frequency: 0.43
+    Cloud:
+        Family_count: 99
+        min_genomes_frequency: 0.02
+        max_genomes_frequency: 0.22
+        sd_genomes_frequency: 0.04
+        mean_genomes_frequency: 0.05
+    Number_of_partitions: 3
+    Genomes_fluidity:
+        all: 0.025
+        shell: 0.555
+        cloud: 0.039
+        accessory: 0.623
+    RGP: 66
+    Spots: 2
+    Modules:
+        Number_of_modules: 4
+        Families_in_Modules: 19
+        Partition_composition:
+            Persistent: 0.0
+            Shell: 42.11
+            Cloud: 57.89
+
+Parameters:
+    annotate:
+        norna: False
+        kingdom: bacteria
+        translation_table: 11
+        prodigal_procedure: None
+        allow_overlap: False
+        # read_annotations_from_file: False
+    cluster:
+        coverage: 0.8
+        identity: 0.8
+        mode: 1
+        # defragmentation: True
+        no_defrag: False
+        translation_table: 11
+        # read_clustering_from_file: False
+    graph:
+        remove_high_copy_number: 10
+    partition:
+        beta: 2.6
+        max_degree_smoothing: 10.0
+        free_dispersion: True
+        ICL_margin: 0.04
+        seed: 42
+        # computed nb of partitions: True
+        nb_of_partitions: -1
+        # final nb of partitions: 3
+        krange: [3, 12]
+    rgp:
+        persistent_penalty: 2
+        variable_gain: 1
+        min_length: 3000
+        min_score: 3
+        dup_margin: 0.05
+    spot:
+        set_size: 3
+        overlapping_match: 2
+        exact_match_size: 1
+    module:
+        size: 3
+        min_presence: 2
+        transitive: 4
+        jaccard: 0.86
+        dup_margin: 0.05
+
+Metadata: null
+

--- a/testingDataset/expected_info_files/stepbystep_info.yaml
+++ b/testingDataset/expected_info_files/stepbystep_info.yaml
@@ -14,31 +14,31 @@ Content:
     Genes: 45429
     Genomes: 51
     Families: 1010
-    Edges: 1074
+    Edges: 1075
     Persistent:
-        Family_count: 874
+        Family_count: 873
         min_genomes_frequency: 0.86
         max_genomes_frequency: 1.0
         sd_genomes_frequency: 0.01
         mean_genomes_frequency: 0.99
     Shell:
-        Family_count: 37
+        Family_count: 38
         min_genomes_frequency: 0.18
-        max_genomes_frequency: 0.78
-        sd_genomes_frequency: 0.17
-        mean_genomes_frequency: 0.43
+        max_genomes_frequency: 0.86
+        sd_genomes_frequency: 0.18
+        mean_genomes_frequency: 0.45
     Cloud:
         Family_count: 99
         min_genomes_frequency: 0.02
         max_genomes_frequency: 0.22
-        sd_genomes_frequency: 0.04
+        sd_genomes_frequency: 0.05
         mean_genomes_frequency: 0.05
     Number_of_partitions: 3
     Genomes_fluidity:
         all: 0.025
-        shell: 0.555
+        shell: 0.553
         cloud: 0.039
-        accessory: 0.623
+        accessory: 0.624
     RGP: 66
     Spots: 2
     Modules:

--- a/testingDataset/launch_test_locally.py
+++ b/testingDataset/launch_test_locally.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+"""
+Description
+
+:Example:
+"""
+
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+import logging
+from pathlib import Path
+import yaml
+
+def parse_yaml_file(yaml_file):
+
+    # Load the YAML file
+    with open(yaml_file, 'r') as stream:
+
+        workflow = yaml.safe_load(stream)
+
+    return workflow
+
+def create_symbolic_links(source_dir, target_dir):
+    # Convert paths to Path objects
+    source_dir = Path(source_dir)
+    target_dir = Path(target_dir)
+
+    # Ensure target directory exists
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    # Loop through each item in the source directory
+    for item in source_dir.iterdir():
+        target_item_path = target_dir / item.name
+
+        # Create symbolic link for each item
+        try:
+            target_item_path.symlink_to(item.resolve())
+        except FileExistsError:
+            pass
+
+def parse_arguments(default_ci_yaml, testing_datadir):
+    """Parse script arguments."""
+    parser = ArgumentParser(description="...",
+                            formatter_class=ArgumentDefaultsHelpFormatter)
+
+
+    parser.add_argument('--ci_yaml', help="increase output verbosity",  default=default_ci_yaml, type=Path,)
+    
+    parser.add_argument('--data_dir', help="Directory where dataset files are located", default=testing_datadir, type=Path,)
+    
+    parser.add_argument('-o', '--outdir', help="increase output verbosity",  default='local_CI', type=Path)
+
+    parser.add_argument('-c', '--cpu', type=int, default=1,
+                        help="Use this amount of cpu when number of cpu is specified in the command.")
+    
+    parser.add_argument("-v", "--verbose", help="increase output verbosity",
+                    action="store_true")
+    
+    parser.add_argument('--skip_msa', action="store_true",
+                    help="Skip msa command as it takes quite some time to complete.")
+
+
+    parser.add_argument('-f', '--force', action="store_true",
+                    help="Force writing in output directory if exists.")
+
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+
+
+    script_path = Path(__file__).resolve()
+    ppanggolin_main_dir = script_path.parent.parent
+    default_ci_yaml = ppanggolin_main_dir / ".github/workflows/main.yml"
+    testing_datadir = ppanggolin_main_dir / "testingDataset"
+
+
+    args = parse_arguments(default_ci_yaml, testing_datadir)
+
+    if args.verbose:
+        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
+        logging.info('Mode verbose ON')
+
+    else:
+        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
+
+
+    if not args.outdir.is_dir():
+        logging.debug(f"Create output directory {args.outdir.absolute().as_posix()}")
+        Path.mkdir(args.outdir)
+    
+    elif not args.force:
+        raise FileExistsError(
+            f"{args.outdir} already exists. Use -f if you want to overwrite the files in the directory")
+
+    # setup test dir
+    # execution_dir = args.outdir # / args.data_dir.name
+    create_symbolic_links(args.data_dir, args.outdir)
+
+
+    workflow = parse_yaml_file(args.ci_yaml)
+
+    excluded_steps = ['Install ppanggolin']
+
+    test_script = args.outdir  / 'launch_test_command.sh'
+    with open(test_script, "w") as fl:
+        
+        fl.write('#!/bin/bash\nset -e\n')
+
+        # Iterate over jobs and steps        
+        for job in workflow['jobs'].values():
+
+            if 'steps' not in job:
+                continue
+            
+            for step in job['steps']:
+                if 'run' not in step:
+                    continue
+
+                if step['name'] in excluded_steps:
+                    logging.info(f'Ignoring: {step}')
+                    continue
+
+                # Execute the command line
+                command = step['run'].strip()
+
+                # process the command
+                command = command.replace('--cpu 1', f"--cpu {args.cpu}")
+                command = command.replace('cd ', "# cd ")
+
+                if args.skip_msa:
+                    command = command.replace('ppanggolin msa', "# ppanggolin msa")
+                if command == "pytest":
+                    command = f"pytest {ppanggolin_main_dir}"
+                
+            
+                # log the step name
+                logging.info(f'Executing: {step["name"]}')
+                logging.debug(f" {command}\n")
+                
+                # write the command in the script
+                fl.write(f'\n# {step["name"]}\n\n')
+                fl.write(command)
+                        
+
+    print(f"(cd {args.outdir}; bash {test_script.name})")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
PPanGGOLiN  has a CI that tests most of its commands and parameters to make sure that none are broken. However, it does not test the content of the file created by the command. This means that if a change in the code affects the content of an output, we may not see it.

To mitigate this risk, this PR introduces a minimal check on the output files produced by the `ppanggolin info' command to ensure that no changes have been made to the contents of the pangenome. 
- The CI pipeline now includes a call to a Python script named `compare_results.py`, located within the `testingDataset` directory. This script compares the content of the files produced by the CI with the expected files stored in the `testingDataset/expected_info_files` directory. 
- A companion script named `launch_test_locally.py` has also been added to the `testingDataset` directory. This script reads the CI pipeline file and creates a bash script to launch the contents of the pipeline locally. This is useful to not only rely on the github action to test changes made to the code. Documentation has been updated to include how to use this script.


