### PR TITLE
Fix error when using an external clustering 

### DIFF
--- a/docs/user/PangenomeAnalyses/pangenomeCluster.md
+++ b/docs/user/PangenomeAnalyses/pangenomeCluster.md
@@ -174,31 +174,42 @@ flowchart TD
 
 #### Indicate fragmented gene
 
-It's also possible to indicate if the gene is fragmented, by adding a new column in last position. Fragmented gene are tag with an 'F' in the last column.
+You can indicate if a gene is fragmented by adding a new column. Fragmented genes are marked with an 'F' in this final column.
 
-You can add this column when you assume or not the representative gene. PPanGGOLiN will guess that this column is to precise the fragmented gene and assume if it must assert the representative gene
+The position of this column depends on whether you include a representative gene column:
+- Without a representative gene column, the fragmented gene column should be in the **third position**.
+- With a representative gene column, it should appear in the **fourth position**.
 
-Here is a minimal example of your clustering file with fragmented gene precise:
-
+##### Example 1: Clustering file without representative gene column (fragmented gene in 3rd column):
 ```
-Family_A    Gene_1  Gene_2
-Family_A    Gene_2  Gene_2
-Family_A    Gene_3  Gene_2  F
-Family_B    Gene_4  Gene_4
-Family_B    Gene_5  Gene_4
-Family_C    Gene_6  Gene_6  F
+Family_A	Gene_1
+Family_A	Gene_2
+Family_A	Gene_3	F
+Family_B	Gene_4
+Family_B	Gene_5
+Family_C	Gene_6	F
+```
+
+##### Example 2: Clustering file with representative gene column (fragmented gene in 4th column):
+```
+Family_A	Gene_1	Gene_2
+Family_A	Gene_2	Gene_2
+Family_A	Gene_3	Gene_2	F
+Family_B	Gene_4	Gene_4
+Family_B	Gene_5	Gene_4
+Family_C	Gene_6	Gene_6	F
 ```
 
 ```{warning}
-*Attention: Column Order is Important!*
+*Attention: Column Order Matters!*
 
-Please ensure that the columns are ordered as follows:
-1. The cluster identifier
-2. The gene ID
-3. The representative ID (if provided)
-4. The fragmented status of the gene (if provided)
+Please ensure that your columns follow the correct order:
+1. Cluster identifier
+2. Gene ID
+3. Representative gene ID (if present)
+4. Fragmented status ('F' if the gene is fragmented, or leave blank)
 
-If you do not include a representative ID, then the fragmented status should be in the third column.
+If no representative gene column is included, the fragmented status should be placed in the **third column**.
 ```
 
 ### Defragmentation

--- a/docs/user/PangenomeAnalyses/pangenomeCluster.md
+++ b/docs/user/PangenomeAnalyses/pangenomeCluster.md
@@ -124,17 +124,17 @@ flowchart TD
 
 #### Specify the representative gene
 
-It's possible to indicate which gene is the representative gene by adding a column between the gene family name.
+It's possible to indicate which gene is the representative gene by adding a third column.
 
 
-Here is a minimal example of your clustering file:
+Here is a minimal example of your clustering file with the third column being the representative gene:
 
 ```
-Family_A    Gene_2  Gene_1
+Family_A    Gene_1  Gene_2
 Family_A    Gene_2  Gene_2
-Family_A    Gene_2  Gene_3
+Family_A    Gene_3  Gene_2
+Family_B    Gene_4  Gene_4
 Family_B    Gene_5  Gene_4
-Family_B    Gene_5  Gene_5
 Family_C    Gene_6  Gene_6
 ```
 
@@ -181,18 +181,24 @@ You can add this column when you assume or not the representative gene. PPanGGOL
 Here is a minimal example of your clustering file with fragmented gene precise:
 
 ```
-Family_A    Gene_2  Gene_1  
-Family_A    Gene_2  Gene_2  
-Family_A    Gene_2  Gene_3  'F'
-Family_B    Gene_5  Gene_4  
-Family_B    Gene_5  Gene_5  
-Family_C    Gene_6  Gene_6  'F'
+Family_A    Gene_1  Gene_2
+Family_A    Gene_2  Gene_2
+Family_A    Gene_3  Gene_2  F
+Family_B    Gene_4  Gene_4
+Family_B    Gene_5  Gene_4
+Family_C    Gene_6  Gene_6  F
 ```
 
 ```{warning}
-*The column order is
-important !*  You must first provide the cluster identifier, the representative id, and then the gene id to finish with
-the fragmented status of the gene.
+*Attention: Column Order is Important!*
+
+Please ensure that the columns are ordered as follows:
+1. The cluster identifier
+2. The gene ID
+3. The representative ID (if provided)
+4. The fragmented status of the gene (if provided)
+
+If you do not include a representative ID, then the fragmented status should be in the third column.
 ```
 
 ### Defragmentation

