### PR TITLE
a few minor code changes

### DIFF
--- a/ppanggolin/RGP/genomicIsland.py
+++ b/ppanggolin/RGP/genomicIsland.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging
@@ -101,8 +100,7 @@ class IdenticalRegions:
         Return iterable of genes from all RGPs that are identical in families
         """
         for rgp in self.rgps:
-            for gene in rgp.genes:
-                yield gene
+            yield from rgp.genes
     @property
     def spots(self) -> Set[Spot]:
         """
@@ -283,7 +281,7 @@ def add_info_to_identical_rgps(rgp_graph: nx.Graph, identical_rgps_objects: List
                            name=identical_rgp_obj.name,
                            families_count=len(identical_rgp_obj.families),
                            identical_rgp_count=len(identical_rgp_obj.rgps),
-                           identical_rgp_names=';'.join([i_rgp.name for i_rgp in identical_rgp_obj.rgps]),
+                           identical_rgp_names=';'.join(i_rgp.name for i_rgp in identical_rgp_obj.rgps),
                            identical_rgp_genomes=';'.join({i_rgp.organism.name for i_rgp in identical_rgp_obj.rgps}),
                            identical_rgp_contig_border_count=len(
                                [True for i_rgp in identical_rgp_obj.rgps if i_rgp.is_contig_border]),

--- a/ppanggolin/align/alignOnPang.py
+++ b/ppanggolin/align/alignOnPang.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import time

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/annotate/synta.py
+++ b/ppanggolin/annotate/synta.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/cluster/cluster.py
+++ b/ppanggolin/cluster/cluster.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/context/searchGeneContext.py
+++ b/ppanggolin/context/searchGeneContext.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/edge.py
+++ b/ppanggolin/edge.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding: utf8
 
 # default libraries
 from collections import defaultdict
@@ -50,8 +49,7 @@ class Edge:
 
         :return: Generator with organisms as the key and an iterable of the gene pairs as value
         """
-        for organism in self._organisms.keys():
-            yield organism
+        yield from self._organisms.keys()
 
     @property
     def number_of_organisms(self) -> int:

--- a/ppanggolin/figures/draw_spot.py
+++ b/ppanggolin/figures/draw_spot.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 
 # default libraries

--- a/ppanggolin/figures/drawing.py
+++ b/ppanggolin/figures/drawing.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/figures/tile_plot.py
+++ b/ppanggolin/figures/tile_plot.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/formats/readBinaries.py
+++ b/ppanggolin/formats/readBinaries.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging
@@ -152,8 +151,7 @@ def read_chunks(table: tables.Table, column: str = None, chunk: int = 10000):
     :param chunk:
     """
     for i in range(0, table.nrows, chunk):
-        for row in table.read(start=i, stop=i + chunk, field=column):
-            yield row
+        yield from table.read(start=i, stop=i + chunk, field=column)
 
 
 def read_genedata(h5f: tables.File) -> Dict[int, Genedata]:

--- a/ppanggolin/formats/writeAnnotations.py
+++ b/ppanggolin/formats/writeAnnotations.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/formats/writeBinaries.py
+++ b/ppanggolin/formats/writeBinaries.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/formats/writeFlatGenomes.py
+++ b/ppanggolin/formats/writeFlatGenomes.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/formats/writeFlatMetadata.py
+++ b/ppanggolin/formats/writeFlatMetadata.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/formats/writeMSA.py
+++ b/ppanggolin/formats/writeMSA.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse
@@ -123,7 +122,7 @@ def write_fasta_families(family: GeneFamily, tmpdir: tempfile.TemporaryDirectory
 
     # get genes that are present in only one copy for our family in each organism.
     single_copy_genes = []
-    for _, genes in family.get_org_dict().items():
+    for genes in family.get_org_dict().values():
         if len(genes) == 1:
             single_copy_genes.extend(genes)
 

--- a/ppanggolin/formats/writeMetadata.py
+++ b/ppanggolin/formats/writeMetadata.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging
@@ -58,7 +57,7 @@ def write_metadata_status(pangenome: Pangenome, h5f: tables.File, status_group: 
         metadata_group._v_attrs.modules = True
         metasources_group._v_attrs.modules = metasources["modules"]
 
-    return True if any(metadata_group._v_attrs._f_list()) else False
+    return any(metadata_group._v_attrs._f_list())
 
 
 def write_metadata_group(h5f: tables.File, metatype: str) -> tables.Group:

--- a/ppanggolin/formats/writeSequences.py
+++ b/ppanggolin/formats/writeSequences.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/formats/write_proksee.py
+++ b/ppanggolin/formats/write_proksee.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import json

--- a/ppanggolin/geneFamily.py
+++ b/ppanggolin/geneFamily.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding: utf8
 
 # default libraries
 from __future__ import annotations
@@ -259,8 +258,7 @@ class GeneFamily(MetaFeatures):
 
         :return: Edges of the gene family
         """
-        for edge in self._edges_getter.values():
-            yield edge
+        yield from self._edges_getter.values()
 
     @property
     def neighbors(self) -> Generator[GeneFamily, None, None]:
@@ -268,8 +266,7 @@ class GeneFamily(MetaFeatures):
 
         :return: Neighbors
         """
-        for neighbor in self._edges_getter.keys():
-            yield neighbor
+        yield from self._edges_getter.keys()
 
     @property
     def genes(self):
@@ -277,8 +274,7 @@ class GeneFamily(MetaFeatures):
 
         :return: Generator of genes
         """
-        for gene in self._genes_getter.values():
-            yield gene
+        yield from self._genes_getter.values()
 
     @property
     def organisms(self) -> Generator[Organism, None, None]:
@@ -288,8 +284,7 @@ class GeneFamily(MetaFeatures):
         """
         if len(self._genePerOrg) == 0:
             _ = self.get_org_dict()
-        for org in self._genePerOrg.keys():
-            yield org
+        yield from self._genePerOrg.keys()
 
     @property
     def spots(self) -> Generator[Spot, None, None]:
@@ -297,8 +292,7 @@ class GeneFamily(MetaFeatures):
 
         :return: Generator of spots
         """
-        for spot in self._spots:
-            yield spot
+        yield from self._spots
 
     @property
     def module(self) -> Module:
@@ -446,8 +440,7 @@ class GeneFamily(MetaFeatures):
             _ = self.get_org_dict()
         if org not in self._genePerOrg:
             raise KeyError(f"Genome does not have the gene family: {self.name}")
-        for gene in self._genePerOrg[org]:
-            yield gene
+        yield from self._genePerOrg[org]
 
 
     def is_single_copy(self, dup_margin: float, exclude_fragment: bool) -> bool:
@@ -459,10 +452,7 @@ class GeneFamily(MetaFeatures):
         :return: A boolean indicating whether the gene family is single copy.
         """
         
-        if self.duplication_ratio(exclude_fragment) < dup_margin:
-            return True
-        else:
-            return False
+        return self.duplication_ratio(exclude_fragment) < dup_margin
 
     def duplication_ratio(self, exclude_fragment: bool) -> bool:
         """

--- a/ppanggolin/genome.py
+++ b/ppanggolin/genome.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding: utf8
 
 from __future__ import annotations
 import logging
@@ -230,7 +229,7 @@ class Feature(MetaFeatures):
         """
         Return a string representation of the coordinates
         """
-        return ','.join([f'{start}..{stop}' for start, stop in self.coordinates])
+        return ','.join(f'{start}..{stop}' for start, stop in self.coordinates)
     
     def start_relative_to(self, gene):
         """

--- a/ppanggolin/graph/makeGraph.py
+++ b/ppanggolin/graph/makeGraph.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/info/info.py
+++ b/ppanggolin/info/info.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/main.py
+++ b/ppanggolin/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import sys

--- a/ppanggolin/meta/meta.py
+++ b/ppanggolin/meta/meta.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/metadata.py
+++ b/ppanggolin/metadata.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding: utf8
 
 # default libraries
 import logging
@@ -119,8 +118,7 @@ class MetaFeatures:
         """
 
         for meta_dict in self._metadata_getter.values():
-            for metadata in meta_dict.values():
-                yield metadata
+            yield from meta_dict.values()
 
     @property
     def sources(self) -> Generator[str, None, None]:
@@ -260,7 +258,7 @@ class MetaFeatures:
         :return: True if it has metadata else False
         """
 
-        return True if self.number_of_metadata > 0 else False
+        return self.number_of_metadata > 0
 
     def has_source(self, source: str) -> bool:
         """Check if the source is in the metadata feature
@@ -269,4 +267,4 @@ class MetaFeatures:
 
         :return: True if the source is in the metadata feature else False
         """
-        return True if source in self._metadata_getter else False
+        return source in self._metadata_getter

--- a/ppanggolin/metrics/fluidity.py
+++ b/ppanggolin/metrics/fluidity.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/metrics/metrics.py
+++ b/ppanggolin/metrics/metrics.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/mod/module.py
+++ b/ppanggolin/mod/module.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/nem/partition.py
+++ b/ppanggolin/nem/partition.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging
@@ -166,7 +165,7 @@ def run_partitioning(nem_dir_path: Path, nb_org: int, beta: float = 2.5, free_di
                         partitions_list[i] = "S_"  # SHELL in case of doubt gene families is attributed to shell
                     else:
                         partitions_list[i] = parti[positions_max_prob.pop()]
-    except IOError:
+    except OSError:
         logging.getLogger("PPanGGOLiN").debug(
             "partitioning did not work (the number of genomes used is probably too low), "
             "see logs here to obtain more details " + nem_dir_path.as_posix() + "/nem_file_" +

--- a/ppanggolin/nem/rarefaction.py
+++ b/ppanggolin/nem/rarefaction.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/pangenome.py
+++ b/ppanggolin/pangenome.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding: utf8
 
 # default libraries
 import logging
@@ -201,8 +200,7 @@ class Pangenome:
         
         :return: Generator of gene families
         """
-        for family in self._fam_getter.values():
-            yield family
+        yield from self._fam_getter.values()
 
     @property
     def number_of_gene_families(self) -> int:
@@ -259,8 +257,7 @@ class Pangenome:
         
         :return: Generator of edge
         """
-        for edge in self._edge_getter.values():
-            yield edge
+        yield from self._edge_getter.values()
 
     def add_edge(self, gene1: Gene, gene2: Gene) -> Edge:
         """
@@ -304,8 +301,7 @@ class Pangenome:
         
         :return: Generator :class:`ppanggolin.genome.Organism`
         """
-        for organism in self._org_getter.values():
-            yield organism
+        yield from self._org_getter.values()
 
     @property
     def number_of_organisms(self) -> int:
@@ -507,8 +503,7 @@ class Pangenome:
 
         :return: list of RGP
         """
-        for region in self._region_getter.values():
-            yield region
+        yield from self._region_getter.values()
 
     def get_region(self, name: str) -> Region:
         """Returns a region with the given region_name. Creates it if it does not exist.

--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/region.py
+++ b/ppanggolin/region.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding: utf8
 
 # default libraries
 from __future__ import annotations
@@ -319,8 +318,7 @@ class Region(MetaFeatures):
 
         :return: Genes in the region
         """
-        for gene in sorted(self._genes_getter.values(), key=lambda x: x.position):
-            yield gene
+        yield from sorted(self._genes_getter.values(), key=lambda x: x.position)
 
     @property
     def families(self) -> Generator[GeneFamily, None, None]:
@@ -625,8 +623,7 @@ class Spot(MetaFeatures):
 
         :return: Regions in the spot
         """
-        for region in self._region_getter.values():
-            yield region
+        yield from self._region_getter.values()
 
     @property
     def families(self) -> Generator[GeneFamily, None, None]:

--- a/ppanggolin/utility/utils.py
+++ b/ppanggolin/utility/utils.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging
@@ -72,9 +71,9 @@ def check_log(log_file: str) -> TextIO:
             if os.access(log_file, os.W_OK):
                 return log_file
             else:
-                raise IOError(f"The given log file {log_file} is not writable. Please check if it is accessible.")
+                raise OSError(f"The given log file {log_file} is not writable. Please check if it is accessible.")
         else:
-            raise IOError(f"The given log file: {log_file} is a directory. Please provide a valid log file.")
+            raise OSError(f"The given log file: {log_file} is a directory. Please provide a valid log file.")
 
     # target does not exist, check perms on parent dir
     parent_dir = os.path.dirname(log_file)
@@ -84,7 +83,7 @@ def check_log(log_file: str) -> TextIO:
     if os.access(parent_dir, os.W_OK):
         return log_file
     else:
-        raise IOError(f"The given log file {log_file} is not writable. Please check if it is accessible.")
+        raise OSError(f"The given log file {log_file} is not writable. Please check if it is accessible.")
 
 
 def check_tsv_sanity(tsv: Path):
@@ -94,8 +93,8 @@ def check_tsv_sanity(tsv: Path):
     """
     try:
         input_file = open(tsv, "r")
-    except IOError as ios_error:
-        raise IOError(ios_error)
+    except OSError as ios_error:
+        raise OSError(ios_error)
     except Exception as exception_error:
         raise Exception(f"The following unexpected error happened when opening the list of genomes path: "
                         f"{exception_error}")
@@ -166,7 +165,7 @@ def set_verbosity_level(args):
             logging.basicConfig(filename=args.log, level=level,
                                 format=str_format,
                                 datefmt=datefmt)
-        logging.getLogger("PPanGGOLiN").info("Command: " + " ".join([arg for arg in sys.argv]))
+        logging.getLogger("PPanGGOLiN").info("Command: " + " ".join(arg for arg in sys.argv))
         logging.getLogger("PPanGGOLiN").info(f"PPanGGOLiN version: {distribution('ppanggolin').version}")
 
 
@@ -709,7 +708,7 @@ def manage_cli_and_config_args(subcommand: str, config_file: str, subcommand_to_
     params_that_differ = get_args_differing_from_default(default_args, args, input_params)
 
     if params_that_differ:
-        params_that_differ_str = ', '.join([f'{p}={v}' for p, v in params_that_differ.items()])
+        params_that_differ_str = ', '.join(f'{p}={v}' for p, v in params_that_differ.items())
         logging.getLogger("PPanGGOLiN").debug(
             f"{len(params_that_differ)} {subcommand} parameters have non-default value: {params_that_differ_str}")
 
@@ -750,7 +749,7 @@ def manage_cli_and_config_args(subcommand: str, config_file: str, subcommand_to_
             step_params_that_differ = get_args_differing_from_default(default_step_args, step_args)
 
             if step_params_that_differ:
-                step_params_that_differ_str = ', '.join([f'{p}={v}' for p, v in step_params_that_differ.items()])
+                step_params_that_differ_str = ', '.join(f'{p}={v}' for p, v in step_params_that_differ.items())
                 logging.getLogger("PPanGGOLiN").debug(f"{len(step_params_that_differ)} {workflow_step} parameters have "
                                                       f"a non-default value: {step_params_that_differ_str}")
 

--- a/ppanggolin/workflow/all.py
+++ b/ppanggolin/workflow/all.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import logging

--- a/ppanggolin/workflow/panModule.py
+++ b/ppanggolin/workflow/panModule.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/workflow/panRGP.py
+++ b/ppanggolin/workflow/panRGP.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/ppanggolin/workflow/workflow.py
+++ b/ppanggolin/workflow/workflow.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding:utf-8
 
 # default libraries
 import argparse

--- a/tests/context/test_context.py
+++ b/tests/context/test_context.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# coding: utf8
 
 import pytest
 from ppanggolin.context.searchGeneContext import (extract_contig_window, get_n_next_genes_index,

--- a/tests/region/test_rgp_cluster.py
+++ b/tests/region/test_rgp_cluster.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# coding: utf8
 
 import pytest
 from random import randint
@@ -18,7 +17,7 @@ def genes() -> Generator[Set[Gene], None, None]:
     organism = Organism("organism")
     contig = Contig(0, "contig")
     genes = []
-    for i in range(0, randint(11, 20)):
+    for i in range(randint(11, 20)):
         gene = Gene(f"gene_{str(i)}")
         gene.fill_annotations(start=10 * i + 1, stop=10 * (i + 1), strand='+', position=i, genetic_code=4)
         gene.fill_parents(organism, contig)

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# coding: utf8
 
 import pytest
 from typing import Generator, Tuple

--- a/tests/test_genefamily.py
+++ b/tests/test_genefamily.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# coding: utf8
 
 import pytest
 from random import randint

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# coding: utf8
 
 import pytest
 from typing import Generator, Tuple

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# coding: utf8
 
 import pytest
 from random import randint

--- a/tests/test_pangenome.py
+++ b/tests/test_pangenome.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# coding: utf8
 
 import pytest
 from random import choices, randint

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# coding: utf8
 
 import pytest
 from typing import Generator, Set

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# coding: utf8
 
 import pytest
 from pathlib import Path


### PR DESCRIPTION
:fr: 

juste quelques petits details

plus suppression des lignes de declaration d'encodage utf8, inutiles

:gb: 

The utf-8 encoding is now the default in python since python3, so there is no need to declare that in every file.

Using `yield from` is recommended as much better by pep 0380 (https://peps.python.org/pep-0380/).

`IOError` is now an alias for `OSError`.

Some of the changes were scripted using the very fast linter `ruff`, see the section `UP` in its documentation : https://docs.astral.sh/ruff/rules/#pyupgrade-up and in particular UP009 and UP024.