### PR TITLE
Add support for python 3.11 and 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-13']
-        python-version: ['3.8', '3.10']
+        python-version: ['3.8', '3.10', '3.11', '3.12']
 
     steps:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,8 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-13']
-        python-version: ['3.8', '3.10', '3.11', '3.12']
-
+        python-version: [ '3.12'] # '3.8', '3.10', '3.11',
+ 
     steps:
 
     # Get number of cpu available on the current runner

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-13']
-        python-version: ['3.8','3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.12']
  
     steps:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-13']
-        python-version: [ '3.12'] # '3.8', '3.10', '3.11',
+        python-version: ['3.8','3.8', '3.10', '3.11', '3.12']
  
     steps:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-13']
-        python-version: ['3.8','3.8', '3.10', '3.11', '3.12']
+        python-version: ['3.8','3.9', '3.10', '3.11', '3.12']
  
     steps:
 

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -1,7 +1,7 @@
 # Installation
 
-```{warning}
-Supported python version are 3.8, 3.9 and 3.10
+```{info}
+Supported python version are 3.8, 3.9, 3.10, 3.11 and 3.12
 ```
 
 ## Installing PPanGGOLiN with Conda (recommended)

--- a/ppanggolin/nem/rarefaction.py
+++ b/ppanggolin/nem/rarefaction.py
@@ -391,7 +391,7 @@ def make_rarefaction_curve(pangenome: Pangenome, output: Path, tmpdir: Path = No
     all_samples = []
     for i in range(min_sampling, max_sampling):  # each point
         for _ in range(depth):  # number of samples per points
-            all_samples.append(set(random.sample(set(pangenome.organisms), i + 1)))
+            all_samples.append(set(random.sample(list(pangenome.organisms), i + 1)))
     logging.getLogger("PPanGGOLiN").info(f"Done sampling genomes in the pan, there are {len(all_samples)} samples")
     samp_nb_per_part = []
 

--- a/ppanggolin_env.yaml
+++ b/ppanggolin_env.yaml
@@ -12,9 +12,9 @@ dependencies:
   - scipy=1
   - plotly=5
   - gmpy2=2
-  - pandas=2.0
+  - pandas=2
   - colorlover=0.3
-  - numpy=1.24
+  - numpy=1
   - bokeh=3
   # Tool that are not in python 
   - infernal=1


### PR DESCRIPTION
This PR is all about making PPanGGOLiN compatible with Python 3.11 and 3.12. 
Now you can use PPanGGOLiN with Python versions 3.8 through 3.12.  🎉 

1. **Compatibility Update**: Tweaked the `random.sample` call in the `rarefaction` module to fix issues with the newer Python versions. This problem was pointed out in issue #253.
2. **Docs Update**: Updated the installation doc to indicate that we support Python 3.8, 3.9, 3.10, 3.11, and 3.12.