### PR TITLE
Fix 'gene_to_gene_family.tsv' file from projection

### DIFF
--- a/docs/user/projection.md
+++ b/docs/user/projection.md
@@ -51,7 +51,7 @@ Additionally, within the Output directory, there is a subdirectory for each inpu
 For Gene Family and Partition of Input Genes:
 
 - `cds_sequences.fasta`: This file contains the sequences of coding regions (CDS) from the input genome.
-- `gene_to_gene_family.tsv`: It provides the mapping of genes to gene families of the pangenome. Its format follows [this output](Outputs.md#gene-families-and-genes)
+- `gene_to_gene_family.tsv`: It provides the mapping of genes to gene families of the pangenome. Its format follows [this output](PangenomeAnalyses/pangenomeAnalyses.md#gene-families-to-genes-associations)
 - `sequences_partition_projection.tsv`: This file maps the input genes to its partition (Persistent, Shell or Cloud).
 - `specific_genes.tsv`: This file lists the gene of the input genomes that do not align to any gene of the pangenome. These genes are assigned to Cloud parititon. 
 

--- a/ppanggolin/align/alignOnPang.py
+++ b/ppanggolin/align/alignOnPang.py
@@ -300,8 +300,7 @@ def write_gene_to_gene_family(seqid_to_gene_family: Dict[str, GeneFamily], seq_s
     with open(gene_fam_map_file, "w") as cluster_proj_file:
         for input_seq in seq_set:
             # get the seq gene family and if there is no hit, itself
-            gene_family = seqid_to_gene_family.get(input_seq,
-                                                   default=None)
+            gene_family = seqid_to_gene_family.get(input_seq)
             if gene_family is None:
                 gene_family_name = input_seq
             else:

--- a/ppanggolin/align/alignOnPang.py
+++ b/ppanggolin/align/alignOnPang.py
@@ -287,22 +287,26 @@ def project_and_write_partition(seqid_to_gene_family: Dict[str, GeneFamily], seq
 
 def write_gene_to_gene_family(seqid_to_gene_family: Dict[str, GeneFamily], seq_set: Set[str], output: Path) -> Path:
     """
-    Write input gene to gene family.
+    Write input gene to pangenome gene family.
 
-    :param seqid_to_gene_family: dictionnary which link sequence and pangenome gene family
+    :param seqid_to_gene_family: dictionnary which links input sequence and pangenome gene family
     :param seq_set: input sequences
     :param output: Path of the output directory
 
-    :return: Path to file which contain partition projection
+    :return: Path to the file which contains gene to gene family projection results
     """
 
     gene_fam_map_file = output.absolute() / "gene_to_gene_family.tsv"
-    with open(gene_fam_map_file, "w") as partProjFile:
-        for input_seq, gene_fam in seqid_to_gene_family.items():
-            partProjFile.write(f"{input_seq}\t{gene_fam.name}\n")
-
-        for remaining_seq in seq_set - seqid_to_gene_family.keys():
-            partProjFile.write(f"{remaining_seq}\t{remaining_seq}\n")  # if there is no hit, gene family is itself.
+    with open(gene_fam_map_file, "w") as cluster_proj_file:
+        for input_seq in seq_set:
+            # get the seq gene family and if there is no hit, itself
+            gene_family = seqid_to_gene_family.get(input_seq,
+                                                   default=None)
+            if gene_family is None:
+                gene_family_name = input_seq
+            else:
+                gene_family_name = gene_family.name
+            cluster_proj_file.write(f"{input_seq}\t{gene_family_name}\n")
 
     return gene_fam_map_file
 


### PR DESCRIPTION
This fixes #221.

The previous version was writing all genes of all input genomes used in the projection, then the genes from the input genome that did not have a gene family in the pangenome.

Correct behavior is to only write the genes of the input genome.