### PR TITLE
Adding identifier to metadata in object and HDF5

### DIFF
--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -499,13 +499,11 @@ def read_org_gbff(organism_name: str, gbff_file_path: Path, circular_contigs: Li
                 rna_counter += 1
 
     genome_metadata, contig_to_uniq_metadata = combine_contigs_metadata(contig_to_metadata)
-    
-    genome_meta_obj = Metadata(source='annotation_file', **genome_metadata)
-    organism.add_metadata(source="annotation_file", metadata=genome_meta_obj)
+
+    organism.add_metadata(metadata=Metadata(source='annotation_file', **genome_metadata))
 
     for contig, metadata_dict in contig_to_uniq_metadata.items():
-        contigs_meta_obj = Metadata(source='annotation_file', **metadata_dict)
-        contig.add_metadata(source="annotation_file", metadata=contigs_meta_obj)
+        contig.add_metadata(Metadata(source='annotation_file', **metadata_dict))
 
     return organism, True
 
@@ -763,8 +761,7 @@ def add_metadata_from_gff_file(contig_name_to_region_info: Dict[str, str], org: 
     if len(contig_name_to_region_info) == org.number_of_contigs:
         genome_metadata, contig_to_uniq_metadata = combine_contigs_metadata(contig_name_to_region_info)
         if genome_metadata:
-            genome_meta_obj = Metadata(source='annotation_file', **genome_metadata)
-            org.add_metadata(source="annotation_file", metadata=genome_meta_obj)
+            org.add_metadata(Metadata(source='annotation_file', **genome_metadata))
     else:
         logging.getLogger("PPanGGOLiN").warning(
             f"Inconsistent data in GFF file {gff_file_path}: "
@@ -776,9 +773,8 @@ def add_metadata_from_gff_file(contig_name_to_region_info: Dict[str, str], org: 
             contig = org.get(contig_name)
         except KeyError:
             raise ValueError(f"Contig '{contig_name}' does not exist in the genome object created from GFF file {gff_file_path}.")
-        
-        contigs_meta_obj = Metadata(source='annotation_file', **metadata_dict)
-        contig.add_metadata(source="annotation_file", metadata=contigs_meta_obj)
+
+        contig.add_metadata(Metadata(source='annotation_file', **metadata_dict))
 
 
 def check_and_add_extra_gene_part(gene: Gene, new_gene_info: Dict, max_separation: int = 10):

--- a/ppanggolin/formats/readBinaries.py
+++ b/ppanggolin/formats/readBinaries.py
@@ -677,7 +677,11 @@ def read_metadata(pangenome: Pangenome, h5f: tables.File, metatype: str,
         source_table = metadata_group._f_get_child(source)
         for row in tqdm(read_chunks(source_table), total=source_table.nrows, unit='metadata', disable=disable_bar):
             meta_dict = {'source': source}
-            identifier = row["ID"].decode() if isinstance(row["ID"], bytes) else int(row["ID"])
+            try:
+                meta_id = row["metadata_id"]
+            except KeyError:
+                meta_id = None
+            identifier = row["ID"].decode("utf-8") if isinstance(row["ID"], bytes) else int(row["ID"])
             # else:
             #     identifier = row["name"].decode()
             if metatype == "families":
@@ -701,8 +705,7 @@ def read_metadata(pangenome: Pangenome, h5f: tables.File, metatype: str,
             for field in row.dtype.names:
                 if field not in ["ID", "name"]:
                     meta_dict[field] = row[field].decode() if isinstance(row[field], bytes) else row[field]
-            meta = Metadata(**meta_dict)
-            element.add_metadata(source=source, metadata=meta)
+            element.add_metadata(metadata=Metadata(**meta_dict), metadata_id=meta_id)
     pangenome.status["metadata"][metatype] = "Loaded"
 
 

--- a/ppanggolin/formats/writeFlatMetadata.py
+++ b/ppanggolin/formats/writeFlatMetadata.py
@@ -89,7 +89,7 @@ def write_flat_metadata_files(pangenome: Pangenome, output: Path,
 
         for element in getattr(pangenome, element_type_to_attribute[element_type]):
             for source in set(element.sources) & set(sources):
-                for metadata in element.get_metadata_by_source(source):
+                for metadata in element.get_metadata_by_source(source).values():
                     metadata_dict = metadata.to_dict()
                     if element_type == "spots":
                         metadata_dict[element_type] = f"spot_{element.ID}"

--- a/ppanggolin/formats/writeMetadata.py
+++ b/ppanggolin/formats/writeMetadata.py
@@ -104,7 +104,7 @@ def get_metadata_contig_len(select_ctg: List[Contig], source: str) -> Tuple[Dict
     expected_rows = 0
 
     for contig in select_ctg:
-        for metadata in contig.get_metadata_by_source(source):
+        for metadata in contig.get_metadata_by_source(source).values():
             for attr, value in ((k, v) for k, v in metadata.__dict__.items() if k != "source"):
                 if isinstance(value, bytes):
                     value = value.decode('UTF-8')

--- a/ppanggolin/formats/writeMetadata.py
+++ b/ppanggolin/formats/writeMetadata.py
@@ -236,7 +236,6 @@ def write_metadata_metatype(h5f: tables.File, source: str, metatype: str,
     """
     metatype_group = write_metadata_group(h5f, metatype)
     meta_len = get_metadata_len(select_elements, source)
-    h5f.remove_node(metatype_group, source)
     source_table = h5f.create_table(metatype_group, source, desc_metadata(*meta_len[:-1]), expectedrows=meta_len[-1])
     meta_row = source_table.row
     for element in tqdm(select_elements, unit=metatype, desc=f'Source = {source}', disable=disable_bar):

--- a/ppanggolin/meta/meta.py
+++ b/ppanggolin/meta/meta.py
@@ -135,8 +135,7 @@ def assign_metadata(metadata_df: pd.DataFrame, pangenome: Pangenome, source: str
             else:
                 logging.getLogger().debug(f"{metatype}: {row[metatype]} doesn't exist")
         else:
-            meta = Metadata(source=source, **{k: v for k, v in row.to_dict().items() if k != metatype})
-            element.add_metadata(source=source, metadata=meta)
+            element.add_metadata(Metadata(source=source, **{k: v for k, v in row.to_dict().items() if k != metatype}))
 
     pangenome.status["metadata"][metatype] = "Computed"
     pangenome.status["metasources"][metatype].append(source)

--- a/ppanggolin/metadata.py
+++ b/ppanggolin/metadata.py
@@ -156,8 +156,8 @@ class MetaFeatures:
     def add_metadata(self, metadata: Metadata, metadata_id: int = None) -> None:
         """Add metadata to metadata getter
 
-        :param source: Name of the metadata source
         :param metadata: metadata value to add for the source
+        :param metadata_id: metadata identifier
 
         :raises AssertionError: Source or metadata is not with the correct type
         """
@@ -234,7 +234,6 @@ class MetaFeatures:
         :return: Name of the source with the maximum annotation and the number of metadata corresponding
         """
         max_source, max_meta = max(self._metadata_getter.items(), key=lambda x: len(x[1]))
-        print(max_source, len(max_meta))
         return max_source, len(max_meta)
 
     def has_metadata(self) -> bool:
@@ -247,4 +246,10 @@ class MetaFeatures:
         return True if self.number_of_metadata > 0 else False
 
     def has_source(self, source: str) -> bool:
+        """Check if the source is in the metadata feature
+
+        :param source: name of the source
+
+        :return: True if the source is in the metadata feature else False
+        """
         return True if source in self._metadata_getter else False

--- a/ppanggolin/pangenome.py
+++ b/ppanggolin/pangenome.py
@@ -827,15 +827,15 @@ class Pangenome:
     def metadata(self, metatype: str) -> Generator[Metadata, None, None]:
         """Create a generator with all metadatas in the pangenome
 
-		:param metatype: Select to which pangenome element metadata should be generate
+        :param metatype: Select to which pangenome element metadata should be generate
 
         :return: Set of metadata source
         """
         for elem in self.select_elem(metatype):
             yield elem.metadata
 
-    def get_elem_by_metadata(self, metatype: str, **kwargs) -> Generator[
-        Union[GeneFamily, Gene, Organism, Region, Spot, Module], None, None]:
+    def get_elem_by_metadata(self, metatype: str, **kwargs
+                             ) -> Generator[Union[GeneFamily, Gene, Organism, Region, Spot, Module], None, None]:
         """Get element in pangenome with metadata attribute expected
 
         :param metatype: Select to which pangenome element metadata
@@ -847,16 +847,16 @@ class Pangenome:
             if len(list(elem.get_metadata_by_attribute(**kwargs))) > 0:
                 yield elem
 
-    def get_elem_by_sources(self, source: List[str],
-                            metatype: str) -> Generator[Union[GeneFamily, Gene, Contig, Organism,
-                                                              Region, Spot, Module], None, None]:
-        """ Get gene famlies with a specific source in pangenome
+    def get_elem_by_source(self, source: str, metatype: str
+                           ) -> Generator[Union[GeneFamily, Gene, Contig, Organism, Region, Spot, Module], None, None]:
+        """ Get gene families with a specific source in pangenome
 
         :param source: Name of the source
+        :param metatype: select to which pangenome element metadata should be written
 
         :return: Gene families with the source
         """
         assert metatype in ["families", "genomes", "contigs", "genes", "RGPs", "spots", "modules"]
         for elem in self.select_elem(metatype):
-            if elem.get_metadata_by_source(source) is not None:
+            if elem.has_source(source):
                 yield elem

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -83,24 +83,24 @@ class TestMetaFeatures:
         """
         metafeatures = MetaFeatures()
         for meta in metadata:
-            metafeatures.add_metadata(meta.source, meta)
+            metafeatures.add_metadata(meta)
         yield metafeatures
 
     def test_add_metadata(self, metafeatures, metadata):
         """Tests that metadata can be added to the metadata getter
         """
-        assert all(metafeatures._metadata_getter[meta.source] == [meta] for meta in metadata)
+        assert all(list(metafeatures._metadata_getter[meta.source].values()) == [meta] for meta in metadata)
 
     def test_get_metadata_feature_corresponding_to_source(self, metafeatures, metadata):
         """Tests that all the metadata features corresponding to a source can be retrieved
         """
-        assert all(metafeatures.get_metadata_by_source(meta.source) == [meta] for meta in metadata)
+        assert all(list(metafeatures.get_metadata_by_source(meta.source).values()) == [meta] for meta in metadata)
 
     def test_remove_source_from_feature(self, metafeatures):
         """Tests that a source can be removed from the feature
         """
         metadata = Metadata("source_del", attribute1="value")
-        metafeatures.add_metadata("source_del", metadata)
+        metafeatures.add_metadata(metadata)
         metafeatures.del_metadata_by_source("source_del")
         assert metafeatures.get_metadata_by_source("source_del") is None
 
@@ -114,7 +114,7 @@ class TestMetaFeatures:
         """
         meta = Metadata("source_test", attribute1="value_to_retrieve")
         # meta_list = Metadata("source_list", attribute1=["val_1", "val_2"])
-        metafeatures.add_metadata(meta.source, meta)
+        metafeatures.add_metadata(meta)
         # metafeatures[meta_list.source] = meta_list
         assert list(metafeatures.get_metadata_by_attribute(attribute1="value_to_retrieve")) == [meta]
         # assert list(metafeatures.get_metadata(attribute1="val_1")) == [meta_list]
@@ -124,26 +124,12 @@ class TestMetaFeatures:
         """
         metadata1 = Metadata("source_max", attribute1="value1")
         metadata2 = Metadata("source_max", attribute2="value2")
-        metafeatures.add_metadata("source_max", metadata1)
-        metafeatures.add_metadata("source_max", metadata2)
+        metafeatures.add_metadata(metadata1)
+        metafeatures.add_metadata(metadata2)
         assert metafeatures.max_metadata_by_source() == ("source_max", 2)
 
     def test_metadata_is_not_with_type_metadata(self, metafeatures):
         """Tests that an AssertionError is raised when metadata is not with type Metadata
         """
         with pytest.raises(AssertionError):
-            metafeatures.add_metadata("source1", "not_metadata")
-
-    def test_source_is_not_a_string(self, metafeatures):
-        """Tests that an AssertionError is raised when the source is not a string
-        """
-
-        metadata = Metadata("source1", attribute1="value1")
-        with pytest.raises(AssertionError):
-            metafeatures.add_metadata(1, metadata)
-
-    def test_source_or_metadata_is_not_with_correct_type(self, metafeatures, metadata):
-        """Tests that an AssertionError is raised when the source or metadata is not with the correct type
-        """
-        with pytest.raises(AssertionError):
-            metafeatures.add_metadata(1, "not_metadata")
+            metafeatures.add_metadata("not_metadata")

--- a/tests/test_pangenome.py
+++ b/tests/test_pangenome.py
@@ -804,25 +804,25 @@ class TestPangenomeMetadata(TestPangenome):
         """
         metadata = Metadata(source="source", attribute="attr")
         family = GeneFamily(family_id=pangenome.max_fam_id, name="Fam")
-        family.add_metadata(source=metadata.source, metadata=metadata)
+        family.add_metadata(metadata=metadata)
         pangenome.add_gene_family(family)
         org = Organism("Org")
-        org.add_metadata(source=metadata.source, metadata=metadata)
+        org.add_metadata(metadata=metadata)
         ctg = Contig(0, "Ctg")
         org.add(ctg)
         gene = Gene("Gene")
-        gene.position, gene.start = (0, 0)
-        gene.add_metadata(source=metadata.source, metadata=metadata)
-        ctg[gene.start] = gene
+        gene.fill_annotations(start=0, stop=100, position=0, strand='+')
+        gene.add_metadata(metadata=metadata)
+        ctg.add(gene)
         pangenome.add_organism(org)
         rgp = Region("RGP")
-        rgp.add_metadata(source=metadata.source, metadata=metadata)
+        rgp.add_metadata(metadata=metadata)
         pangenome.add_region(rgp)
         spot = Spot(0)
-        spot.add_metadata(source=metadata.source, metadata=metadata)
+        spot.add_metadata(metadata=metadata)
         pangenome.add_spot(spot)
         module = Module(0)
-        module.add_metadata(source=metadata.source, metadata=metadata)
+        module.add_metadata(metadata=metadata)
         pangenome.add_module(module)
 
     def test_select_elem(self, add_element_to_pangenome, pangenome):
@@ -876,7 +876,7 @@ class TestPangenomeMetadata(TestPangenome):
                     assert isinstance(metadata, Metadata)
                     assert metadata.source == 'source'
 
-    def test_get_elem_by_sources(self, add_element_to_pangenome, pangenome):
+    def test_get_elem_by_source(self, add_element_to_pangenome, pangenome):
         """Tests the metadata generator filtered by source of the Pangenome class.
 
         :param add_element_to_pangenome: Add elements to the pangenome
@@ -884,7 +884,7 @@ class TestPangenomeMetadata(TestPangenome):
         """
         for metatype, expected_type in {"families": GeneFamily, "genomes": Organism, "genes": Gene, "RGPs": Region,
                                         "spots": Spot, "modules": Module}.items():
-            for elem in pangenome.get_elem_by_sources(source='source', metatype=metatype):
+            for elem in pangenome.get_elem_by_source(source='source', metatype=metatype):
                 assert isinstance(elem, expected_type)
                 for metadata in elem.metadata:
                     assert isinstance(metadata, Metadata)


### PR DESCRIPTION
In pangenome, an element (gene, family, ...) could be associated with multiple metadata for one source. 
A metadata identifier has been added to each metadata. The identifier is object-dependent and aims to identify the right metadata for each object in cross-reference. 