### PR TITLE
Fix metadata related issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,18 @@ on:
   pull_request:
     branches: 
       - '*'
+    paths:
+      # if any of this files or directory changed, trigger the CI
+      # The only case where it is not triggerd is when docs/ is modified
+      - 'tests/**'
+      - 'testingDataset/**'
+      - '.github/**'
+      - 'ppanggolin/**'
+      - 'MANIFEST.in'
+      - 'VERSION'
+      - 'ppanggolin_env.yaml'
+      - 'pyproject.toml'
+      - 'setup.py'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -322,8 +322,9 @@ def parse_feature_lines(feature_lines: List[str]) -> Generator[Dict[str, str], N
 
         else: 
             # the line does not start a qualifier so its the continuation of the last qualifier value.
+            value = line.strip()
             value = value[:-1] if value.endswith('"') else value
-            current_feature[current_qualifier][-1] += f" {line.strip()}"
+            current_feature[current_qualifier][-1] += f" {value}"
 
     # Append the last feature
     if current_feature:

--- a/ppanggolin/formats/writeBinaries.py
+++ b/ppanggolin/formats/writeBinaries.py
@@ -607,84 +607,82 @@ def erase_pangenome(pangenome: Pangenome, graph: bool = False, gene_families: bo
     :param metatype:
     :param source:
     """
-    try:
-        if metadata and (metatype is None or source is None):
-            raise AssertionError
-    except AssertionError:
-        raise AssertionError("To erase metadata. You should provide metatype and source")
-    h5f = tables.open_file(pangenome.file, "a")
-    status_group = h5f.root.status
-    info_group = h5f.root.info
+    
+    if metadata and (metatype is None or source is None):
+        raise ValueError("To erase metadata. You should provide metatype and source")
+    
+    with tables.open_file(pangenome.file, "a") as h5f:
+        status_group = h5f.root.status
+        info_group = h5f.root.info
 
-    if '/edges' in h5f and (graph or gene_families):
-        logging.getLogger("PPanGGOLiN").info("Erasing the formerly computed edges")
-        h5f.remove_node("/", "edges")
-        status_group._v_attrs.NeighborsGraph = False
-        pangenome.status["neighborsGraph"] = "No"
-        h5f.del_node_attr(info_group, "numberOfEdges")
-    if '/geneFamilies' in h5f and gene_families:
-        logging.getLogger("PPanGGOLiN").info("Erasing the formerly computed gene family to gene associations...")
-        h5f.remove_node('/', 'geneFamilies')  # erasing the table, and rewriting a new one.
-        pangenome.status["defragmented"] = "No"
-        pangenome.status["genesClustered"] = "No"
-        status_group._v_attrs.defragmented = False
-        status_group._v_attrs.genesClustered = False
+        if '/edges' in h5f and (graph or gene_families):
+            logging.getLogger("PPanGGOLiN").info("Erasing the formerly computed edges")
+            h5f.remove_node("/", "edges")
+            status_group._v_attrs.NeighborsGraph = False
+            pangenome.status["neighborsGraph"] = "No"
+            h5f.del_node_attr(info_group, "numberOfEdges")
+        if '/geneFamilies' in h5f and gene_families:
+            logging.getLogger("PPanGGOLiN").info("Erasing the formerly computed gene family to gene associations...")
+            h5f.remove_node('/', 'geneFamilies')  # erasing the table, and rewriting a new one.
+            pangenome.status["defragmented"] = "No"
+            pangenome.status["genesClustered"] = "No"
+            status_group._v_attrs.defragmented = False
+            status_group._v_attrs.genesClustered = False
 
-        h5f.del_node_attr(info_group, "numberOfClusters")
+            h5f.del_node_attr(info_group, "numberOfClusters")
 
-    if '/geneFamiliesInfo' in h5f and gene_families:
-        logging.getLogger("PPanGGOLiN").info("Erasing the formerly computed gene family representative sequences...")
-        h5f.remove_node('/', 'geneFamiliesInfo')  # erasing the table, and rewriting a new one.
-        pangenome.status["geneFamilySequences"] = "No"
-        status_group._v_attrs.geneFamilySequences = False
-        if partition:
-            logging.getLogger("PPanGGOLiN").info("Erasing former partitions...")
-            pangenome.status["partitioned"] = "No"
-            status_group._v_attrs.Partitioned = False
-            if 'Partitioned' in status_group._v_attrs._f_list():
+        if '/geneFamiliesInfo' in h5f and gene_families:
+            logging.getLogger("PPanGGOLiN").info("Erasing the formerly computed gene family representative sequences...")
+            h5f.remove_node('/', 'geneFamiliesInfo')  # erasing the table, and rewriting a new one.
+            pangenome.status["geneFamilySequences"] = "No"
+            status_group._v_attrs.geneFamilySequences = False
+            if partition:
+                logging.getLogger("PPanGGOLiN").info("Erasing former partitions...")
+                pangenome.status["partitioned"] = "No"
                 status_group._v_attrs.Partitioned = False
+                if 'Partitioned' in status_group._v_attrs._f_list():
+                    status_group._v_attrs.Partitioned = False
 
-            h5f.del_node_attr(info_group, "numberOfPersistent")
-            h5f.del_node_attr(info_group, "persistentStats")
-            h5f.del_node_attr(info_group, "numberOfShell")
-            h5f.del_node_attr(info_group, "shellStats")
-            h5f.del_node_attr(info_group, "numberOfCloud")
-            h5f.del_node_attr(info_group, "cloudStats")
-            h5f.del_node_attr(info_group, "numberOfPartitions")
-            h5f.del_node_attr(info_group, "numberOfSubpartitions")
+                h5f.del_node_attr(info_group, "numberOfPersistent")
+                h5f.del_node_attr(info_group, "persistentStats")
+                h5f.del_node_attr(info_group, "numberOfShell")
+                h5f.del_node_attr(info_group, "shellStats")
+                h5f.del_node_attr(info_group, "numberOfCloud")
+                h5f.del_node_attr(info_group, "cloudStats")
+                h5f.del_node_attr(info_group, "numberOfPartitions")
+                h5f.del_node_attr(info_group, "numberOfSubpartitions")
 
-    if '/RGP' in h5f and (gene_families or partition or rgp):
-        logging.getLogger("PPanGGOLiN").info("Erasing the formerly computer RGP...")
-        pangenome.status["predictedRGP"] = "No"
-        status_group._v_attrs.predictedRGP = False
-        h5f.remove_node("/", "RGP")
+        if '/RGP' in h5f and (gene_families or partition or rgp):
+            logging.getLogger("PPanGGOLiN").info("Erasing the formerly computer RGP...")
+            pangenome.status["predictedRGP"] = "No"
+            status_group._v_attrs.predictedRGP = False
+            h5f.remove_node("/", "RGP")
 
-        h5f.del_node_attr(info_group, "numberOfRGP")
+            h5f.del_node_attr(info_group, "numberOfRGP")
 
-    if '/spots' in h5f and (gene_families or partition or rgp or spots):
-        logging.getLogger("PPanGGOLiN").info("Erasing the formerly computed spots...")
-        pangenome.status["spots"] = "No"
-        status_group._v_attrs.spots = False
-        h5f.remove_node("/", "spots")
+        if '/spots' in h5f and (gene_families or partition or rgp or spots):
+            logging.getLogger("PPanGGOLiN").info("Erasing the formerly computed spots...")
+            pangenome.status["spots"] = "No"
+            status_group._v_attrs.spots = False
+            h5f.remove_node("/", "spots")
 
-        h5f.del_node_attr(info_group, "numberOfSpots")
+            h5f.del_node_attr(info_group, "numberOfSpots")
 
-    if '/modules' in h5f and (gene_families or partition or modules):
-        logging.getLogger("PPanGGOLiN").info("Erasing the formerly computed modules...")
-        pangenome.status["modules"] = "No"
-        status_group._v_attrs.modules = False
-        h5f.remove_node("/", "modules")
+        if '/modules' in h5f and (gene_families or partition or modules):
+            logging.getLogger("PPanGGOLiN").info("Erasing the formerly computed modules...")
+            pangenome.status["modules"] = "No"
+            status_group._v_attrs.modules = False
+            h5f.remove_node("/", "modules")
 
-        h5f.del_node_attr(info_group, "numberOfModules")
-        h5f.del_node_attr(info_group, "numberOfFamiliesInModules")
-        for info in ['CloudSpecInModules', 'PersistentSpecInModules', 'ShellSpecInModules', 'numberOfFamiliesInModules',
-                     'StatOfFamiliesInModules']:
-            if info in info_group._v_attrs._f_list():
-                h5f.del_node_attr(info_group, info)
-    if '/metadata/' in h5f and metadata:
-        erase_metadata(pangenome, h5f, status_group, metatype, source)
+            h5f.del_node_attr(info_group, "numberOfModules")
+            h5f.del_node_attr(info_group, "numberOfFamiliesInModules")
+            for info in ['CloudSpecInModules', 'PersistentSpecInModules', 'ShellSpecInModules', 'numberOfFamiliesInModules',
+                        'StatOfFamiliesInModules']:
+                if info in info_group._v_attrs._f_list():
+                    h5f.del_node_attr(info_group, info)
 
-    h5f.close()
+        if '/metadata/' in h5f and metadata:
+            erase_metadata(pangenome, h5f, status_group, metatype, source)
 
 
 def write_pangenome(pangenome: Pangenome, filename, force: bool = False, disable_bar: bool = False):

--- a/ppanggolin/formats/writeMetadata.py
+++ b/ppanggolin/formats/writeMetadata.py
@@ -254,9 +254,6 @@ def write_metadata_metatype(h5f: tables.File, source: str, metatype: str,
                         if isinstance(value, bytes):
                             value = value.decode('UTF-8')
                         meta_row[desc] = value
-                    # else:
-                    #     print(desc)
-                    #     meta_row[desc] = None
             meta_row.append()
     source_table.flush()
 

--- a/ppanggolin/formats/writeMetadata.py
+++ b/ppanggolin/formats/writeMetadata.py
@@ -254,8 +254,9 @@ def write_metadata_metatype(h5f: tables.File, source: str, metatype: str,
                         if isinstance(value, bytes):
                             value = value.decode('UTF-8')
                         meta_row[desc] = value
-                    else:
-                        meta_row[desc] = None
+                    # else:
+                    #     print(desc)
+                    #     meta_row[desc] = None
             meta_row.append()
     source_table.flush()
 


### PR DESCRIPTION
This PR adjusts two aspects related to metadata handling:

1. Properly trims trailing quotes when ppanggolin parses multi-line features in GBFF files. Previously, these remaining quotes were incorrectly included in contig and genome metadata, and product fields of genes.
2. Addresses an issue where `None` values were being added to the metadata table when a line had no value for a specific column. Since  column needs to be  homogeneous in table of h5 file, the  `None` values caused an obscure error. 
