### PR TITLE
Add metadata from annotation files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,7 +159,7 @@ jobs:
         ppanggolin metadata -p mybasicpangenome/pangenome.h5 -s db4 -m metadata/metadata_rgps.tsv -a RGPs
         ppanggolin metadata -p mybasicpangenome/pangenome.h5 -s db5 -m metadata/metadata_contigs.tsv  -a contigs
         ppanggolin metadata -p mybasicpangenome/pangenome.h5 -s db6 -m metadata/metadata_modules.tsv  -a modules
-
+        ppanggolin write_metadata -p mybasicpangenome/pangenome.h5 -o metadata_flat_output
 
 
         ppanggolin write_pangenome -p mybasicpangenome/pangenome.h5 --output mybasicpangenome -f --gexf --light_gexf --cpu $NUM_CPUS

--- a/docs/user/metadata.md
+++ b/docs/user/metadata.md
@@ -1,4 +1,6 @@
-# Adding Metadata to Pangenome Elements
+# Metadata and Pangenome
+
+## Associating Metadata with Pangenome Elements
 
 The `metadata` command allows the addition of metadata linked to various pangenome elements. Metadata can be associated with genes, genomes, families, RGPs, spots, and modules using a simple TSV file. 
 
@@ -17,7 +19,11 @@ The associated metadata can then be exported in various output files of PPanGGOL
 
 The metadata linked to pangenome elements can be exported to various output file formats within PPanGGOLiN, including GFF, PROKSEE JSON Map, and Table outputs of the `write_genomes` command (see [here](./writeGenomes.md#incorporating-metadata-into-tables-gff-and-proksee-files) for more details). Additionally, the metadata can also be included in the gexf graph file representing the pangenome and in the RGP clustering graph.
 
-## Metadata Format
+```{note} 
+Some information (such as species, strain, dbx_ref) are extracted when found from genome annotation files (GBFF, GFF) during the annotation step and added to the pangenome file as metadata under the source 'annotation_files'. These metadata can be extracted using the `write_metadata` command.
+```
+
+### Metadata Format
 
 PPanGGOLiN offers a highly flexible metadata file format. Only one column name is mandatory, and it aligns with the assignment argument chosen by the user (ie. families, RGPS...).
 
@@ -48,3 +54,28 @@ PPanGGOLiN enables the addition of metadata to various pangenome elements, inclu
 
 #### `--omit`
 This option allows you to bypass errors resulting from an unfound ID in the pangenome. It can be beneficial when utilizing a general TSV with elements not present in the pangenome. This argument should be used carefully.  
+
+## Checking Metadata Associated with the Pangenome
+
+You can inspect which pangenome elements have associated metadata and their respective sources using the `ppanggolin info` command. For more details on this command, refer to the [info command documentation](./PangenomeAnalyses/pangenomeInfo.md).
+
+To check the metadata, execute the following command:
+
+```bash
+ppanggolin info -p PANGENOME --metadata
+```
+
+## Exporting Metadata to TSV Files
+
+The `write_metadata` command allows you to export metadata to TSV files. It creates one file per source of pangenome element metadata.
+
+For example, if families have metadata from sources `hmmer` and `dbcan`, and genomes have metadata from the source `gtdb`, the command will create three files:
+- `families_metadata_from_hmmer.tsv`
+- `families_metadata_from_dbcan.tsv`
+- `genomes_metadata_from_gtdb.tsv`
+
+To export metadata from your pangenome, execute the following command:
+
+```bash
+ppanggolin write_metadata -p PANGENOME --output metadata_tsv_files
+```

--- a/docs/user/metadata.md
+++ b/docs/user/metadata.md
@@ -1,6 +1,6 @@
 # Metadata and Pangenome
 
-## Associating Metadata with Pangenome Elements
+## Associating Metadata to Pangenome Elements
 
 The `metadata` command allows the addition of metadata linked to various pangenome elements. Metadata can be associated with genes, genomes, families, RGPs, spots, and modules using a simple TSV file. 
 
@@ -19,8 +19,8 @@ The associated metadata can then be exported in various output files of PPanGGOL
 
 The metadata linked to pangenome elements can be exported to various output file formats within PPanGGOLiN, including GFF, PROKSEE JSON Map, and Table outputs of the `write_genomes` command (see [here](./writeGenomes.md#incorporating-metadata-into-tables-gff-and-proksee-files) for more details). Additionally, the metadata can also be included in the gexf graph file representing the pangenome and in the RGP clustering graph.
 
-```{note} 
-Some information (such as species, strain, dbx_ref) are extracted when found from genome annotation files (GBFF, GFF) during the annotation step and added to the pangenome file as metadata under the source 'annotation_files'. These metadata can be extracted using the `write_metadata` command.
+```{note}
+Certain information (such as species, strain, and dbx_ref) is extracted from genome annotation files (GBFF, GFF) during the annotation step and added to the pangenome as metadata under the source 'annotation_files'. These metadata can be extracted using the `write_metadata` command.
 ```
 
 ### Metadata Format

--- a/docs/user/writeGenomes.md
+++ b/docs/user/writeGenomes.md
@@ -144,13 +144,13 @@ Since PPanGGOLiN does not retain genomic sequences, it is necessary to provide t
 
 ### Incorporating Metadata into Tables, GFF, and Proksee Files
 
-You can inject metadata, previously added with the `metadata` command, into genome outputs using the `--add_metadata` parameter. When users add metadata, they specify the source of this metadata. These metadata sources can be selectively included using the `--metadata_sources` parameter. By default, all sources are added when the `--add_metadata` flag is specified.
+You can inject metadata associated to genes and families, previously added with the `metadata` command, into genome outputs using the `--add_metadata` parameter. When users add metadata, they specify the source of this metadata. These metadata sources can be selectively included using the `--metadata_sources` parameter. By default, all sources are added when the `--add_metadata` flag is specified.
 
 #### Metadata in GFF Files
 
 Metadata is integrated into the attributes column of the GFF file. The patterns for adding metadata are as follows:
 
-- In CDS lines, metadata associated with genes follow this pattern: `gene_<source>_<key>=<value>`. Gene family metadata follows a similar pattern: `gene_<source>_<key>=<value>`.
+- In CDS lines, metadata associated with genes follow this pattern: `gene_<source>_<key>=<value>`. Gene family metadata follows a similar pattern: `family_<source>_<key>=<value>`.
 - In the contig lines of type `region` describing the contig, genome metadata is added with the pattern: `genome_<source>_<key>=<value>`, and contig metadata is added with: `contig_<source>_<key>=<value>`.
 - In RGP lines, metadata is added using the pattern: `rpg_<source>_<key>=<value>`.
 
@@ -192,10 +192,15 @@ For instance, with the metadata previously added to the DYB08_RS16060 gene famil
 
 #### Metadata in Table output
 
-Metadata is seamlessly incorporated into table output with the addition of extra columns. These columns follow the GFF attribute naming: 
+Metadata can be incorporated into table output as well with the addition of extra columns. These columns follow the GFF attribute naming: 
 
 - gene metadata: `gene_<source>_<key>`
-- family metadata: `gene_<source>_<key>`
+- family metadata: `family_<source>_<key>`
+- rgp metadata: `rgp_<source>_<key>`
 
-<!-- exemple ? -->
+For instance, with the metadata previously added to the DYB08_RS16060 gene family, the table would look like this:
 
+
+| gene          | contig        | start   | stop | strand | family  | ...  | family_pfam_accession | family_pfam_description | family_pfam_type |
+|---------------|---------------|---------|------|--------|---------|------|-----------------------|-------------------------|------------------|
+| ABAYE_RS00475 | NC_010404.1   | 77317   | 77958| -      | DYB08_RS16060| ... | PF18894 | This entry represents a probable metallopeptidase domain found in a variety of phage and bacterial proteome | domain|

--- a/ppanggolin/__init__.py
+++ b/ppanggolin/__init__.py
@@ -28,6 +28,7 @@ SUBCOMMAND_TO_SUBPARSER = {
     "draw": ppanggolin.figures.subparser,
     "write_pangenome": ppanggolin.formats.writeFlatPangenome.subparser,
     "write_genomes": ppanggolin.formats.writeFlatGenomes.subparser,
+    "write_metadata": ppanggolin.formats.writeFlatMetadata.subparser,
     "fasta": ppanggolin.formats.writeSequences.subparser,
     "msa": ppanggolin.formats.writeMSA.subparser,
     "metrics": ppanggolin.metrics.metrics.subparser,

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -978,11 +978,15 @@ def read_annotations(pangenome: Pangenome, organisms_file: Path, cpu: int = 1, p
     pangenome.parameters["annotate"]["use_pseudo"] = pseudo
     pangenome.parameters["annotate"]["# read_annotations_from_file"] = True
 
-    pangenome.status["metadata"]["genomes"] = "Computed"
 
-    pangenome.status["metadata"]["contigs"] = "Computed"
-    pangenome.status["metasources"]["genomes"].append("annotation_file")
-    pangenome.status["metasources"]["contigs"].append("annotation_file")
+    if any((genome.has_metadata() for genome in pangenome.organisms)):
+        pangenome.status["metadata"]["genomes"] = "Computed"
+        pangenome.status["metasources"]["genomes"].append("annotation_file")
+
+    if any((contig.has_metadata() for contig in pangenome.contigs)):
+        pangenome.status["metadata"]["contigs"] = "Computed"
+        pangenome.status["metasources"]["contigs"].append("annotation_file")
+
 
 def get_gene_sequences_from_fastas(pangenome: Pangenome, fasta_files: Path, disable_bar: bool = False):
     """

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -231,7 +231,7 @@ def parse_gbff_by_contig(gbff_file_path: Path) -> Generator[Tuple[List[str], Lis
 
 
 
-def parse_contig_header_lines(header_lines: List[str]) -> defaultdict[list]:
+def parse_contig_header_lines(header_lines: List[str]) -> Dict[List]:
     """
     Parse required information from header lines of a contig from a GBFF file.
 

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -231,12 +231,12 @@ def parse_gbff_by_contig(gbff_file_path: Path) -> Generator[Tuple[List[str], Lis
 
 
 
-def parse_contig_header_lines(header_lines: List[str]) -> Dict[List]:
+def parse_contig_header_lines(header_lines: List[str]) -> Dict[str, str]:
     """
     Parse required information from header lines of a contig from a GBFF file.
 
     :param header_lines: List of strings representing header lines of a contig from a GBFF file.
-    :return: A defaultdict with keys representing different fields and values representing their corresponding values.
+    :return: A dict with keys representing different fields and values representing their corresponding values joined by new line.
     """
     field = ""  # Initialize field
     field_to_value = defaultdict(list)  # Initialize defaultdict to store field-value pairs

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -420,7 +420,7 @@ def read_org_gbff(organism_name: str, gbff_file_path: Path, circular_contigs: Li
 
         if contig_len != len(sequence):
             logging.getLogger("PPanGGOLiN").warning("Unable to determine if the contig is circular or linear in file "
-                                                    f"'{gbff_file_path}' from the LOCUS line: {line}. "
+                                                    f"'{gbff_file_path}' from the LOCUS header information: {header['LOCUS']}. "
                                                     "By default, the contig will be considered linear.")
 
         if "CIRCULAR" in header['LOCUS'].upper():

--- a/ppanggolin/formats/__init__.py
+++ b/ppanggolin/formats/__init__.py
@@ -4,3 +4,4 @@ from .writeFlatPangenome import subparser, launch
 from .writeSequences import subparser, launch
 from .writeMSA import subparser, launch
 from .writeFlatGenomes import subparser, launch
+from .writeFlatMetadata import subparser, launch

--- a/ppanggolin/formats/readBinaries.py
+++ b/ppanggolin/formats/readBinaries.py
@@ -927,7 +927,7 @@ def get_need_info(pangenome, need_annotations: bool = False, need_families: bool
             if set(pangenome.status["metasources"][metatype]) & sources_to_load:
                 metatypes_to_load.add(metatype)
             else:
-                logging.getLogger("PPanGGOLiN").warning(
+                logging.getLogger("PPanGGOLiN").debug(
                     f"There is no metadata assigned to {metatype} with specified sources:"
                     f" {', '.join(sources_to_load)} in the pangenome. This metatype is ignored.")
         if metatypes_to_load and sources_to_load:

--- a/ppanggolin/formats/writeFlatMetadata.py
+++ b/ppanggolin/formats/writeFlatMetadata.py
@@ -94,15 +94,15 @@ def write_flat_metadata_files(pangenome: Pangenome, output: Path,
                         metadata_dict[element_type] = f"spot_{element.ID}"
                     elif element_type == "modules":
                         metadata_dict[element_type] = f"module_{element.ID}"
-                    elif element_type in ["genes", "contigs"]:
+                    elif element_type in ["genes"]:
                         metadata_dict[element_type] = element.ID
-                    elif element_type in ["families", 'genomes', "RGPs"]:
+                    elif element_type in ["families", 'genomes', "RGPs", "contigs"]:
                         metadata_dict[element_type] = element.name
 
                     # Add genome name for genome-specific elements if genome is not already a metadata
                     if element_type in ["genes", "contigs", "RGPs"] and "genomes" not in metadata_dict:
                         metadata_dict["genomes"] = element.organism.name
-                        first_columns = ["genomes"] + first_columns
+                        first_columns = ["genomes", element_type ]
 
                     source_to_metadata[source].append(metadata_dict)
 

--- a/ppanggolin/formats/writeFlatMetadata.py
+++ b/ppanggolin/formats/writeFlatMetadata.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# coding:utf-8
+
+# default libraries
+import argparse
+from itertools import combinations
+from collections import defaultdict
+import logging
+from typing import List, Dict, Set, Tuple
+from pathlib import Path
+import random
+from tqdm import tqdm
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+# installed libraries
+import networkx as nx
+from plotly.express.colors import qualitative
+import pandas as pd
+
+# local libraries
+from ppanggolin.geneFamily import GeneFamily
+from ppanggolin.genome import Organism, Gene, RNA
+from ppanggolin.region import Region, Module
+from ppanggolin.pangenome import Pangenome
+from ppanggolin.utils import write_compressed_or_not, mk_outdir, extract_contig_window, parse_input_paths_file
+from ppanggolin.formats.readBinaries import check_pangenome_info
+from ppanggolin.formats.write_proksee import write_proksee_organism
+from ppanggolin.formats.writeSequences import read_genome_file, write_spaced_fasta
+from ppanggolin.formats.writeFlatGenomes import get_organism_list 
+
+
+def write_flat_metadata_files(pangenome: Pangenome, output: Path, 
+                              pangenome_elements: List[str] = None, metadata_sources: List[str] = None, 
+                               compress: bool = False, disable_bar: bool = False):
+    """
+    Main function to write flat files from pangenome
+
+    :param pangenome: Pangenome object
+    :param output: Path to output directory
+    :param cpu: Number of available core
+    :param table: write table with pangenome annotation for each genome
+    :param gff: write a gff file with pangenome annotation for each organism
+    :param proksee: write a proksee file with pangenome annotation for each organisms
+    :param compress: Compress the file in .gz
+    :param disable_bar: Disable progress bar
+    :param fasta: File containing the list FASTA files for each organism
+    :param anno: File containing the list of GBFF/GFF files for each organism
+    :param organisms_filt: String used to specify which organism to write. if all, all organisms are written.
+    :param add_metadata: Add metadata to GFF files
+    :param metadata_sep: The separator used to join multiple metadata values
+    :param metadata_sources: Sources of the metadata to use and write in the outputs. None means all sources are used.
+    """
+
+    if not pangenome.has_metadata():
+        logging.getLogger("PPangGGOLiN").warning("No metadata is assigned to any pangenome element. Therefore it is not possible to write them.")
+
+
+    elif all(( pangenome.status['metadata'][element] == "No" for element in pangenome_elements)):
+            logging.getLogger("PPangGGOLiN").warning(f"No metadata is assigned to any of the requested pangenome elements: {','.join(pangenome_elements)}.")
+            return
+
+    if metadata_sources is None: 
+        # source has not been specified and therefore all sources are considered
+        element_to_sources = {element:sources  for element, sources in pangenome.status['metasources'].items() if sources}
+
+    else:
+        # sources has been specified. Checking that they match actual sources
+        element_to_sources = {}
+        for element in pangenome_elements:
+            existing_sources = pangenome.status['metasources'][element]
+            if set(existing_sources) & set(metadata_sources):
+                element_to_sources[element] = set(existing_sources) & set(metadata_sources)
+
+        if not element_to_sources:
+            logging.getLogger("PPangGGOLiN").warning(f"None of given metadata sources ({metadata_sources}) "
+                                                        f"is source of any of the requested pangenome elements: {pangenome_elements}.")
+            return
+        
+    logging.getLogger("PPangGGOLiN").info(f"Writing metadata for {', '.join(element_to_sources)} from {len([s for sources in element_to_sources.values() for s in sources])} sources.")
+    
+    need_dict = {"need_annotations": True,
+                 "need_families": "families" in element_to_sources,
+                 "need_rgp": "RGPs" in element_to_sources,
+                 "need_spots": "spots" in element_to_sources,
+                 "need_modules": "modules" in element_to_sources, 
+                 "need_metadata": True,
+                 "sources": metadata_sources
+                 }
+    
+    check_pangenome_info(pangenome, disable_bar=disable_bar, **need_dict,)
+
+    element_type_to_attribute =  {"families":"gene_families", "genomes":"organisms", 
+                           "RGPs":"regions", "genes":"genes", "modules":"modules",
+                           "spots":"spots", "contigs":"contigs"}
+    
+    for element_type, sources in element_to_sources.items():
+        first_columns = [element_type]
+        source_to_metadata = defaultdict(list)
+
+        for element in getattr(pangenome, element_type_to_attribute[element_type]):
+
+            for source in set(element.sources) & set(sources):
+            
+                for metadata in element.get_metadata_by_source(source):
+                    metadata_dict =  metadata.to_dict()
+                    if element_type == "spots":
+                        metadata_dict[element_type] = f"spot_{element.ID}"
+                    
+                    elif element_type == "modules":
+                        metadata_dict[element_type] = f"module_{element.ID}"
+
+                    elif element_type in ["genes", "contigs"]:
+                        metadata_dict[element_type] = element.ID
+
+                    elif element_type in ["families", 'genomes', "RGPs"]:
+                        metadata_dict[element_type] = element.name
+
+                    # add genome name for genome specific element if genomes is not a metadata
+                    if element_type in ["genes", "contigs", "RGPs"] and "genomes" not in metadata_dict:
+                        metadata_dict["genomes"] = element.organism.name
+                        first_columns = ["genomes"] + first_columns
+
+                    source_to_metadata[source].append(metadata_dict)
+
+
+        for source, metadata_list in source_to_metadata.items():
+
+            df_source = pd.DataFrame(metadata_list)
+            columns_order = first_columns + [col for col in df_source.columns if col not in first_columns]  
+            df_source = df_source.reindex(columns_order, axis=1)
+            tsv_file_name = f"{element_type}_metadata_from_{source}.tsv" 
+            if compress:
+                tsv_file_name = f"{tsv_file_name}.gz"
+
+            tsv_path = output / tsv_file_name
+
+            logging.getLogger("PPangGGOLiN").info(f"Writing {element_type} metadata from source {source} in '{tsv_path}'")
+            df_source.to_csv(tsv_path, sep="\t", index=False)
+
+    logging.getLogger("PPangGGOLiN").info("Done writing metadata in TSV format")
+
+
+def launch(args: argparse.Namespace):
+    """
+    Command launcher
+
+    :param args: All arguments provide by user
+    """
+    mk_outdir(args.output, args.force)
+
+    pangenome = Pangenome()
+    pangenome.add_file(args.pangenome)
+
+    write_flat_metadata_files(pangenome, metadata_sources=args.metadata_sources,
+                              pangenome_elements=args.pangenome_elements,
+                               output=args.output, compress=args.compress,  disable_bar=args.disable_prog_bar)
+
+
+def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """
+    Subparser to launch PPanGGOLiN in Command line
+
+    :param sub_parser : sub_parser for align command
+
+    :return : parser arguments for align command
+    """
+    parser = sub_parser.add_parser("write_metadata", formatter_class=argparse.RawTextHelpFormatter)
+    parser_flat(parser)
+    return parser
+
+
+def parser_flat(parser: argparse.ArgumentParser):
+    """
+    Parser for specific argument of write command
+
+    :param parser: parser for align argument
+    """
+    pangenome_elements = {"families", "genomes", "contigs", "genes", "RGPs", "spots", "modules"}
+    required = parser.add_argument_group(title="Required arguments",
+                                         description="One of the following arguments is required :")
+    required.add_argument('-p', '--pangenome', required=False, type=Path, help="The pangenome .h5 file")
+    required.add_argument('-o', '--output', required=True, type=Path,
+                          help="Output directory where the file(s) will be written")
+    optional = parser.add_argument_group(title="Optional arguments")
+
+    optional.add_argument("--compress", required=False, action="store_true",
+                          help="Compress the files in .gz")
+
+    optional.add_argument("-e", "--pangenome_elements",
+                          required=False,
+                          nargs="+",
+                          choices=pangenome_elements,
+                          default=pangenome_elements,
+                          help="Specify pangenome elements for which to write metadata. "
+                               "default is all element with metadata. ")
+
+    optional.add_argument("-s", "--metadata_sources",
+                          default=None,
+                          nargs="+",
+                          help="Which source of metadata should be written. "
+                               "By default all metadata sources are included.")
+
+
+if __name__ == '__main__':
+    """To test local change and allow using debugger"""
+    from ppanggolin.utils import set_verbosity_level, add_common_arguments
+
+    main_parser = argparse.ArgumentParser(
+        description="Depicting microbial species diversity via a Partitioned PanGenome Graph Of Linked Neighbors",
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    parser_flat(main_parser)
+    add_common_arguments(main_parser)
+    set_verbosity_level(main_parser.parse_args())
+    launch(main_parser.parse_args())

--- a/ppanggolin/formats/writeFlatMetadata.py
+++ b/ppanggolin/formats/writeFlatMetadata.py
@@ -22,7 +22,8 @@ def write_flat_metadata_files(pangenome: Pangenome, output: Path,
                               compress: bool = False, disable_bar: bool = False) -> None:
     """
     Main function to write flat metadata files from a pangenome.
-
+    :todo: Split the function in subfunction
+    
     :param pangenome: Pangenome object
     :param output: Path to output directory
     :param pangenome_elements: List of pangenome elements to include metadata for

--- a/ppanggolin/formats/writeFlatMetadata.py
+++ b/ppanggolin/formats/writeFlatMetadata.py
@@ -3,142 +3,122 @@
 
 # default libraries
 import argparse
-from itertools import combinations
 from collections import defaultdict
 import logging
-from typing import List, Dict, Set, Tuple
+from typing import List
 from pathlib import Path
-import random
-from tqdm import tqdm
-import time
-from concurrent.futures import ThreadPoolExecutor
 
 # installed libraries
-import networkx as nx
-from plotly.express.colors import qualitative
 import pandas as pd
 
 # local libraries
-from ppanggolin.geneFamily import GeneFamily
-from ppanggolin.genome import Organism, Gene, RNA
-from ppanggolin.region import Region, Module
 from ppanggolin.pangenome import Pangenome
-from ppanggolin.utils import write_compressed_or_not, mk_outdir, extract_contig_window, parse_input_paths_file
+from ppanggolin.utils import mk_outdir
 from ppanggolin.formats.readBinaries import check_pangenome_info
-from ppanggolin.formats.write_proksee import write_proksee_organism
-from ppanggolin.formats.writeSequences import read_genome_file, write_spaced_fasta
-from ppanggolin.formats.writeFlatGenomes import get_organism_list 
 
 
 def write_flat_metadata_files(pangenome: Pangenome, output: Path, 
                               pangenome_elements: List[str] = None, metadata_sources: List[str] = None, 
-                               compress: bool = False, disable_bar: bool = False):
+                              compress: bool = False, disable_bar: bool = False) -> None:
     """
-    Main function to write flat files from pangenome
+    Main function to write flat metadata files from a pangenome.
 
     :param pangenome: Pangenome object
     :param output: Path to output directory
-    :param cpu: Number of available core
-    :param table: write table with pangenome annotation for each genome
-    :param gff: write a gff file with pangenome annotation for each organism
-    :param proksee: write a proksee file with pangenome annotation for each organisms
-    :param compress: Compress the file in .gz
-    :param disable_bar: Disable progress bar
-    :param fasta: File containing the list FASTA files for each organism
-    :param anno: File containing the list of GBFF/GFF files for each organism
-    :param organisms_filt: String used to specify which organism to write. if all, all organisms are written.
-    :param add_metadata: Add metadata to GFF files
-    :param metadata_sep: The separator used to join multiple metadata values
-    :param metadata_sources: Sources of the metadata to use and write in the outputs. None means all sources are used.
+    :param pangenome_elements: List of pangenome elements to include metadata for
+    :param metadata_sources: List of metadata sources to use; if None, all sources are used
+    :param compress: Compress the output files in .gz format
+    :param disable_bar: Disable the progress bar
     """
-
+    
     if not pangenome.has_metadata():
-        logging.getLogger("PPangGGOLiN").warning("No metadata is assigned to any pangenome element. Therefore it is not possible to write them.")
+        logging.getLogger("PPanGGOLiN").warning("No metadata is assigned to any pangenome element. Writing metadata is not possible.")
+        return
 
+    if pangenome_elements is None:
+        pangenome_elements = []
 
-    elif all(( pangenome.status['metadata'][element] == "No" for element in pangenome_elements)):
-            logging.getLogger("PPangGGOLiN").warning(f"No metadata is assigned to any of the requested pangenome elements: {','.join(pangenome_elements)}.")
-            return
+    if all(pangenome.status['metadata'][element] == "No" for element in pangenome_elements):
+        logging.getLogger("PPanGGOLiN").warning(f"No metadata is assigned to any of the requested pangenome elements: {', '.join(pangenome_elements)}.")
+        return
 
-    if metadata_sources is None: 
-        # source has not been specified and therefore all sources are considered
-        element_to_sources = {element:sources  for element, sources in pangenome.status['metasources'].items() if sources}
-
+    if metadata_sources is None:
+        # Use all available sources if none are specified
+        element_to_sources = {element: sources for element, sources in pangenome.status['metasources'].items() if sources}
     else:
-        # sources has been specified. Checking that they match actual sources
+        # Use only the specified sources, if they match available sources
         element_to_sources = {}
         for element in pangenome_elements:
             existing_sources = pangenome.status['metasources'][element]
-            if set(existing_sources) & set(metadata_sources):
-                element_to_sources[element] = set(existing_sources) & set(metadata_sources)
+            matching_sources = set(existing_sources) & set(metadata_sources)
+            if matching_sources:
+                element_to_sources[element] = matching_sources
 
         if not element_to_sources:
-            logging.getLogger("PPangGGOLiN").warning(f"None of given metadata sources ({metadata_sources}) "
-                                                        f"is source of any of the requested pangenome elements: {pangenome_elements}.")
+            logging.getLogger("PPanGGOLiN").warning(f"None of the specified metadata sources ({metadata_sources}) match the requested pangenome elements: {pangenome_elements}.")
             return
         
-    logging.getLogger("PPangGGOLiN").info(f"Writing metadata for {', '.join(element_to_sources)} from {len([s for sources in element_to_sources.values() for s in sources])} sources.")
+    logging.getLogger("PPanGGOLiN").info(f"Writing metadata for {', '.join(element_to_sources.keys())} from {len([s for sources in element_to_sources.values() for s in sources])} sources.")
     
-    need_dict = {"need_annotations": True,
-                 "need_families": "families" in element_to_sources,
-                 "need_rgp": "RGPs" in element_to_sources,
-                 "need_spots": "spots" in element_to_sources,
-                 "need_modules": "modules" in element_to_sources, 
-                 "need_metadata": True,
-                 "sources": metadata_sources
-                 }
+    need_dict = {
+        "need_annotations": True,
+        "need_families": "families" in element_to_sources,
+        "need_rgp": "RGPs" in element_to_sources,
+        "need_spots": "spots" in element_to_sources,
+        "need_modules": "modules" in element_to_sources, 
+        "need_metadata": True,
+        "sources": metadata_sources
+    }
     
-    check_pangenome_info(pangenome, disable_bar=disable_bar, **need_dict,)
+    check_pangenome_info(pangenome, disable_bar=disable_bar, **need_dict)
 
-    element_type_to_attribute =  {"families":"gene_families", "genomes":"organisms", 
-                           "RGPs":"regions", "genes":"genes", "modules":"modules",
-                           "spots":"spots", "contigs":"contigs"}
+    element_type_to_attribute = {
+        "families": "gene_families", 
+        "genomes": "organisms", 
+        "RGPs": "regions", 
+        "genes": "genes", 
+        "modules": "modules",
+        "spots": "spots", 
+        "contigs": "contigs"
+    }
     
     for element_type, sources in element_to_sources.items():
         first_columns = [element_type]
         source_to_metadata = defaultdict(list)
 
         for element in getattr(pangenome, element_type_to_attribute[element_type]):
-
             for source in set(element.sources) & set(sources):
-            
                 for metadata in element.get_metadata_by_source(source):
-                    metadata_dict =  metadata.to_dict()
+                    metadata_dict = metadata.to_dict()
                     if element_type == "spots":
                         metadata_dict[element_type] = f"spot_{element.ID}"
-                    
                     elif element_type == "modules":
                         metadata_dict[element_type] = f"module_{element.ID}"
-
                     elif element_type in ["genes", "contigs"]:
                         metadata_dict[element_type] = element.ID
-
                     elif element_type in ["families", 'genomes', "RGPs"]:
                         metadata_dict[element_type] = element.name
 
-                    # add genome name for genome specific element if genomes is not a metadata
+                    # Add genome name for genome-specific elements if genome is not already a metadata
                     if element_type in ["genes", "contigs", "RGPs"] and "genomes" not in metadata_dict:
                         metadata_dict["genomes"] = element.organism.name
                         first_columns = ["genomes"] + first_columns
 
                     source_to_metadata[source].append(metadata_dict)
 
-
         for source, metadata_list in source_to_metadata.items():
-
             df_source = pd.DataFrame(metadata_list)
-            columns_order = first_columns + [col for col in df_source.columns if col not in first_columns]  
+            columns_order = first_columns + [col for col in df_source.columns if col not in first_columns]
             df_source = df_source.reindex(columns_order, axis=1)
-            tsv_file_name = f"{element_type}_metadata_from_{source}.tsv" 
+            tsv_file_name = f"{element_type}_metadata_from_{source}.tsv"
             if compress:
-                tsv_file_name = f"{tsv_file_name}.gz"
-
+                tsv_file_name += ".gz"
             tsv_path = output / tsv_file_name
 
-            logging.getLogger("PPangGGOLiN").info(f"Writing {element_type} metadata from source {source} in '{tsv_path}'")
+            logging.getLogger("PPanGGOLiN").info(f"Writing {element_type} metadata from source '{source}' to '{tsv_path}'")
             df_source.to_csv(tsv_path, sep="\t", index=False)
 
-    logging.getLogger("PPangGGOLiN").info("Done writing metadata in TSV format")
+    logging.getLogger("PPanGGOLiN").info("Finished writing metadata in TSV format.")
 
 
 def launch(args: argparse.Namespace):

--- a/ppanggolin/formats/write_proksee.py
+++ b/ppanggolin/formats/write_proksee.py
@@ -150,12 +150,16 @@ def write_contig(organism: Organism, genome_sequences: Dict[str, str] = None, me
     """
     contigs_data_list = []
 
-
+    genome_metadata = organism.formatted_metadata_dict(metadata_sep)
     for contig in tqdm(organism.contigs, unit="contig", disable=True):
 
         metadata_for_proksee = {"is_circular": bool(contig.is_circular)}
 
+        metadata_for_proksee.update(genome_metadata)
         metadata_for_proksee.update(contig.formatted_metadata_dict(metadata_sep))
+
+        metadata_for_proksee = {key:val for key,val in metadata_for_proksee.items() if val not in ["None", '']}
+
         contig_info = {
             "name": contig.name,
             "length": contig.length,

--- a/ppanggolin/geneFamily.py
+++ b/ppanggolin/geneFamily.py
@@ -158,6 +158,7 @@ class GeneFamily(MetaFeatures):
         self[gene.ID] = gene
         gene.family = self
         if gene.organism is not None and gene.organism in self._genePerOrg:
+            # TODO try to remove the second condition and check if projection is working
             self._genePerOrg[gene.organism].add(gene)
 
     def get(self, identifier: str) -> Gene:

--- a/ppanggolin/main.py
+++ b/ppanggolin/main.py
@@ -61,6 +61,7 @@ def cmd_line() -> argparse.Namespace:
     desc += "    draw              Draw figures representing the pangenome through different aspects\n"
     desc += "    write_pangenome   Writes 'flat' files that represent the pangenome and its elements for use with other software.\n"
     desc += "    write_genomes     Writes 'flat' files that represent the genomes along with their associated pangenome elements.\n"
+    desc += "    write_metadata    Writes 'TSV' files that represent the metadata associated with elements of the pangenome.\n"
     desc += "    fasta             Writes fasta files for different elements of the pangenome.\n"
     desc += "    info              Prints information about a given pangenome graph file.\n"
     desc += "    metrics           Compute several metrics on a given pangenome.\n"
@@ -138,7 +139,7 @@ def cmd_line() -> argparse.Namespace:
                      "Use the command line or the config file.")
 
     cmds_pangenome_required = ["cluster", "info", "module", "graph", "align",
-                               "context", "write_pangenome", "write_genomes", "msa", "draw", "partition",
+                               "context", "write_pangenome", "write_genomes", "write_metadata", "msa", "draw", "partition",
                                "rarefaction", "spot", "fasta", "metrics", "rgp", "projection", "metadata"]
     if args.subcommand in cmds_pangenome_required and args.pangenome is None:
         parser.error("Please specify a pangenome file using the --pangenome argument, "
@@ -191,6 +192,8 @@ def main():
         ppanggolin.formats.writeFlatPangenome.launch(args)
     elif args.subcommand == "write_genomes":
         ppanggolin.formats.writeFlatGenomes.launch(args)
+    elif args.subcommand == "write_metadata":
+        ppanggolin.formats.writeFlatMetadata.launch(args)
     elif args.subcommand == "fasta":
         ppanggolin.formats.writeSequences.launch(args)
     elif args.subcommand == "msa":

--- a/ppanggolin/meta/meta.py
+++ b/ppanggolin/meta/meta.py
@@ -87,15 +87,15 @@ def assign_metadata(metadata_df: pd.DataFrame, pangenome: Pangenome, source: str
     :param pangenome: A Pangenome object representing the pangenome to which metadata will be assigned.
     :param source: A string representing the source of the metadata.
     :param metatype: A string representing the type of element to which metadata will be assigned.
-    :param omit: A boolean indicating whether to raise an error if metadata cannot be assigned to an element. If True, metadata will not be assigned to elements that do not exist in the pangenome. If False, an error will be raised. Default is False.
+    :param omit: A boolean indicating whether to raise an error if metadata cannot be assigned to an element. 
+                 If True, metadata will not be assigned to elements that do not exist in the pangenome. 
+                 If False, an error will be raised. Default is False.
     :param disable_bar: A boolean indicating whether to disable the progress bar. Default is False.
 
     :raise KeyError: element name is not find in pangenome
     :raise AssertionError: Metatype is not recognized
     """
     assert metatype in ["families", "genomes", "contigs", "genes", "RGPs", "spots", "modules"]
-
-    org2contig = None
 
     def check_duplicate_contig_name():
         contig_names = set()
@@ -108,7 +108,7 @@ def assign_metadata(metadata_df: pd.DataFrame, pangenome: Pangenome, source: str
                                 "Add a column 'genomes' to indicate to which genome the contig belongs to.")
 
     if metatype == "contigs" and "genomes" not in metadata_df.columns:
-            check_duplicate_contig_name()
+        check_duplicate_contig_name()
 
     for row in tqdm(metadata_df.iterrows(), unit='row',
                     total=metadata_df.shape[0], disable=disable_bar):

--- a/ppanggolin/metadata.py
+++ b/ppanggolin/metadata.py
@@ -76,6 +76,13 @@ class Metadata:
         fields = list(self.__dict__)
         fields.remove("source")
         return fields
+    
+    def to_dict(self):
+        """
+        Get metadata in dict format.
+        """
+
+        return self.__dict__.copy()
 
     @staticmethod
     def _join_list(attr_list: Union[str, List[str]]):
@@ -140,6 +147,7 @@ class MetaFeatures:
 
         return {source_field: separator.join(values) for source_field, values in source_field_2_values.items()}
 
+    
     def add_metadata(self, source, metadata):
         """Add metadata to metadata getter
 

--- a/ppanggolin/metadata.py
+++ b/ppanggolin/metadata.py
@@ -218,3 +218,12 @@ class MetaFeatures:
         """
         max_source, max_meta = max(self._metadata_getter.items(), key=lambda x: len(x[1]))
         return max_source, len(max_meta)
+
+    def has_metadata(self):
+        """
+        Does the feature has some metadata associated.
+
+        :return: True if it has metadata else False
+        """
+
+        return True if len(self._metadata_getter) > 0 else False

--- a/ppanggolin/metadata.py
+++ b/ppanggolin/metadata.py
@@ -77,7 +77,7 @@ class Metadata:
         fields.remove("source")
         return fields
     
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         """
         Get metadata in dict format.
         """
@@ -219,7 +219,7 @@ class MetaFeatures:
         max_source, max_meta = max(self._metadata_getter.items(), key=lambda x: len(x[1]))
         return max_source, len(max_meta)
 
-    def has_metadata(self):
+    def has_metadata(self) -> bool:
         """
         Does the feature has some metadata associated.
 

--- a/ppanggolin/pangenome.py
+++ b/ppanggolin/pangenome.py
@@ -773,6 +773,13 @@ class Pangenome:
         return exact_core_families
 
     """Metadata"""
+    def has_metadata(self):
+        """
+        Whether or not the pangenome has metadata associated with any of its elements.
+        """
+        return any(( status != "No" for status in self.status['metadata'].values()))
+
+
     def select_elem(self, metatype: str):
         """Get all the element for the given metatype
 

--- a/ppanggolin/pangenome.py
+++ b/ppanggolin/pangenome.py
@@ -773,7 +773,7 @@ class Pangenome:
         return exact_core_families
 
     """Metadata"""
-    def has_metadata(self):
+    def has_metadata(self) -> bool:
         """
         Whether or not the pangenome has metadata associated with any of its elements.
         """

--- a/testingDataset/expected_info_files/myannopang_info.yaml
+++ b/testingDataset/expected_info_files/myannopang_info.yaml
@@ -60,5 +60,7 @@ Parameters:
         # final nb of partitions: 3
         krange: [3, 20]
 
-Metadata: null
+Metadata:
+    contigs: annotation_file
+    genomes: annotation_file
 

--- a/testingDataset/launch_test_locally.py
+++ b/testingDataset/launch_test_locally.py
@@ -102,7 +102,7 @@ def main():
 
     workflow = parse_yaml_file(args.ci_yaml)
 
-    excluded_steps = ['Install ppanggolin']
+    excluded_steps = ['Install ppanggolin', "Get core number on linux", "Get core number on macos"]
 
     test_script = args.outdir  / 'launch_test_command.sh'
     with open(test_script, "w") as fl:

--- a/tests/annotate/test_annotate.py
+++ b/tests/annotate/test_annotate.py
@@ -1,6 +1,6 @@
 import pytest
 from pathlib import Path
-from ppanggolin.annotate.annotate import extract_positions, read_anno_file, parse_contig_header_lines, parse_gbff_by_contig, parse_feature_lines, parse_dna_seq_lines, read_org_gbff
+from ppanggolin.annotate.annotate import extract_positions, read_anno_file, parse_contig_header_lines, parse_gbff_by_contig, parse_feature_lines, parse_dna_seq_lines, read_org_gbff, combine_contigs_metadata
     
 
 
@@ -229,3 +229,19 @@ def test_parse_dna_seq_lines():
             "       21 ggccc ctttt"]
     
     assert parse_dna_seq_lines(lines) == "AAACCGGGTTCCAAATTTGGGGCCCCTTTT"
+
+
+def test_combine_contigs_metadata():
+
+    contig_to_metadata = {
+        "contig1":{"sp":"spA", "strain":"123", "contig_feat":"ABC"},
+        "contig2":{"sp":"spA", "strain":"123", "contig_feat":"XYZ"},
+        "contig3":{"sp":"spA", "strain":"123"}
+    }
+
+    genome_metadata, contig_metadata = combine_contigs_metadata(contig_to_metadata)
+
+    assert genome_metadata == {"sp":"spA", "strain":"123"}
+    assert contig_metadata == {"contig1":{"contig_feat":"ABC"}, "contig2":{"contig_feat":"XYZ"},}
+
+

--- a/tests/annotate/test_annotate.py
+++ b/tests/annotate/test_annotate.py
@@ -102,7 +102,7 @@ def test_read_org_gbff(genome_data_with_joined_genes):
     genome, _ = read_org_gbff(genome_name, genome_path, circular_contigs, pseudo=True)
 
     # this genome has 2 genes that are joined. 
-    assert genome.number_of_genes() == 917 
+    assert genome.number_of_genes() == 917
     
 
 

--- a/tests/annotate/test_annotate.py
+++ b/tests/annotate/test_annotate.py
@@ -1,6 +1,7 @@
 import pytest
 from pathlib import Path
-from ppanggolin.annotate.annotate import extract_positions, read_anno_file
+from ppanggolin.annotate.annotate import extract_positions, read_anno_file, parse_contig_header_lines, parse_gbff_by_contig, parse_feature_lines, parse_dna_seq_lines, read_org_gbff
+    
 
 
 @pytest.mark.parametrize("input_string, expected_positions, expected_complement, expected_pseudogene", [
@@ -38,10 +39,25 @@ def genome_data():
     """
     Fixture providing common data for the tests.
     """
-    # from the dir of the current python file, find a gbff file stored in testingDataset/GBFF repository
-    genome_path = Path(__file__).resolve().parent / "../../testingDataset/GBFF/GCF_000026905.1_ASM2690v1_genomic.gbff.gz"
+    script_path = Path(__file__).resolve()
+    ppanggolin_main_dir = script_path.parent.parent.parent
+
+    genome_path = ppanggolin_main_dir / "testingDataset/GBFF/GCF_000026905.1_ASM2690v1_genomic.gbff.gz"
     circular_contigs = []
     genome_name = "GCF_000026905" 
+    return genome_name, genome_path, circular_contigs
+
+@pytest.fixture
+def genome_data_with_joined_genes():
+    """
+    Fixture providing gbff file with joined genes
+    """
+    script_path = Path(__file__).resolve()
+    ppanggolin_main_dir = script_path.parent.parent.parent
+
+    genome_path = ppanggolin_main_dir / "testingDataset/GBFF/GCF_002776845.1_ASM277684v1_genomic.gbff.gz"
+    circular_contigs = []
+    genome_name = "GCF_002776845" 
     return genome_name, genome_path, circular_contigs
 
 def test_read_anno_file(genome_data):
@@ -73,13 +89,143 @@ def test_read_anno_file_with_pseudo_enable(genome_data):
     assert genome.number_of_contigs == 1
 
 
-def test_with_joined_genes():
-    genome_path = Path(__file__).resolve().parent / "../../testingDataset/GBFF/GCF_002776845.1_ASM277684v1_genomic.gbff.gz"
-    genome_name = "GCF_002776845"
-    circular_contigs = []
+def test_with_joined_genes(genome_data_with_joined_genes):
+    genome_name, genome_path, circular_contigs = genome_data_with_joined_genes
     use_pseudogene = True
     genome, _ = read_anno_file(genome_name, genome_path, circular_contigs, use_pseudogene)
 
     # this genome has 2 genes that are joined. 
     assert genome.number_of_genes() == 917 
     
+def test_read_org_gbff(genome_data_with_joined_genes):
+    genome_name, genome_path, circular_contigs = genome_data_with_joined_genes
+    genome, _ = read_org_gbff(genome_name, genome_path, circular_contigs, pseudo=True)
+
+    # this genome has 2 genes that are joined. 
+    assert genome.number_of_genes() == 917 
+    
+
+
+def test_gbff_header_parser():
+
+    header_lines = [
+    "LOCUS       NC_022109            1041595 bp    DNA     circular CON 24-MAR-2017",
+    "DEFINITION  Chlamydia trachomatis strain D/14-96 genome.",
+    "VERSION     NC_022109.1",
+    "SOURCE      Chlamydia trachomatis",
+    "  ORGANISM  Chlamydia trachomatis",
+    "            Bacteria; Chlamydiae; Chlamydiales; Chlamydiaceae;",
+    "            Chlamydia/Chlamydophila group; Chlamydia.",
+    ]
+
+    parsed_header = parse_contig_header_lines(header_lines)
+
+    assert parsed_header ==  {
+            "LOCUS"     :  "NC_022109            1041595 bp    DNA     circular CON 24-MAR-2017",
+            "DEFINITION" : "Chlamydia trachomatis strain D/14-96 genome.",
+            "VERSION"   :  "NC_022109.1",
+            "SOURCE"     : "Chlamydia trachomatis",
+            "ORGANISM" : "Chlamydia trachomatis\nBacteria; Chlamydiae; Chlamydiales; Chlamydiaceae;\nChlamydia/Chlamydophila group; Chlamydia."
+    }
+
+
+
+# Define test data
+@pytest.fixture
+def sample_gbff_path(tmp_path):
+    gbff_content = """LOCUS       NC_022109            1041595 bp    DNA     circular CON 24-MAR-2017
+DEFINITION  Chlamydia trachomatis strain D/14-96 genome.
+ACCESSION   NC_022109
+VERSION     NC_022109.1
+KEYWORDS    RefSeq.
+SOURCE      Chlamydia trachomatis
+FEATURES             Location/Qualifiers
+     source          1..1041595
+                     /organism="Chlamydia trachomatis"
+                     /mol_type="genomic DNA"
+ORIGIN
+        1 aaaccgggtt
+       11 ccaaatttgg
+//
+LOCUS       NC_022110            2041595 bp    DNA     circular CON 24-MAR-2017
+DEFINITION  Another genome.
+KEYWORDS    RefSeq.
+SOURCE      Chlamydia trachomatis
+  ORGANISM  Chlamydia trachomatis
+            Bacteria; Chlamydiae; Chlamydiales; Chlamydiaceae;
+            Chlamydia/Chlamydophila group; Chlamydia.
+FEATURES             Location/Qualifiers
+     source          1..2041595
+                     /organism="Chlamydia trachomatis"
+                     /mol_type="genomic DNA"
+ORIGIN
+        1 aaaccgggtt
+       11 ccaaatttgg
+       21 ggcccctttt
+//
+"""
+
+    gbff_file_path = tmp_path / "sample.gbff"
+    with open(gbff_file_path, "w") as f:
+        f.write(gbff_content)
+    return gbff_file_path
+
+# Define test cases
+def test_parse_gbff_by_contig(sample_gbff_path):
+    contigs = list(parse_gbff_by_contig(sample_gbff_path))
+
+    assert len(contigs) == 2
+
+    # Check first contig
+    header_1, feature_1, sequence_1 = contigs[0]
+    assert len(header_1) == 6
+    assert len(list(feature_1)) == 1
+    assert sequence_1 == "AAACCGGGTTCCAAATTTGG"
+
+    # Check second contig
+    header_2, feature_2, sequence_2 = contigs[1]
+    assert len(header_2) == 5
+    assert list(feature_2) == [{"type":"source", "location":"1..2041595", "organism":'Chlamydia trachomatis', "mol_type":"genomic DNA"}]
+
+    assert sequence_2 == "AAACCGGGTTCCAAATTTGGGGCCCCTTTT"
+
+
+
+# Define test cases
+@pytest.mark.parametrize("input_lines, expected_output", [
+    (["     gene            123..456",
+      "                     /locus_tag=ABC123",
+      "                     /note=Some note",
+      "     CDS             789..1011",
+      "                     /protein_id=DEF456",
+      "                     /translation=ATGCTAGCATCG"], 
+     [{"type": "gene",
+       "location": "123..456",
+       "locus_tag": "ABC123",
+       "note": "Some note"},
+      {"type": "CDS","location": "789..1011", "protein_id": "DEF456", "translation": "ATGCTAGCATCG"}]),
+    (["     gene            123..456", 
+      "                     /locus_tag=ABC123", 
+      "                     /note=Some note", 
+      "     CDS             789..1011",
+      '                     /protein_id="DEF456"', 
+      '                     /translation="ATGCTAGCATCG"', 
+      "     gene            789..1011",
+      "                     /locus_tag=DEF789",
+      "                     /note=Another note"], 
+     [{"type": "gene", "location": "123..456", "locus_tag": "ABC123", "note": "Some note"},
+      {"type": "CDS", "location": "789..1011", "protein_id": "DEF456", "translation": "ATGCTAGCATCG"},
+      {"type": "gene", "location": "789..1011", "locus_tag": "DEF789", "note": "Another note"}]),
+    # Add more test cases as needed
+])
+def test_parse_feature_lines(input_lines, expected_output):
+    print(expected_output)
+    assert list(parse_feature_lines(input_lines)) == expected_output
+
+
+def test_parse_dna_seq_lines():
+    lines =["        1 aaacc gggtt",
+            "       11 ccaaa tttgg",
+            "       21 ggccc ctttt"]
+    
+    assert parse_dna_seq_lines(lines) == "AAACCGGGTTCCAAATTTGGGGCCCCTTTT"


### PR DESCRIPTION
This PR extracts information from annotation files (GBFF and GFF) and adds them as metadata to genomes and contigs in the pangenome file.

Tasks to complete:
- [x] Extract and add metadata from GBFF files
- [x] Extract and add metadata from GFF files
- [x] ~~Display metadata by default in output files~~
- [x] Give the possibility to output metadata in TSV format from the pangenome file
- [x] Update metadata documentation

I have completely redesigned the `read_org_gbff` function to simplify metadata extraction from GBFF files.

Metadata will still no be displayed in output files by default as this behavior may lead to some error regarding the metadata separator. If the user want to display metadata in the output files, it needs to add the `--add_metadata` flag as before. 

Note: This PR builds on the AnnotJoin branch, which has introduced several changes to annotation file parsing. Therefore, it is dependent on PR #206 and should be merged afterward.
