### PR TITLE
Fix random.sample call to be compatible with python 3.12

### DIFF
--- a/ppanggolin/nem/partition.py
+++ b/ppanggolin/nem/partition.py
@@ -321,7 +321,7 @@ def evaluate_nb_partitions(organisms: set, output: Path = None, sm_degree: int =
     newtmpdir = tmpdir / "eval_partitions"
 
     if len(organisms) > chunk_size:
-        select_organisms = set(random.sample(set(organisms), chunk_size))
+        select_organisms = set(random.sample(list(organisms), chunk_size))
     else:
         select_organisms = set(organisms)
 


### PR DESCRIPTION
This PR fixes an issue in the `partition` module where the `random.sample` function caused an error in Python versions 3.11 and 3.12, as reported in issue #268.

While PR #255 added support for Python 3.12, this specific issue has been missed. The `random.sample` function is only called when the number of genomes exceeds the chunk size, which defaults to 500. Since the CI tests run with only 50 genomes, this bug wasn't detected.

To verify the fix, you can run the `partition` command with a chunk size smaller than the number of genomes:

```bash
cd testingDataset
ppanggolin annotate --fasta genomes.fasta.list --output stepbystep --cpu 12
ppanggolin cluster -p stepbystep/pangenome.h5 --cpu 12
ppanggolin graph -p stepbystep/pangenome.h5
ppanggolin partition --output stepbystep -f -p stepbystep/pangenome.h5 --cpu 12 --chunk_size 40
```
