### PR TITLE
Handle case where a spotless pangenome is used in projection

### DIFF
--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -914,7 +914,7 @@ def predict_spots_in_input_organisms(
     # Check congruency with already computed spot and add spot id in node attributes
     check_spots_congruency(graph_spot, initial_spots)
 
-    new_spot_id_counter = max((s.ID for s in initial_spots)) + 1
+    new_spot_id_counter = max((s.ID for s in initial_spots)) + 1 if len(initial_spots) != 0 else 1
 
     input_org_to_spots = {}
     for input_organism, rgps in input_org_2_rgps.items():


### PR DESCRIPTION
An edge case have been identified in issue #264 where a pangenome without any existing spots is used in a projection. In this case, the projection process, which predicts spots in the input genome, attempts to retrieve the highest spot ID to determine the appropriate ID for any new spots detected. This leads to an error when no spot IDs are available.

To resolve this, I’ve implemented a check to see if the pangenome contains any spots. If no spots are found, the process will now default to using an ID of 1 for new spots.