### PR TITLE
Fix dup margin default value

### DIFF
--- a/ppanggolin/formats/writeMSA.py
+++ b/ppanggolin/formats/writeMSA.py
@@ -53,7 +53,7 @@ def get_families_to_write(pangenome: Pangenome, partition_filter: str = "core", 
                 for family in pangenome.gene_families:
                     if family.number_of_organisms == nb_org:
                         if single_copy:
-                            if family.is_single_copy(dup_margin=dup_margin, exclude_fragment=True):
+                            if family.is_single_copy(dup_margin=dup_margin, exclude_fragment=False):
                                 families.add(family)
                         else:
                             families.add(family)
@@ -61,7 +61,7 @@ def get_families_to_write(pangenome: Pangenome, partition_filter: str = "core", 
                 for family in pangenome.gene_families:
                     if family.number_of_organisms < nb_org:
                         if single_copy:
-                            if family.is_single_copy(dup_margin=dup_margin, exclude_fragment=True):
+                            if family.is_single_copy(dup_margin=dup_margin, exclude_fragment=False):
                                 families.add(family)
                         else:
                             families.add(family)
@@ -69,7 +69,7 @@ def get_families_to_write(pangenome: Pangenome, partition_filter: str = "core", 
                 for family in pangenome.gene_families:
                     if family.number_of_organisms >= nb_org * soft_core:
                         if single_copy:
-                            if family.is_single_copy(dup_margin=dup_margin, exclude_fragment=True):
+                            if family.is_single_copy(dup_margin=dup_margin, exclude_fragment=False):
                                 families.add(family)
                         else:
                             families.add(family)

--- a/ppanggolin/formats/writeMSA.py
+++ b/ppanggolin/formats/writeMSA.py
@@ -22,25 +22,6 @@ from ppanggolin.formats.readBinaries import check_pangenome_info
 from ppanggolin.genetic_codes import genetic_codes
 
 
-def is_single_copy(family: GeneFamily, dup_margin: float = 0.95) -> bool:
-    """
-    Check if a gene family can be considered 'single copy' or not
-
-    :param family: GeneFamily object
-    :param dup_margin: maximal number of genomes in which the gene family can have multiple members and still be considered a 'single copy' gene family
-
-    :return: True if gene family is single copy else False
-    """
-    nb_multi = 0
-    for gene_list in family.get_org_dict().values():
-        if len(gene_list) > 1:
-            nb_multi += 1
-    dup_ratio = nb_multi / family.number_of_organisms
-    if dup_ratio < dup_margin:
-        return True
-    return False
-
-
 def get_families_to_write(pangenome: Pangenome, partition_filter: str = "core", soft_core: float = 0.95,
                           dup_margin: float = 0.95, single_copy: bool = True) -> Set[GeneFamily]:
     """
@@ -63,7 +44,7 @@ def get_families_to_write(pangenome: Pangenome, partition_filter: str = "core", 
             for family in pangenome.gene_families:
                 if family.named_partition == partition_filter:
                     if single_copy:
-                        if is_single_copy(family, dup_margin):
+                        if family.is_single_copy(dup_margin=dup_margin, exclude_fragment=True):
                             families.add(family)
                     else:
                         families.add(family)
@@ -72,7 +53,7 @@ def get_families_to_write(pangenome: Pangenome, partition_filter: str = "core", 
                 for family in pangenome.gene_families:
                     if family.number_of_organisms == nb_org:
                         if single_copy:
-                            if is_single_copy(family, dup_margin):
+                            if family.is_single_copy(dup_margin=dup_margin, exclude_fragment=True):
                                 families.add(family)
                         else:
                             families.add(family)
@@ -80,7 +61,7 @@ def get_families_to_write(pangenome: Pangenome, partition_filter: str = "core", 
                 for family in pangenome.gene_families:
                     if family.number_of_organisms < nb_org:
                         if single_copy:
-                            if is_single_copy(family, dup_margin):
+                            if family.is_single_copy(dup_margin=dup_margin, exclude_fragment=True):
                                 families.add(family)
                         else:
                             families.add(family)
@@ -88,7 +69,7 @@ def get_families_to_write(pangenome: Pangenome, partition_filter: str = "core", 
                 for family in pangenome.gene_families:
                     if family.number_of_organisms >= nb_org * soft_core:
                         if single_copy:
-                            if is_single_copy(family, dup_margin):
+                            if family.is_single_copy(dup_margin=dup_margin, exclude_fragment=True):
                                 families.add(family)
                         else:
                             families.add(family)

--- a/testingDataset/compare_results.py
+++ b/testingDataset/compare_results.py
@@ -98,8 +98,7 @@ def get_suffix_except_gz(path: Path):
             return ext
         
 
-def compare_directories(expected_dir, tested_dir, ignored_files, diff_outdir, report_identical_files, extension_to_compare=[".tsv", ".json", '.gff', '.txt', '.csv', '.faa', '.fasta', ".yaml"]):
-
+def compare_directories(expected_dir, tested_dir, ignored_files, diff_outdir, report_identical_files, extension_to_compare=[".tsv", ".aln", ".json", '.gff', '.txt', '.csv', '.faa', '.fasta', ".yaml"]):
     # Define directory information with color
     expected_dir_info = f"- Expected directory: {expected_dir}"
     tested_dir_info = f"- Tested directory: {tested_dir}"
@@ -177,8 +176,8 @@ def compare_directories(expected_dir, tested_dir, ignored_files, diff_outdir, re
     print(f"{len(ignored_files_ext)} file(s) ignored due to their extension.")
 
     # Display unexpected files in Tested results
-    print(f"{len(dcmp.left_only)} file(s) unexpectedly found in Tested results.")
-    print(f"{len(dcmp.right_only)} file(s) missing in Tested results.")
+    print(f"{len(dcmp.right_only)} file(s) unexpectedly found in Tested results.")
+    print(f"{len(dcmp.left_only)} file(s) missing in Tested results.")
 
     # Display different files count
     print(f"{len(different_files)} file(s) differ.")

--- a/testingDataset/launch_test_locally.py
+++ b/testingDataset/launch_test_locally.py
@@ -102,7 +102,7 @@ def main():
 
     workflow = parse_yaml_file(args.ci_yaml)
 
-    excluded_steps = ['Install ppanggolin']
+    excluded_steps = ['Install ppanggolin', "Get core number on linux", "Get core number on macos"]
 
     test_script = args.outdir  / 'launch_test_command.sh'
     with open(test_script, "w") as fl:


### PR DESCRIPTION
As highlighted in issue #223, the default value of `dup_margin` in the function [is_single_copy](https://github.com/labgem/PPanGGOLiN/blob/f3ba6a1f33256f19175b570c4b711bb8970d0365/ppanggolin/formats/writeMSA.py#L25) was incorrect and should be 0.05. However, this had no practical impact as the default value was never actually used.

This PR removes the `is_single_copy` function and replaces it with the `is_single_copy` method from the `Gene_Family` class, which is already utilized elsewhere in the code. This change reduces code duplication and ensures consistency across the codebase.

This update addresses the concerns raised in issue #223.