### PR TITLE
some typos in source

### DIFF
--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -141,7 +141,7 @@ def compute_grr(rgp_a_families: Set[GeneFamily], rgp_b_families: Set[GeneFamily]
 
 def compute_jaccard_index(rgp_a_families: set, rgp_b_families: set) -> float:
     """
-    Compute jaccard index between two rgp based on their famillies.
+    Compute jaccard index between two rgp based on their families.
 
     :param rgp_a_families: Rgp A
     :param rgp_b_families: rgp B
@@ -291,7 +291,7 @@ def add_info_to_identical_rgps(rgp_graph: nx.Graph, identical_rgps_objects: List
                                [True for i_rgp in identical_rgp_obj.rgps if i_rgp.is_whole_contig]),
                            identical_rgp_spots=";".join(spots_of_identical_rgp_obj),
                            spot_id=spots_of_identical_rgp_obj.pop() if len(
-                               spots_of_identical_rgp_obj) == 1 else "Mulitple spots",
+                               spots_of_identical_rgp_obj) == 1 else "Multiple spots",
                             modules = ';'.join({str(module) for module in identical_rgp_obj.modules}),
                            )
 
@@ -608,18 +608,18 @@ def cluster_rgp(pangenome, grr_cutoff: float, output: str, basename: str,
         add_rgp_metadata_to_graph(grr_graph, rgps_in_graph)
 
     if "gexf" in graph_formats:
-        # writting graph in gexf format
+        # writing graph in gexf format
         graph_file_name = os.path.join(output, f"{basename}.gexf")
-        logging.info(f"Writting graph in gexf format in {graph_file_name}.")
+        logging.info(f"Writing graph in gexf format in {graph_file_name}.")
         nx.readwrite.gexf.write_gexf(grr_graph, graph_file_name)
 
     if "graphml" in graph_formats:
         graph_file_name = os.path.join(output, f"{basename}.graphml")
-        logging.info(f"Writting graph in graphml format in {graph_file_name}.")
+        logging.info(f"Writing graph in graphml format in {graph_file_name}.")
         nx.readwrite.graphml.write_graphml(grr_graph, graph_file_name)
 
     outfile = os.path.join(output, f"{basename}.tsv")
-    logging.info(f"Writting rgp clusters in tsv format in {outfile}")
+    logging.info(f"Writing rgp clusters in tsv format in {outfile}")
 
     write_rgp_cluster_table(
         outfile, grr_graph, rgps_in_graph, grr_metric, rgp_to_spot)

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -113,7 +113,7 @@ def extract_positions(string: str) -> Tuple[List[Tuple[int, int]], bool, bool]:
     """
     Extracts start and stop positions from a string and determines whether it is complement and pseudogene.
     
-    Exemple of strings that the function is able to process: 
+    Example of strings that the function is able to process: 
 
     "join(190..7695,7695..12071)",
     "complement(join(4359800..4360707,4360707..4360962))",
@@ -359,7 +359,7 @@ def combine_contigs_metadata(contig_to_metadata: Dict[str, Dict[str, str]]) -> T
     all_tag_to_value = [(tag, value) for source_info in contig_to_metadata.values() for (tag, value) in
                         source_info.items() if isinstance(value, str)]
 
-    # Filter tags that would have a / as it is forbiden when writing the table in HDF5. Such tag can appear with db_xref formating
+    # Filter tags that would have a / as it is forbidden when writing the table in HDF5. Such tag can appear with db_xref formatting
     invalid_tag_names = []
     for tag, _ in set(all_tag_to_value):
         try:
@@ -691,7 +691,7 @@ def read_org_gff(organism: str, gff_file_path: Path, circular_contigs: List[str]
 
                 if fields_gff[gff_type] == 'region':
                     # keep region attributes to add them as metadata of genome and contigs
-                    # excluding some info as they are alredy contained in contig object.
+                    # excluding some info as they are already contained in contig object.
 
                     contig_name_to_region_info[fields_gff[gff_seqname]] = {tag.lower(): value for tag, value in
                                                                            attributes.items() if
@@ -790,7 +790,7 @@ def read_org_gff(organism: str, gff_file_path: Path, circular_contigs: List[str]
                         rna_counter += 1
                         contig.add_rna(rna)
 
-    # Correct coordinates of genes that overlapp the edge of circulars contig
+    # Correct coordinates of genes that overlap the edge of circulars contig
     correct_putative_overlaps(org.contigs)
 
     # GET THE FASTA SEQUENCES OF THE GENES
@@ -798,7 +798,7 @@ def read_org_gff(organism: str, gff_file_path: Path, circular_contigs: List[str]
         contig_sequences = read_fasta(org, fasta_string.split('\n'))  # _ is total contig length
         for contig in org.contigs:
             if contig.length != len(contig_sequences[contig.name]):
-                raise ValueError("The contig lenght defined is different than the sequence length")
+                raise ValueError("The contig length defined is different than the sequence length")
 
             for gene in contig.genes:
                 gene.add_sequence(get_dna_sequence(contig_sequences[contig.name], gene))

--- a/ppanggolin/annotate/synta.py
+++ b/ppanggolin/annotate/synta.py
@@ -74,7 +74,7 @@ def launch_aragorn(fna_file: str, org: Organism) -> defaultdict:
             start, stop = map(int, ast.literal_eval(line_data[2].replace("c", "")))
             if start < 1 or stop < 1:
                 # In some case aragorn gives negative coordinates. This case is just ignored.
-                logging.warning(f'Aragorn gives non valide coordiates for a RNA gene: {line_data}  This RNA is ignored.')
+                logging.warning(f'Aragorn gives non valid coordinates for a RNA gene: {line_data}  This RNA is ignored.')
                 continue
             c += 1
             gene = RNA(rna_id=locustag + '_tRNA_' + str(c).zfill(4))
@@ -210,7 +210,7 @@ def read_fasta(org: Organism, fna_file: Union[TextIOWrapper, list]) -> Dict[str,
 
 def write_tmp_fasta(contigs: dict, tmpdir: str) -> tempfile._TemporaryFileWrapper:
     """
-     Writes a temporary fna formated file and returns the file-like object. Useful in case of  compressed input file.
+     Writes a temporary fna formatted file and returns the file-like object. Useful in case of  compressed input file.
      The file will be deleted when close() is called.
 
     :param contigs: Contigs sequences of each contig

--- a/ppanggolin/cluster/cluster.py
+++ b/ppanggolin/cluster/cluster.py
@@ -100,7 +100,7 @@ def first_clustering(sequences: Path, tmpdir: Path, cpu: int = 1, code: int = 11
     reprfa = tmpdir / 'representative_sequences.fasta'
     cmd = list(map(str, ["mmseqs", "result2flat", seqdb, seqdb, repdb, reprfa, "--use-fasta-header"]))
     run_subprocess(cmd, msg="MMSeqs2 result2flat failed with the following error:\n")
-    logging.getLogger("PPanGGOLiN").info("Writing gene to family informations")
+    logging.getLogger("PPanGGOLiN").info("Writing gene to family information")
     outtsv = tmpdir / 'families_tsv'
     cmd = list(map(str, ["mmseqs", "createtsv", seqdb, seqdb, cludb, outtsv, "--threads", cpu, "--full-header"]))
     run_subprocess(cmd, msg="MMSeqs2 createtsv failed with the following error:\n")
@@ -157,7 +157,7 @@ def read_tsv(tsv_file_name: Path) -> Tuple[Dict[str, Tuple[str, bool]], Dict[str
 
     :param tsv_file_name: path to the tsv
 
-    :return: two dictionnary which link genes and families
+    :return: two dictionaries which link genes and families
     """
     genes2fam = {}
     fam2genes = defaultdict(set)

--- a/ppanggolin/context/searchGeneContext.py
+++ b/ppanggolin/context/searchGeneContext.py
@@ -202,10 +202,10 @@ def get_gene_contexts(context_graph: nx.Graph, families_of_interest: Set[GeneFam
 
     # Connected component graph Filtering
 
-    # remove singleton famillies
+    # remove singleton families
     connected_components = (component for component in connected_components if len(component) > 1)
 
-    # remove component made only of famillies not initially requested
+    # remove component made only of families not initially requested
     connected_components = (component for component in connected_components if component & families_of_interest)
 
     gene_contexts = set()

--- a/ppanggolin/figures/draw_spot.py
+++ b/ppanggolin/figures/draw_spot.py
@@ -252,7 +252,7 @@ def mk_source_data(genelists: list, fam_col: dict, fam_to_mod: dict) -> (ColumnD
         last_gene = genelist[-1]
         
         if is_gene_list_ordered(genelist):
-            # if the order has been inverted, positionning elements on the figure is different
+            # if the order has been inverted, positioning elements on the figure is different
             ordered = True
             start = first_gene.start
         else:
@@ -460,7 +460,7 @@ def mk_genomes(gene_lists: list, ordered_counts: list) -> (ColumnDataSource, lis
         first_gene = genelist[0]
         last_gene =  genelist[-1]
         if is_gene_list_ordered(genelist):
-            # if the order has been inverted, positionning elements on the figure is different
+            # if the order has been inverted, positioning elements on the figure is different
             width = abs(last_gene.stop_relative_to(first_gene ) - genelist[0].start) 
             df["width"].append(width)
         else:
@@ -627,7 +627,7 @@ def draw_selected_spots(selected_spots: Union[List[Spot], Set[Spot]], pangenome:
             left_border = [gene for gene in left_border_and_in_between_genes if gene.family.named_partition == "persistent" and gene.family not in multigenics]
             right_border = [gene for gene in right_border_and_in_between_genes if gene.family.named_partition == "persistent" and gene.family not in multigenics]
 
-            # in some rare case with plasmid left and rigth border can be made of the same genes
+            # in some rare case with plasmid left and right border can be made of the same genes
             # we use a set to only have one gene represented.  
             consecutive_genes_lists = contig.get_ordered_consecutive_genes(set(left_border_and_in_between_genes + right_border_and_in_between_genes + list(rgp.genes)))
             

--- a/ppanggolin/formats/writeAnnotations.py
+++ b/ppanggolin/formats/writeAnnotations.py
@@ -140,7 +140,7 @@ def write_genes(pangenome: Pangenome,  h5f: tables.File, annotation: tables.Grou
     :param gene_desc: Genes table description
     :param disable_bar: Allow to disable progress bar
 
-    :returns: Dictionnary linking genedata to gene identifier
+    :returns: Dictionary linking genedata to gene identifier
     """
     global genedata_counter
     genedata2gene = {}
@@ -188,7 +188,7 @@ def write_rnas(pangenome: Pangenome,  h5f: tables.File, annotation: tables.Group
     :param rna_desc: RNAs table description
     :param disable_bar: Allow to disable progress bar
 
-    :returns: Dictionnary linking genedata to RNA identifier
+    :returns: Dictionary linking genedata to RNA identifier
     """
     global genedata_counter
     genedata2rna = {}
@@ -295,11 +295,11 @@ def get_genedata(feature: Union[Gene, RNA]) -> Genedata:
                     feature.product, genetic_code, coordinates = feature.coordinates)
 
 def write_gene_joined_coordinates(h5f, annotation, genes_with_joined_coordinates_2_id, disable_bar):
-    """Writting genedata information in pangenome file
+    """Writing genedata information in pangenome file
 
     :param h5f: Pangenome file
     :param annotation: Annotation group in Table
-    :param genedata2gene: Dictionnary linking genedata to gene identifier.
+    :param genedata2gene: Dictionary linking genedata to gene identifier.
     :param disable_bar: Allow disabling progress bar
     """
     number_of_gene_pieces = sum([len(gene.coordinates) for gene in genes_with_joined_coordinates_2_id])
@@ -330,12 +330,12 @@ def write_gene_joined_coordinates(h5f, annotation, genes_with_joined_coordinates
 
 def write_genedata(pangenome: Pangenome,  h5f: tables.File, annotation: tables.Group,
                    genedata2gene: Dict[Genedata, int], disable_bar=False):
-    """Writting genedata information in pangenome file
+    """Writing genedata information in pangenome file
 
     :param pangenome: Pangenome object filled with annotation.
     :param h5f: Pangenome file
     :param annotation: Annotation group in Table
-    :param genedata2gene: Dictionnary linking genedata to gene identifier.
+    :param genedata2gene: Dictionary linking genedata to gene identifier.
     :param disable_bar: Allow disabling progress bar
     """
     try:
@@ -377,7 +377,7 @@ def write_annotations(pangenome: Pangenome, h5f: tables.File, rec_organisms: boo
     :param rec_contigs: Allow writing contigs in pangenomes
     :param rec_genes: Allow writing genes in pangenomes
     :param rec_rnas: Allow writing RNAs in pangenomes
-    :param disable_bar: Alow to disable progress bar
+    :param disable_bar: Allow to disable progress bar
     """
     annotation = h5f.create_group("/", "annotations", "Annotations of the pangenome organisms")
 
@@ -429,7 +429,7 @@ def gene_sequences_desc(gene_id_len: int, gene_type_len: int) -> Dict[str, Union
     :param gene_id_len: Maximum size of gene sequence identifier
     :param gene_type_len: Maximum size of gene type
 
-    :return: Formated table
+    :return: Formatted table
     """
     return {
         "gene": tables.StringCol(itemsize=gene_id_len),
@@ -455,7 +455,7 @@ def sequence_desc(max_seq_len: int) -> Dict[str, Union[tables.UIntCol, tables.St
     """
     Table description to save sequences
     :param max_seq_len: Maximum size of gene type
-    :return: Formated table
+    :return: Formatted table
     """
     return {
         "seqid": tables.UInt32Col(),

--- a/ppanggolin/formats/writeBinaries.py
+++ b/ppanggolin/formats/writeBinaries.py
@@ -60,13 +60,13 @@ def getmin(arg: iter) -> float:
 
 def gene_fam_desc(max_name_len: int, max_sequence_length: int, max_part_len: int) -> dict:
     """
-    Create a formated table for gene families description
+    Create a formatted table for gene families description
 
     :param max_name_len: Maximum size of gene family name
     :param max_sequence_length: Maximum size of gene family representing gene sequences
     :param max_part_len: Maximum size of gene family partition
 
-    :return: Formated table
+    :return: Formatted table
     """
     return {
         "name": tables.StringCol(itemsize=max_name_len),
@@ -123,12 +123,12 @@ def write_gene_fam_info(pangenome: Pangenome, h5f: tables.File, force: bool = Fa
 
 def gene_to_fam_desc(gene_fam_name_len: int, gene_id_len: int) -> dict:
     """
-    Create a formated table for gene in gene families information
+    Create a formatted table for gene in gene families information
 
     :param gene_fam_name_len: Maximum size of gene family names
     :param gene_id_len: Maximum size of gene identifier
 
-    :return: formated table
+    :return: formatted table
     """
     return {
         "geneFam": tables.StringCol(itemsize=gene_fam_name_len),
@@ -180,11 +180,11 @@ def write_gene_families(pangenome: Pangenome, h5f: tables.File, force: bool = Fa
 
 def graph_desc(max_gene_id_len):
     """
-    Create a formated table for pangenome graph
+    Create a formatted table for pangenome graph
 
     :param max_gene_id_len: Maximum size of gene id
 
-    :return: formated table
+    :return: formatted table
     """
     return {
         'geneTarget': tables.StringCol(itemsize=max_gene_id_len),
@@ -235,12 +235,12 @@ def write_graph(pangenome: Pangenome, h5f: tables.File, force: bool = False, dis
 
 def rgp_desc(max_rgp_len, max_gene_len):
     """
-    Create a formated table for region of genomic plasticity
+    Create a formatted table for region of genomic plasticity
 
     :param max_rgp_len: Maximum size of RGP
     :param max_gene_len: Maximum sizez of gene
 
-    :return: formated table
+    :return: formatted table
     """
     return {
         'RGP': tables.StringCol(itemsize=max_rgp_len),
@@ -293,11 +293,11 @@ def write_rgp(pangenome: Pangenome, h5f: tables.File, force: bool = False, disab
 
 def spot_desc(max_rgp_len):
     """
-    Create a formated table for hotspot
+    Create a formatted table for hotspot
 
     :param max_rgp_len: Maximum size of RGP
 
-    :return: formated table
+    :return: formatted table
     """
     return {
         'spot': tables.UInt32Col(),
@@ -347,11 +347,11 @@ def write_spots(pangenome: Pangenome, h5f: tables.File, force: bool = False, dis
 
 def mod_desc(gene_fam_name_len):
     """
-    Create a formated table for hotspot
+    Create a formatted table for hotspot
 
     :param gene_fam_name_len: Maximum size of gene families name
 
-    :return: formated table
+    :return: formatted table
     """
     return {
         "geneFam": tables.StringCol(itemsize=gene_fam_name_len),
@@ -446,7 +446,7 @@ def write_info(pangenome: Pangenome, h5f: tables.File):
     if "/info" in h5f:
         info_group = h5f.root.info
     else:
-        info_group = h5f.create_group("/", "info", "Informations about the pangenome content")
+        info_group = h5f.create_group("/", "info", "Information about the pangenome content")
     if pangenome.status["genomesAnnotated"] in ["Computed", "Loaded"]:
         info_group._v_attrs.numberOfGenes = pangenome.number_of_genes
         info_group._v_attrs.numberOfGenomes = pangenome.number_of_organisms

--- a/ppanggolin/formats/writeFlatGenomes.py
+++ b/ppanggolin/formats/writeFlatGenomes.py
@@ -395,10 +395,10 @@ def convert_overlapping_coordinates_for_gff(coordinates: List[Tuple[int, int]], 
     
     start, stop = coordinates[0]
     new_coordinates =  [(start, stop )]
-    # convert all coordinate that are at the begining 
+    # convert all coordinates that are at the beginning 
     # of the contig to the extent of the contig
     for start_n, stop_n in coordinates[1:]:
-        if start_n < start: # we are on the begining of the contig
+        if start_n < start: # we are on the beginning of the contig
             new_start = contig_length + start_n
             new_stop = contig_length + stop_n
             new_coordinates.append((new_start, new_stop))

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -480,7 +480,7 @@ def summarize_genome(organism: Organism,
     :param pangenome_persistent_count: Count of persistent genes in the pangenome.
     :param pangenome_persistent_single_copy_families: Set of gene families considered as persistent single-copy in the pangenome.
     :param soft_core_families: soft core families of the pangenome
-    :parma exact_core_families: exact core families of the pangenome
+    :param exact_core_families: exact core families of the pangenome
     :param input_org_rgps:  Number of regions of genomic plasticity in the input organism. None if not computed.
     :param input_org_spots:  Number of spots in the input organism. None if not computed.
     :param input_org_modules: Number of modules in the input organism. None if not computed.
@@ -1059,7 +1059,7 @@ def write_pangenome_flat_files(pangenome: Pangenome, output: Path, cpu: int = 1,
     :param soft_core: Soft core threshold to use
     :param dup_margin: minimum ratio of organisms in which family must have multiple genes to be considered duplicated
     :param csv: write csv file format as used by Roary
-    :param gene_pa: write gene presence abscence matrix
+    :param gene_pa: write gene presence absence matrix
     :param gexf: write pangenome graph in gexf format
     :param light_gexf: write pangenome graph with only gene families
     :param stats: write statistics about pangenome
@@ -1210,7 +1210,7 @@ def parser_flat(parser: argparse.ArgumentParser):
     optional.add_argument("--gexf", required=False, action="store_true",
                           help="write a gexf file with all the annotations and all the genes of each gene family")
     optional.add_argument("--light_gexf", required=False, action="store_true",
-                          help="write a gexf file with the gene families and basic informations about them")
+                          help="write a gexf file with the gene families and basic information about them")
     
     optional.add_argument("--json", required=False, action="store_true", help="Writes the graph in a json file format")
 

--- a/ppanggolin/formats/writeMSA.py
+++ b/ppanggolin/formats/writeMSA.py
@@ -224,7 +224,7 @@ def write_whole_genome_msa(pangenome: Pangenome, families: set, phylo_name: Path
     :param use_gene_id: Use gene identifiers rather than organism names for sequences in the family MSA
     """
 
-    # sort familes by ID, so the gene order is consistent
+    # sort families by ID, so the gene order is consistent
     families = sorted(families, key=lambda f: f.ID)
 
     phylo_dict = {}

--- a/ppanggolin/formats/writeMetadata.py
+++ b/ppanggolin/formats/writeMetadata.py
@@ -81,9 +81,9 @@ def write_metadata_group(h5f: tables.File, metatype: str) -> tables.Group:
 
 
 def desc_metadata(max_len_dict: Dict[str, int], type_dict: Dict[str, tables.Col]) -> dict:
-    """Create a formated table for metadata description
+    """Create a formatted table for metadata description
 
-    :return: Formated table
+    :return: Formatted table
     """
     desc_dict = {attr: tables.StringCol(itemsize=max_value) for attr, max_value in max_len_dict.items()}
     desc_dict.update({attr: col_type for attr, col_type in type_dict.items()})

--- a/ppanggolin/geneFamily.py
+++ b/ppanggolin/geneFamily.py
@@ -242,7 +242,7 @@ class GeneFamily(MetaFeatures):
         :raises ValueError: If the gene family has no partition assigned
         """
         if self.partition == "":
-            raise ValueError("The gene family has not beed associated to a partition.")
+            raise ValueError("The gene family has not been associated to a partition.")
         if self.partition.startswith("P"):
             return "persistent"
         elif self.partition.startswith("C"):

--- a/ppanggolin/genome.py
+++ b/ppanggolin/genome.py
@@ -77,7 +77,7 @@ class Feature(MetaFeatures):
         try:
             return sum([(stop - start +1) for start, stop in self.coordinates ])
         except TypeError:
-            raise ValueError(f"Cooridnates of gene {self} has not been defined. Geting is length is then impossible.")
+            raise ValueError(f"Coordinates of gene {self} have not been defined. Getting its length is then impossible.")
 
     @property
     def has_joined_coordinates(self) -> bool:
@@ -311,7 +311,7 @@ class Gene(Feature):
     def RGP(self):
         """Return the RGP that gene belongs to
 
-        :return: RGP fo the Gene
+        :return: RGP of the Gene
         :rtype: Region
         """
         return self._RGP

--- a/ppanggolin/metadata.py
+++ b/ppanggolin/metadata.py
@@ -52,12 +52,12 @@ class Metadata:
     def __len__(self) -> int:
         """Get the number of attribute links to the metadata object
 
-        :return: Number of fields (atribute) of the metadata
+        :return: Number of fields (attribute) of the metadata
         """
         return len(self.__dict__) - 1
 
     def __getattr__(self, attr: str) -> Any:
-        """Get the value corresponding to the given attibute
+        """Get the value corresponding to the given attribute
 
         :return: Value of the attribute
 

--- a/ppanggolin/mod/module.py
+++ b/ppanggolin/mod/module.py
@@ -54,7 +54,7 @@ def compute_mod_graph(pangenome: Pangenome, t: int = 1, disable_bar: bool = Fals
                         edge = g[gene.family][a_gene.family]
                         add_gene(edge, gene)
                         add_gene(edge, a_gene)
-                        if j == i + t + 1 or i == 0:  # if it's the last gene of the serie, or the first serie
+                        if j == i + t + 1 or i == 0:  # if it's the last gene of the series, or the first series
                             add_gene(g.nodes[a_gene.family], a_gene, fam_split=False)
 
     return g

--- a/ppanggolin/nem/NEM/nem_alg.c
+++ b/ppanggolin/nem/NEM/nem_alg.c
@@ -1477,7 +1477,7 @@ static StatusET  MakeRandomPara
 
 
 	/* Get mean coordinates from drawn object non-NaN coordinates ;
-	   or by uniform sampling if drawn object's coodinate is NaN */
+	   or by uniform sampling if drawn object's coordinate is NaN */
         for ( d = 0 ; d < nd ; d ++ )
 	  {
 	    /* Use drawn point's dth coordinate if not NaN */
@@ -2516,7 +2516,7 @@ static int ComputePartitionGEM /* +++ */
     GetNeighFT*     fGetNeigh ;      /*V1.06-c*/
 
     float*          z_nk ;     /* currently simulated partition */
-    int*            occur_nk ; /* occurence count for class h at site i */
+    int*            occur_nk ; /* occurrence count for class h at site i */
     int             icycle ;   /* current Monte-Carlo cycle */
     int             kdraw ;    /* drawn class : 0..nk-1 */
     int             ivis ;
@@ -2551,7 +2551,7 @@ static int ComputePartitionGEM /* +++ */
 	  LabelToClassVector( nk, kmap, &z_nk[ ipt * nk ] ) ;
 	}
 
-      /* Initialize to zero all occurence counts */
+      /* Initialize to zero all occurrence counts */
       for ( ipt = 0 ; ipt < npt ; ipt ++ )
 	for ( k = 0 ; k < nk ; k ++ )
 	  occur_nk[ ( ipt * nk ) + k ] = 0 ;

--- a/ppanggolin/nem/NEM/nem_hlp.c
+++ b/ppanggolin/nem/NEM/nem_hlp.c
@@ -433,7 +433,7 @@ void PrintHelpFileIn( FILE* F )
     fprintf( F , "\n" ) ;
     fprintf( F , " 4.c) file.m (option -s m)\n" ) ;
     fprintf( F , " -----------\n" ) ;
-    fprintf( F , "    Contains the parameters (at begining or throughout the clustering process) of the mixture model separated by spaces\n" ) ;
+    fprintf( F , "    Contains the parameters (at beginning or throughout the clustering process) of the mixture model separated by spaces\n" ) ;
     fprintf( F , "\n" ) ;
     fprintf( F , "    If the parameters are just initialized by this file, the file start by 1, ortherwise if the parameters are fixed throughout the clustering process the file start by 2\n" ) ;
     fprintf( F , "    Then :\n" ) ;
@@ -547,7 +547,7 @@ void PrintHelpVersions( FILE* F )
     fprintf( F , "Version 1.03  (02.10.1997)  \n" ) ;
     fprintf( F , "------------\n" ) ;
     fprintf( F , "If a partial knowledge of the classification is available, the\n" ) ;
-    fprintf( F , "intial cluster centers are computed from the observations with\n" ) ;
+    fprintf( F , "initial cluster centers are computed from the observations with\n" ) ;
     fprintf( F , "known labels.  \n" ) ;
     fprintf( F , "\n" ) ;
     fprintf( F , "The log file is made optional (option '-l y').  The ___.mf file now\n" ) ;
@@ -567,7 +567,7 @@ void PrintHelpVersions( FILE* F )
     fprintf( F , "The heuristics may be invoked with '-B heu_d' or '-B heu_l'. Their\n" ) ;
     fprintf( F , "default parameters may be changed with '-H ...'. \n" ) ;
     fprintf( F , "\n" ) ;
-    fprintf( F , "The final partition may now be printed to standard ouput instead of to a\n" ) ;
+    fprintf( F , "The final partition may now be printed to standard output instead of to a\n" ) ;
     fprintf( F , "file (option '-o -').  The result can thus be redirected as an \n" ) ;
     fprintf( F , "initial partition to another nem_exe session's input.\n" ) ;
     fprintf( F , "\n" ) ;

--- a/ppanggolin/nem/NEM/nem_typ.h
+++ b/ppanggolin/nem/NEM/nem_typ.h
@@ -348,7 +348,7 @@ typedef struct
     char    NeighName[ LEN_FILENAME + 1 ] ; /* name of neighborhood file */
     char    LabelName[ LEN_FILENAME + 1 ] ; /* name of fixed labels file */
     char    RefName[ LEN_FILENAME + 1 ] ;   /* name of reference labels file *//*V1.04-f*/
-    char    ParamName[ LEN_FILENAME + 1 ] ; /* name of initilization param file *//*V1.08-a*/
+    char    ParamName[ LEN_FILENAME + 1 ] ; /* name of initialization param file *//*V1.08-a*/
 }
 NemParaT ;      /* NEM running parameters */
 

--- a/ppanggolin/nem/partition.py
+++ b/ppanggolin/nem/partition.py
@@ -38,7 +38,7 @@ def run_partitioning(nem_dir_path: Path, nb_org: int, beta: float = 2.5, free_di
                      just_log_likelihood: bool = False) \
         -> Union[Tuple[dict, None, None], Tuple[int, float, float], Tuple[dict, dict, float]]:
     """
-    Main function to make partitionning
+    Main function to make partitioning
 
     :param nem_dir_path: Path to directory with nem files
     :param nb_org: Number of organisms
@@ -248,7 +248,7 @@ def write_nem_input_files(tmpdir: Path, organisms: set, sm_degree: int = 10) -> 
     :param organisms: Set of organism from pangenome
     :param sm_degree: Maximum degree of the nodes to be included in the smoothing process.
 
-    :return: total edge weigth to ponderate beta and number of families
+    :return: total edge weight to ponderate beta and number of families
     """
     mk_outdir(tmpdir, force=False)
     total_edges_weight = 0
@@ -487,7 +487,7 @@ def partition(pangenome: Pangenome, output: Path = None, beta: float = 2.5, sm_d
         pangenome.parameters["partition"]["chunk_size"] = chunk_size
     pangenome.parameters["partition"]["# computed nb of partitions"] = False
 
-    # the K value initally given by the user 
+    # the K value initially given by the user 
     pangenome.parameters["partition"]["nb_of_partitions"] = kval
     if kval < 2:
         pangenome.parameters["partition"]["# computed nb of partitions"] = True

--- a/ppanggolin/nem/rarefaction.py
+++ b/ppanggolin/nem/rarefaction.py
@@ -49,7 +49,7 @@ def raref_nem(index: int, tmpdir: Path, beta: float = 2.5, sm_degree: int = 10,
     :param krange: Range of K values to test when detecting K automatically.
     :param seed: seed used to generate random numbers
 
-    :return: Count of each partition and paremeters for the given sample index
+    :return: Count of each partition and parameters for the given sample index
     """
     samp = samples[index]
     currtmpdir = tmpdir / f"{str(index)}"
@@ -147,7 +147,7 @@ def launch_raref_nem(args: Tuple[int, Path, float, int, bool, int, int, list, in
 
     :param args: {index: int, tmpdir: str, beta: float, sm_degree: int, free_dispersion: bool,
                   chunk_size: int, kval: int, krange: list, seed: int}
-    :return: Count of each partition and paremeters for the given sample index
+    :return: Count of each partition and parameters for the given sample index
     """
     return raref_nem(*args)
 

--- a/ppanggolin/pangenome.py
+++ b/ppanggolin/pangenome.py
@@ -191,7 +191,7 @@ class Pangenome:
     def max_fam_id(self, value):
         """Set the last family identifier
 
-        :param value: value of the maximum family identifer
+        :param value: value of the maximum family identifier
         """
         self._max_fam_id = value
 

--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -263,7 +263,7 @@ def write_projection_results(pangenome: Pangenome, organisms: Set[Organism],
     # multigenics = pangenome.get_multigenics(pangenome_params.rgp.dup_margin)
 
     # dup margin value here is specified in argument and is used to compute completeness.
-    # Thats mean it can be different than dup margin used in spot and RGPS.
+    # That means it can be different than dup margin used in spot and RGPS.
 
     pangenome_persistent_single_copy_families = pangenome.get_single_copy_persistent_families(dup_margin=dup_margin,
                                                                                               exclude_fragments=True)
@@ -703,7 +703,7 @@ def predict_RGP(pangenome: Pangenome, input_organisms: List[Organism], persisten
     for input_organism in input_organisms:
         rgps = compute_org_rgp(input_organism, multigenics, persistent_penalty, variable_gain, min_length,
                                min_score, naming=name_scheme, disable_bar=disable_bar)
-        # turn on projected attribut in rgp objects
+        # turn on projected attribute in rgp objects
         # useful when associating spot to prevent failure when multiple spot are associated to a projected RGP
         for rgp in rgps:
             rgp.projected = True

--- a/ppanggolin/region.py
+++ b/ppanggolin/region.py
@@ -432,7 +432,7 @@ class Region(MetaFeatures):
         :return: A list of bordering genes in start and stop position
         """
         genes_in_region = list(self.genes)
-        # Identifiying left border
+        # Identifying left border
         left_border = []
         pos = self.starter.position
         init = pos
@@ -458,7 +458,7 @@ class Region(MetaFeatures):
             if pos == init:
                 break  # looped around the contig
 
-         # Identifiying right border
+         # Identifying right border
         right_border = []
         pos = self.stopper.position
         init = pos

--- a/ppanggolin/utility/utils.py
+++ b/ppanggolin/utility/utils.py
@@ -12,7 +12,7 @@ from ppanggolin.utils import get_subcommand_parser, check_log, ALL_INPUT_PARAMS,
     WORKFLOW_SUBCOMMANDS, ALL_WORKFLOW_DEPENDENCIES, WRITE_PAN_FLAG_DEFAULT_IN_WF, WRITE_GENOME_FLAG_DEFAULT_IN_WF, DRAW_FLAG_DEFAULT_IN_WF
 from ppanggolin import SUBCOMMAND_TO_SUBPARSER
 
-""" Utility scripts to help formating input files of PPanggolin."""
+""" Utility scripts to help formatting input files of PPanggolin."""
 
 
 def split(list_object: list, chunk_count: int) -> List[List[int]]:
@@ -36,9 +36,9 @@ def split_comment_string(comment_string: str, max_word_count: int = 20, prefix: 
 
     :params comment_string: comment string to split
     :params max_word_count: maximum number of word per line
-    :params prefix: prefic used to start a new comment line
+    :params prefix: prefix used to start a new comment line
     
-    :return : the splited comment line.
+    :return : the split comment line.
     """
 
     splitted_comment = comment_string.split()
@@ -185,8 +185,8 @@ def launch_default_config(args: argparse.Namespace):
 
             if parser_action.dest in ALL_INPUT_PARAMS:
                 if sub_command == initial_command:
-                    # with worflow dependencies, we do not use their input params
-                    # as input params are given by worflow cmds
+                    # with workflow dependencies, we do not use their input params
+                    # as input params are given by workflow cmds
                     inputs_actions.append(parser_action)
 
             elif parser_action.dest in ALL_GENERAL_PARAMS:

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -652,7 +652,7 @@ def manage_cli_and_config_args(subcommand: str, config_file: str, subcommand_to_
     Manage command line and config arguments for the given subcommand.
 
     This function parse arguments from the cmd line and config file and set up the following priority: cli > config > default
-    When the subcommand is a workflow, the subcommand used in worflows are also parsed in the config.  
+    When the subcommand is a workflow, the subcommand used in workflows are also parsed in the config.  
 
 
     :params subcommand: Name of the subcommand.
@@ -760,7 +760,7 @@ def manage_cli_and_config_args(subcommand: str, config_file: str, subcommand_to_
 
             params_that_differ.update(step_params_that_differ)
 
-            # Add args namespace of the step to the inital args namespace
+            # Add args namespace of the step to the initial args namespace
             setattr(args, workflow_step, step_args)
 
     if params_that_differ:
@@ -816,7 +816,7 @@ def set_up_config_param_to_parser(config_param_val: dict) -> list:
 
     :params config_param_val: Dict with parameter name as key and parameter value as value.
 
-    :return: list of argument strings formated for an argparse.ArgumentParser object.
+    :return: list of argument strings formatted for an argparse.ArgumentParser object.
     """
 
     arguments_to_parse = []


### PR DESCRIPTION
:fr:

typos dans le code source, aussi trouvées avec codespell

:us: 

This has been done with codespell 2.3.0 with a command like looking like this

`codespell -L=comma,separated,excluded,words ppanggolin`

and then fixing by hand all typos (yes).