### PR TITLE
Fix proksee module

### DIFF
--- a/ppanggolin/formats/write_proksee.py
+++ b/ppanggolin/formats/write_proksee.py
@@ -324,22 +324,26 @@ def write_modules(organism: Organism, gf2genes: Dict[str, List[Gene]], metadata_
 
         if gf_intersection:
             # Calculate the completion percentage
-            completion = round(100 * len(gf_intersection) / len(set(module.families)), 1)
-
+            metadata_for_proksee = {'completion': round(100 * len(gf_intersection) / len(set(module.families)), 1)}
+            
+            metadata_for_proksee.update(module.formatted_metadata_dict(metadata_sep))
             # Create module data entries for genes within intersecting gene families
             for gf in gf_intersection:
                 for gene in gf2genes[gf.name]:
-                    modules_data_list.append({
-                        "name": f"Module_{module.ID}",
-                        "presence": "Module",
-                        "start": gene.start,
-                        "stop": gene.stop,
-                        "contig": gene.contig.name,
-                        "legend": f"module_{module.ID}",
-                        "source": "Module",
-                        "tags": [f'{completion}% complete'],
-                        "meta": module.formatted_metadata_dict(metadata_sep)
+                    for start, stop in gene.coordinates:
+                        modules_data_list.append({
+                            "name": f"Module_{module.ID}",
+                            "presence": "Module",
+                            "start": start,
+                            "stop": stop,
+                            "contig": gene.contig.name,
+                            "legend": f"module_{module.ID}",
+                            "source": "Module",
+                            "tags": [],
+                            "meta": metadata_for_proksee
                     })
+
+                    
 
     return modules_data_list
 

--- a/ppanggolin/formats/write_proksee.py
+++ b/ppanggolin/formats/write_proksee.py
@@ -51,7 +51,7 @@ def write_legend_items(features: List[str], module_to_color: Dict[Module, str] =
 
     if module_to_color is not None and ("modules" in features or "all" in features):
         for mod, color in sorted(module_to_color.items(), key=lambda x: x[0].ID):
-            legend_data["items"].append({"name": f"module_{mod.ID}",
+            legend_data["items"].append({"name": str(mod),
                                          "decoration": "arc",
                                          "swatchColor": color,
                                          "visible": False})
@@ -332,12 +332,12 @@ def write_modules(organism: Organism, gf2genes: Dict[str, List[Gene]], metadata_
                 for gene in gf2genes[gf.name]:
                     for start, stop in gene.coordinates:
                         modules_data_list.append({
-                            "name": f"Module_{module.ID}",
+                            "name": str(module),
                             "presence": "Module",
                             "start": start,
                             "stop": stop,
                             "contig": gene.contig.name,
-                            "legend": f"module_{module.ID}",
+                            "legend": str(module),
                             "source": "Module",
                             "tags": [],
                             "meta": metadata_for_proksee


### PR DESCRIPTION
In some cases, modules in the Proksee map were not displayed correctly. For example:

![image](https://github.com/labgem/PPanGGOLiN/assets/28706177/a2b813d3-b154-4712-8042-90b47d881717)

This issue arises when a gene overlaps the edge of a contig. For genes and RGPs, this scenario is handled by drawing each piece individually   (one starting at the end of the contig and the other beginning at the start of the next). However, this was not implemented for modules, leading to incorrect representations when a gene in a module was split across multiple pieces.

This PR resolves the issue by applying the same logic used for genes and RGPs to modules. Now, modules are accurately drawn even when a gene spans the edge of a contig.

In this example, a gene is overlapping the end of a circular contig. this gene belong to module 217 and this module is drawn correctly folowing the gene:

![image](https://github.com/labgem/PPanGGOLiN/assets/28706177/a5d8b7fc-f8c0-40f6-b12a-502c9cf8023d)


