### PR TITLE
Print a warning log when partition step fails

### DIFF
--- a/ppanggolin/nem/partition.py
+++ b/ppanggolin/nem/partition.py
@@ -166,13 +166,9 @@ def run_partitioning(nem_dir_path: Path, nb_org: int, beta: float = 2.5, free_di
                     else:
                         partitions_list[i] = parti[positions_max_prob.pop()]
     except OSError:
-        raise ValueError(
-            "Partitioning did not work (the number of genomes used is probably too low), "
+        logging.getLogger("PPanGGOLiN").warning("Partitioning did not work (the number of genomes used is probably too low), "
             f"see logs here to obtain more details {nem_dir_path.as_posix()}")
-        
-        # raising an error here for now.  
-        # TODO: Would be better to be able to handle pangenome with no partition.
-        # return {}, None, None  # return empty objects
+        return {}, None, None  # return empty objects
 
     except ValueError:
         # return the default partitions_list which correspond to undefined

--- a/ppanggolin/nem/partition.py
+++ b/ppanggolin/nem/partition.py
@@ -166,25 +166,17 @@ def run_partitioning(nem_dir_path: Path, nb_org: int, beta: float = 2.5, free_di
                     else:
                         partitions_list[i] = parti[positions_max_prob.pop()]
     except OSError:
-        logging.getLogger("PPanGGOLiN").debug(
-            "partitioning did not work (the number of genomes used is probably too low), "
-            "see logs here to obtain more details " + nem_dir_path.as_posix() + "/nem_file_" +
-            str(kval) + ".log")
-        return {}, None, None  # return empty objects
+        raise ValueError(
+            "Partitioning did not work (the number of genomes used is probably too low), "
+            f"see logs here to obtain more details {nem_dir_path.as_posix()}")
+        
+        # raising an error here for now.  
+        # TODO: Would be better to be able to handle pangenome with no partition.
+        # return {}, None, None  # return empty objects
+
     except ValueError:
         # return the default partitions_list which correspond to undefined
         pass
-
-    if not keep_files and no_nem is False:
-        os.remove(nem_dir_path / f"nem_file_{str(kval)}.uf")
-        os.remove(nem_dir_path / f"nem_file_{str(kval)}.mf")
-        os.remove(nem_dir_path / f"nem_file_{str(kval)}.log")
-        os.remove(nem_dir_path / f"nem_file_{str(kval)}.stderr")
-        os.remove(nem_dir_path / f"nem_file_init_{str(kval)}.m")
-        os.remove(nem_dir_path / "nem_file.index")
-        os.remove(nem_dir_path / "nem_file.dat")
-        os.remove(nem_dir_path / "nem_file.nei")
-        os.remove(nem_dir_path / "nem_file.str")
 
     if just_log_likelihood:
         return kval, log_likelihood, entropy
@@ -469,8 +461,15 @@ def partition(pangenome: Pangenome, output: Path = None, beta: float = 2.5, sm_d
     check_pangenome_former_partition(pangenome, force)
     check_pangenome_info(pangenome, need_annotations=True, need_families=True, need_graph=True, disable_bar=disable_bar)
     organisms = set(pangenome.organisms)
-    tmp_dir = tempfile.TemporaryDirectory(dir=tmpdir)
-    tmp_path = Path(tmp_dir.name)
+
+    if keep_tmp_files:
+        # Create a temporary directory without auto-cleanup
+        tmp_dir = tempfile.mkdtemp(dir=tmpdir)
+        tmp_path = Path(tmp_dir)
+    else:
+        # Create a temporary directory with auto-cleanup
+        tmp_dir = tempfile.TemporaryDirectory(dir=tmpdir)
+        tmp_path = Path(tmp_dir.name)
 
     if len(organisms) <= 10:
         logging.getLogger("PPanGGOLiN").warning(f"The number of selected genomes is too low ({len(organisms)} "


### PR DESCRIPTION
When partition step fails as in issue #262, an error occur but in a later step and the message of the partition failure is only given as a debug log making hard for the user to understand whats going on.

Now, with this PR if the partition step fails, a warning log is thrown making what's going wrong more obvious for the user.

This is a quick fix. Ideally, PPanGGOLIN should keep running even if partitioning fails, since it can still provide useful data like core and soft genomes. Implementing this behavior would take more work.This enhancement is tracked in issue #270.