### PR TITLE
Improve metadata management

### DIFF
--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -176,7 +176,7 @@ def add_info_to_rgp_nodes(graph, regions: List[Region], region_to_spot: dict):
                        "is_contig_border": region.is_contig_border,
                        "is_whole_contig": region.is_whole_contig,
                        "spot_id": get_spot_id(region, region_to_spot),
-                       "modules": ';'.join({f"module_{module.ID}" for module in region.modules}),
+                       "modules": ';'.join({str(module) for module in region.modules}),
                        'families_count': region.number_of_families}
 
         region_attributes[region.ID] = region_info
@@ -292,7 +292,7 @@ def add_info_to_identical_rgps(rgp_graph: nx.Graph, identical_rgps_objects: List
                            identical_rgp_spots=";".join(spots_of_identical_rgp_obj),
                            spot_id=spots_of_identical_rgp_obj.pop() if len(
                                spots_of_identical_rgp_obj) == 1 else "Mulitple spots",
-                            modules = ';'.join({f"module_{module.ID}" for module in identical_rgp_obj.modules}),
+                            modules = ';'.join({str(module) for module in identical_rgp_obj.modules}),
                            )
 
 

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -508,7 +508,7 @@ def read_org_gbff(organism_name: str, gbff_file_path: Path, circular_contigs: Li
                 gene_type=feature["feature_type"],
                 position=contig.number_of_genes,
                 gene_name=feature["gene"],
-                product=feature['produce'],
+                product=feature['product'],
                 genetic_code=genetic_code,
                 protein_id=feature["protein_id"]
             )

--- a/ppanggolin/geneFamily.py
+++ b/ppanggolin/geneFamily.py
@@ -301,7 +301,7 @@ class GeneFamily(MetaFeatures):
         :param module: module to set
         """
         if not isinstance(module, Module):
-            raise TypeError("Module object is expected to be set")
+            raise TypeError("Module object is expected to object of Module class")
         self._module = module
 
     @property

--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -1202,7 +1202,7 @@ def launch(args: argparse.Namespace):
 
     check_pangenome_info(pangenome, need_annotations=True, need_families=True, disable_bar=args.disable_prog_bar,
                          need_rgp=predict_rgp, need_modules=project_modules, need_gene_sequences=False,
-                         need_spots=project_spots, need_graph=need_graph)
+                         need_spots=project_spots, need_graph=need_graph, need_metadata=True)
 
     logging.getLogger('PPanGGOLiN').info('Retrieving parameters from the provided pangenome file.')
     pangenome_params = argparse.Namespace(

--- a/ppanggolin/region.py
+++ b/ppanggolin/region.py
@@ -332,6 +332,15 @@ class Region(MetaFeatures):
             yield gene.family
 
     @property
+    def modules(self) -> Set[Module]:
+        """Get the modules of gene families in the RGP
+
+        :return: Modules found in families of the RGP
+        """
+        modules = {family.module for family in self.families if family.module is not None}
+        return modules
+
+    @property
     def number_of_families(self) -> int:
         """Get the number of different gene families in the region
 


### PR DESCRIPTION
This PR improves metadata management in two commands:

1. **Projection**: Previously, metadata was not included in the output file due to missing specifications when loading the pangenome. This PR resolves that issue, ensuring metadata is properly added to the output file.

2. **RGP Clustering**:
   - Previously, modules information were not passed through in the graph. Now, modules found in an RGP are included in the `modules` attribute of nodes. If there are multiple modules, they are joined with a semicolon (e.g., `module_1;module18`).
   - Previously, only metadata associated with RGPs was included in the RGP cluster graph. This PR now also includes metadata associated with families, spots, modules, and genes in RGP nodes. This addition is done in a concise way: the RGP node will only have attributes indicating the presence of metadata sources. For example, if families have metadata with `source="card"`, the RGP node in the graph will have the attribute `has_family_with_card`. This ensures that metadata presence is included without overloading the graph with excessive data.




