### PR TITLE
Fix config outputs in workflow commands when set in config file

### DIFF
--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -636,7 +636,7 @@ def write_persistent_duplication_statistics(pangenome: Pangenome, output: Path, 
     return single_copy_persistent
 
 def write_summaries_in_tsv(summaries: List[Dict[str, Any]], output_file: Path,
-                           dup_margin:float, soft_core:float):
+                           dup_margin:float, soft_core:float, compress:bool = False):
     """
     Writes summaries of organisms stored in a dictionary into a Tab-Separated Values (TSV) file.
 
@@ -644,6 +644,7 @@ def write_summaries_in_tsv(summaries: List[Dict[str, Any]], output_file: Path,
     :param output_file: The Path specifying the output TSV file location.
     :param soft_core: Soft core threshold used
     :param dup_margin: minimum ratio of organisms in which family must have multiple genes to be considered duplicated
+    :param compress: Compress the file in .gz
     """
     # Flatten the nested dictionaries within the summaries dictionary
     flat_summaries = [flatten_nested_dict(summary_info) for summary_info in summaries]
@@ -651,7 +652,7 @@ def write_summaries_in_tsv(summaries: List[Dict[str, Any]], output_file: Path,
     # Create a DataFrame from the flattened summaries
     df_summary = pd.DataFrame(flat_summaries)
 
-    with open(output_file, "w") as flout:
+    with write_compressed_or_not(output_file, compress) as flout:
         flout.write(f"#soft_core={round(soft_core, 3)}\n")
         flout.write(f"#duplication_margin={round(dup_margin, 3)}\n")
 
@@ -702,7 +703,7 @@ def write_stats(output: Path, soft_core: float = 0.95, dup_margin: float = 0.05,
 
         summaries.append(organism_summary)
 
-    write_summaries_in_tsv(summaries, output_file= output / "genomes_statistics.tsv", dup_margin=dup_margin, soft_core=soft_core)
+    write_summaries_in_tsv(summaries, output_file= output / "genomes_statistics.tsv", dup_margin=dup_margin, soft_core=soft_core, compress=compress)
     
     logging.getLogger("PPanGGOLiN").info("Done writing genome per genome statistics")
 

--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -330,7 +330,7 @@ def write_projection_results(pangenome: Pangenome, organisms: Set[Organism],
     write_summaries_in_tsv(summaries,
                            output_file=output_file,
                            dup_margin=dup_margin,
-                           soft_core=soft_core)
+                           soft_core=soft_core, compress=compress)
 
 
 def summarize_projected_genome(organism: Organism,

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -276,7 +276,7 @@ def read_compressed_or_not(file_or_file_path: Union[Path, BinaryIO, TextIOWrappe
             return file_or_file_path
 
 
-def write_compressed_or_not(file_path: Path, compress: bool = False) -> Union[gzip.GzipFile, TextIO]:
+def write_compressed_or_not(file_path: Path, compress: bool = False) -> Union[gzip.GzipFile, TextIOWrapper]:
     """
     Create a file-like object, compressed or not.
 
@@ -736,14 +736,18 @@ def manage_cli_and_config_args(subcommand: str, config_file: str, subcommand_to_
             # overwrite write and draw default when not specified in config 
             if workflow_step == 'write_pangenome':
                 for out_flag in WRITE_PAN_FLAG_DEFAULT_IN_WF:
-                    setattr(default_step_args, out_flag, True)
+                    if out_flag not in config[workflow_step]:
+                        setattr(default_step_args, out_flag, True)
+
             if workflow_step == 'write_genomes':
                 for out_flag in WRITE_GENOME_FLAG_DEFAULT_IN_WF:
-                    setattr(default_step_args, out_flag, True)
+                    if out_flag not in config[workflow_step]:
+                        setattr(default_step_args, out_flag, True)
 
             if workflow_step == "draw":
                 for out_flag in DRAW_FLAG_DEFAULT_IN_WF:
-                    setattr(default_step_args, out_flag, True)
+                    if out_flag not in config[workflow_step]:
+                        setattr(default_step_args, out_flag, True)
 
             step_args = overwrite_args(default_step_args, config_step_args, cli_args)
 

--- a/ppanggolin/workflow/all.py
+++ b/ppanggolin/workflow/all.py
@@ -209,7 +209,7 @@ def launch_workflow(args: argparse.Namespace, panrgp: bool = True,
 
         start_desc = time.time()
 
-        write_pangenome_arguments = ["csv", "Rtab", "gexf", "light_gexf", "projection", "stats", 'json', "families_tsv"]
+        write_pangenome_arguments = ["gexf", "light_gexf", 'json', "csv", "Rtab", "stats", "partitions", "families_tsv"]
 
         # Check that we don't ask write to output something not computed.
         borders, spots, spot_modules, modules, regions = (False, False, False, False, False)


### PR DESCRIPTION
**Summary**

This PR addresses an issue with the default behavior of flat output file generation in workflow commands when specified through the configuration file.

**Background**

In the commands `write_pangenome`, `write_genome`, and `draw`, the default setting for output files is `false`, requiring users to explicitly specify the desired files via the command line. However, within workflow commands, these outputs are generated by default unless the `--no_flat_files` parameter is used. The intended behavior was to force output files to be generated by default unless overridden by the configuration file or CLI arguments.

**Issue**

The previous implementation incorrectly forced output file generation even when the configuration file specified `false` for certain outputs. This made it impossible to selectively generate some outputs while omitting others.

**Fix**

This PR corrects the handling of configuration and CLI arguments, ensuring that the specified settings in the configuration file are respected. Now, the correct outputs will be generated based on user specifications, allowing for more granular control over the output files.


**Additional Fix**

The `compress` flag, intended to compress output files, was previously not applied to the `genomes_statistics.tsv` file. This PR ensures that the file can now be generated in a compressed format if the `compress` flag is set.