--- a/docs/user/PangenomeAnalyses/pangenomeStat.md
+++ b/docs/user/PangenomeAnalyses/pangenomeStat.md
@@ -147,7 +147,7 @@ To generate these files, use the `write_pangenome` subcommand with the `--partit
 
 #### Gene Families to Gene Associations
 
-The `gene_families.tsv` file follows the format produced by [MMseqs2](https://github.com/soedinglab/MMseqs2) using the `createtsv` subcommand. The file consists of four columns:
+The `gene_families.tsv` file consists of four columns:
 
 1. **Gene Family ID**: The identifier for the gene family.
 2. **Gene ID**: The identifier for the gene.

--- a/docs/user/PangenomeAnalyses/pangenomeStat.md
+++ b/docs/user/PangenomeAnalyses/pangenomeStat.md
@@ -144,10 +144,19 @@ To generate these files, use the `write_pangenome` subcommand with the `--partit
 `ppanggolin write_pangenome -p pangenome.h5 --partitions`
 
 
-#### Gene Families to Genes Associations
 
-The `gene_families.tsv` file mirrors the format provided by [MMseqs2](https://github.com/soedinglab/MMseqs2) through its `createtsv` subcommand. This file structure comprises three columns: the gene family name in the first column, the gene names in the second, and a third column that remains empty or contains an "F" to denote potential gene fragments instead of complete genes. This indication appears only if the [defragmentation](./pangenomeCluster.md#defragmentation) pipeline has been used.
+#### Gene Families to Gene Associations
+
+The `gene_families.tsv` file follows the format produced by [MMseqs2](https://github.com/soedinglab/MMseqs2) using the `createtsv` subcommand. The file consists of four columns:
+
+1. **Gene Family ID**: The identifier for the gene family.
+2. **Gene ID**: The identifier for the gene.
+3. **Local ID** (if applicable): This column is used when gene IDs from annotation files are not unique. In such cases, `ppanggolin` assigns an internal ID to genes, and this column helps map the internal ID to the local ID from the annotation file.
+4. **Fragmentation Status**: This column indicates whether the gene is fragmented. It is either empty or contains an "F" to signify potential gene fragments instead of complete genes. This status is provided only if the [defragmentation](./pangenomeCluster.md#defragmentation) pipeline has been used, which is the default behavior.
 
 To generate this file, use the `write_pangenome` subcommand with the `--families_tsv` flag:
 
-`ppanggolin write_pangenome -p pangenome.h5 --families_tsv`
+```bash
+ppanggolin write_pangenome -p pangenome.h5 --families_tsv
+```
+

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -793,7 +793,10 @@ def read_org_gff(organism: str, gff_file_path: Path, circular_contigs: List[str]
     correct_putative_overlaps(org.contigs)
 
     # GET THE FASTA SEQUENCES OF THE GENES
-    if has_fasta and fasta_string != "":
+    if fasta_string == "":
+        has_fasta = False
+
+    if has_fasta:
         contig_sequences = read_fasta(org, fasta_string.split('\n'))  # _ is total contig length
         for contig in org.contigs:
             if contig.length != len(contig_sequences[contig.name]):
@@ -1073,9 +1076,10 @@ def read_annotations(pangenome: Pangenome, organisms_file: Path, cpu: int = 1, p
                 futures.append(future)
 
             for future in futures:
-                org, flag = future.result()
+                org, has_dna_sequence = future.result()
                 pangenome.add_organism(org)
-                if not flag:
+
+                if not has_dna_sequence:
                     pangenome.status["geneSequences"] = "No"
 
     # decide whether we use local ids or ppanggolin ids.

--- a/ppanggolin/cluster/cluster.py
+++ b/ppanggolin/cluster/cluster.py
@@ -441,7 +441,8 @@ def read_clustering_file(families_tsv_path: Path) -> Tuple[pd.DataFrame, bool]:
         families_tsv_path,
         sep="\t",
         header=None,
-        compression=compress_type if compress_type is not None else 'infer'
+        compression=compress_type if compress_type is not None else 'infer',
+        dtype=str
     )
     
     # Process DataFrame based on the number of columns

--- a/ppanggolin/formats/writeFlatGenomes.py
+++ b/ppanggolin/formats/writeFlatGenomes.py
@@ -589,6 +589,11 @@ def write_flat_genome_files(pangenome: Pangenome, output: Path, table: bool = Fa
                 organism_args["annotation_sources"] = {}
      
         if table:
+            # create _genePerOrg dict with get_org_dict methodbefore the multiprocessing to prevent putative errors.
+            # As this is used in multiprocessing when computing nb_copy_in_genome.
+            for family in pangenome.gene_families:
+                family.get_org_dict()
+
             organism_args.update({"need_regions": need_dict['need_rgp'],
                                   "need_modules": need_dict['need_modules'],
                                   "need_spots": need_dict['need_spots']})

--- a/ppanggolin/geneFamily.py
+++ b/ppanggolin/geneFamily.py
@@ -439,7 +439,7 @@ class GeneFamily(MetaFeatures):
         if len(self._genePerOrg) == 0:
             _ = self.get_org_dict()
         if org not in self._genePerOrg:
-            raise KeyError(f"Genome does not have the gene family: {self.name}")
+            raise KeyError(f"Genome {org.name} does not have the gene family: {self.name}")
         yield from self._genePerOrg[org]
 
 

--- a/ppanggolin/genome.py
+++ b/ppanggolin/genome.py
@@ -222,7 +222,8 @@ class Feature(MetaFeatures):
 
         :raise AssertionError: Sequence must be a string
         """
-        assert isinstance(sequence, str), f"'str' type was expected but you provided a '{type(sequence)}' type object"
+        assert isinstance(sequence, str), f"'str' type was expected for dna sequence but you provided a '{type(sequence)}' type object"
+        
         self.dna = sequence
 
     def string_coordinates(self) -> str:

--- a/ppanggolin/pangenome.py
+++ b/ppanggolin/pangenome.py
@@ -129,10 +129,10 @@ class Pangenome:
 
         :return: Returns the gene that has the ID `gene_id`
 
-        :raises AssertionError: If the `gene_id` is not an integer
+        :raises AssertionError: If the `gene_id` is not a string
         :raises KeyError: If the `gene_id` is not in the pangenome
         """
-        assert isinstance(gene_id, str), "Gene id should be an integer"
+        assert isinstance(gene_id, str), f"The provided gene id ({gene_id}) should be a string and not a {type(gene_id)}"
 
         try:
             gene = self._gene_getter[gene_id]

--- a/ppanggolin/pangenome.py
+++ b/ppanggolin/pangenome.py
@@ -232,23 +232,23 @@ class Pangenome:
 
     def add_gene_family(self, family: GeneFamily):
         """
-        Get the :class:`ppanggolin.geneFamily.GeneFamily` object that has the given `name`.
-        If it does not exist, creates it.
-
-        :param family: The gene family to add in pangenomes
-
-        :raises KeyError: Exception if family with the same name already in pangenome
-        :raises Exception: Unexpected exception
+        Adds the given gene family to the pangenome. If a family with the same name already exists, raises a KeyError.
+        
+        :param family: The gene family to add to the pangenome
+        :raises KeyError: If a family with the same name already exists
+        :raises Exception: For any unexpected exceptions
         """
         try:
-            _ = self.get_gene_family(family.name)
+            self.get_gene_family(family.name)
         except KeyError:
+            # Family does not exist, so add it
             self._fam_getter[family.name] = family
             self.max_fam_id += 1
         except Exception as error:
-            raise Exception(error)
+            raise Exception(f"An unexpected error occurred when adding family {family} to pangenome: {str(error)}") from error
         else:
-            raise KeyError("Gene Family already exist")
+            raise KeyError(f"Cannot add family {family.name}: A family with the same name already exists.")
+
 
     """Graph methods"""
     @property


### PR DESCRIPTION
This PR addresses a few issues that users encountered when running the cluster command with an external cluster file.

Fixes made:
- **Avoid unnecessary gene sequence loading**: Previously, gene sequences were being requested and loaded even when using an external cluster file. This was a problem if the pangenome didn’t have sequences. 
- **Ensure correct data types for gene and family IDs**: When gene IDs were purely numeric, pandas was reading them as integers, causing mismatches since gene and family IDs should be treated as strings. We now explicitly ensure these columns are read as strings, avoiding any confusion.
- **Clear error for missing genes**: If a gene from the cluster file wasn’t found in the pangenome, the code didn’t raise an error immediately. This led to confusing errors later. Now a clear error is raised. 
- **Clear error for singleton**: When a singleton family is created and that a family with the same name is already contained in the pangenome, an unclear error was raised. Now the error states clearly the problem.  
- **Fix inconsistencies in documentation**:  The column order for external clustering described in the documentation was inconsistent with the implementation in the code, as highlighted in issue #279. This is now fixed. The correct order is:  family_id gene_id representative id. The families_tsv documentation was also out of date.
