### PR TITLE
Fix mac recipe

### DIFF
--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -22,9 +22,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Setting up miniconda
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge,bioconda,defaults

--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -27,7 +27,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
-          channels: conda-forge,bioconda,defaults
+          channels: bioconda,conda-forge,defaults
+          activate-environment: test
       - name: Set up test environment
         shell: bash -l {0}
         run: |

--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
-          channels: bioconda,conda-forge,defaults
+          channels: bioconda,conda-forge,anaconda,defaults
           activate-environment: test
       - name: Set up test environment
         shell: bash -l {0}

--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest','macos-latest']
+        os: ['ubuntu-latest','macos-13']
         python-version: ['3.8','3.9','3.10']
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'macos-13']
         python-version: ['3.8', '3.9', '3.10']
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     # Install requirements with miniconda
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         channels: conda-forge,bioconda,defaults


### PR DESCRIPTION
This PR is for fixing the macOS github runner which crashed due to github actions "macos-latest" moving to macos-14 with runners with oxs-arm64 architecture, which is not currently supported in bioconda.