### PR TITLE
Improve reading from custom gbff files

### DIFF
--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -446,7 +446,8 @@ def read_org_gbff(organism_name: str, gbff_file_path: Path, circular_contigs: Li
                 contig_counter.value += 1
             organism.add(contig)
             contig.length = contig_len
-        
+        genetic_code = 11
+
         for feature in features:
             if feature['type'] == "source":
                 contig_to_metadata[contig] = {tag:value for tag, value in feature.items() if tag not in ['type', "location"] and isinstance(value, str)}

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -520,7 +520,7 @@ def read_org_gbff(organism_name: str, gbff_file_path: Path, circular_contigs: Li
 
     if used_transl_table_arg:
         logging.getLogger("PPanGGOLiN").info(
-                f"transl_except tag was not found for {used_transl_table_arg} CDS "
+                f"transl_table tag was not found for {used_transl_table_arg} CDS "
                 f"in {gbff_file_path}. Provided translation_table argument value was used instead: {translation_table}."
                 )
                     
@@ -772,7 +772,7 @@ def read_org_gff(organism: str, gff_file_path: Path, circular_contigs: List[str]
 
     if used_transl_table_arg:
         logging.getLogger("PPanGGOLiN").info(
-                f"transl_except tag was not found for {used_transl_table_arg} CDS "
+                f"transl_table tag was not found for {used_transl_table_arg} CDS "
                 f"in {gff_file_path}. Provided translation_table argument value was used instead: {translation_table}."
                 )
     return org, has_fasta
@@ -910,8 +910,8 @@ def read_anno_file(organism_name: str, filename: Path, circular_contigs: list,
     :param organism_name: Name of the organism
     :param filename: Path to the corresponding file
     :param circular_contigs: list of sequence in contig
-    :param translation_table: Translation table (genetic code) to use when /transl_table is missing from CDS tags.
     :param pseudo: allow to read pseudogene
+    :param translation_table: Translation table (genetic code) to use when /transl_table is missing from CDS tags.
 
     :return: Annotated organism for pangenome and true for sequence in file
     """

--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -145,7 +145,8 @@ def manage_input_genomes_annotation(pangenome, input_mode, anno, fasta,
         check_input_names(pangenome, genome_name_to_path)
 
         organisms, org_2_has_fasta = read_annotation_files(genome_name_to_path, cpu=cpu, pseudo=use_pseudo,
-                    disable_bar=disable_bar)
+                                                           translation_table=int(pangenome_params.cluster.translation_table),
+                                                           disable_bar=disable_bar)
         
         if not all((has_fasta for has_fasta in org_2_has_fasta.values())):
             organisms_with_no_fasta = {org for org, has_fasta in org_2_has_fasta.items() if not has_fasta}
@@ -388,7 +389,7 @@ def annotate_fasta_files(genome_name_to_fasta_path: Dict[str, dict], tmpdir: str
     return organisms
 
 
-def read_annotation_files(genome_name_to_annot_path: Dict[str, dict], cpu: int = 1, pseudo: bool = False,
+def read_annotation_files(genome_name_to_annot_path: Dict[str, dict], cpu: int = 1, pseudo: bool = False, translation_table: int = 11,
                           disable_bar: bool = False) -> Tuple[List[Organism], Dict[Organism, bool]]:
     """
     Read the annotation from GBFF file
@@ -397,6 +398,7 @@ def read_annotation_files(genome_name_to_annot_path: Dict[str, dict], cpu: int =
     :param organisms_file: List of GBFF files for each organism
     :param cpu: number of CPU cores to use
     :param pseudo: allow to read pseudogène
+    :param translation_table: Translation table (genetic code) to use when /transl_table is missing from CDS tags.
     :param disable_bar: Disable the progresse bar
     """
 
@@ -407,7 +409,7 @@ def read_annotation_files(genome_name_to_annot_path: Dict[str, dict], cpu: int =
     # unless a gff file without fasta is met (which is the only case where sequences can be absent)
     org_to_has_fasta_flag = {}
 
-    args = [(org_name, org_info['path'], org_info['circular_contigs'], pseudo)
+    args = [(org_name, org_info['path'], org_info['circular_contigs'], pseudo, translation_table)
             for org_name, org_info in genome_name_to_annot_path.items()]
 
     contig_counter = Value('i', 0)

--- a/ppanggolin/workflow/all.py
+++ b/ppanggolin/workflow/all.py
@@ -54,7 +54,7 @@ def launch_workflow(args: argparse.Namespace, panrgp: bool = True,
 
         start_anno = time.time()
         read_annotations(pangenome, args.anno, pseudo=args.annotate.use_pseudo,
-                         cpu=args.annotate.cpu, disable_bar=args.disable_prog_bar)
+                         cpu=args.annotate.cpu, translation_table=args.annotate.translation_table, disable_bar=args.disable_prog_bar)
         anno_time = time.time() - start_anno
 
         start_writing = time.time()


### PR DESCRIPTION
This PR implements the use of the genetic_code input parameter (defaults to 11) when reading from a GBFF or GFF file in cases where the /transl_table attribute is missing. When translation table information is missing, the value provided by the translation_table argument is used, which defaults to 11 but can be adjusted by the user if necessary.

Previously, missing transl_table in GBFF files was not handled, resulting in errors (see issue #226). In addition, the translation code in GBFF files was hardcoded to 11 and could not be changed.

This update should fix issue #226.