### PR TITLE
Fix empty metadata tag in annotation file

### DIFF
--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -360,13 +360,17 @@ def combine_contigs_metadata(contig_to_metadata: Dict[str, Dict[str, str]]) -> T
 
     # Filter tags that would have a / as it is forbidden when writing the table in HDF5. Such tag can appear with db_xref formatting
     invalid_tag_names = []
-    for tag, _ in set(all_tag_to_value):
+    for tag, value in set(all_tag_to_value):
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 check_name_validity(tag)
         except ValueError as err:
             logging.getLogger("PPanGGOLiN").debug(f"{err}. The tag {tag} is ignored for metadata.")
+            invalid_tag_names.append(tag)
+
+        if value == "":
+            logging.getLogger("PPanGGOLiN").debug(f"Ignoring tag '{tag}' for metadata due to an empty value.")
             invalid_tag_names.append(tag)
 
     all_tag_to_value = [(tag, value) for tag, value in all_tag_to_value if tag not in invalid_tag_names]


### PR DESCRIPTION
This PR addresses an issue where genome tags in GBFF files are empty. These tags were being included as genome metadata, but their zero length caused problems when writing to the pangenome file.

To fix this, I’ve implemented a filter to ignore any tags with empty values. Instead a debug log will now be generated to provide info into what’s being filtered out. I also improved the error message when dealing with wrong metadata.

This should resolve issue #285.

### Example of an Empty Tag Encountered
One example of an empty tag is `genome_md5`, which looks like this:

```
LOCUS       ctg.s2.38.arrow        14924 bp    DNA     linear   UNK 
DEFINITION  Fusobacterium sp. nucleatum KCOM1001
ACCESSION   ctg.s2.38.arrow
KEYWORDS    .
SOURCE      Fusobacterium sp. nucleatum KCOM1001.
  ORGANISM  Fusobacterium sp. nucleatum KCOM1001
            Bacteria.
FEATURES             Location/Qualifiers
     source          1..14924
                     /mol_type="genomic DNA"
                     /db_xref="taxon:6666666"
                     /genome_md5=""
                     /project="mzepedar_6666666"
                     /genome_id="6666666.722438"
                     /organism="Fusobacterium sp. nucleatum KCOM1001"
```

