### PR TITLE
Filter non ASCII character

### DIFF
--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -1254,3 +1254,28 @@ def run_subprocess(cmd: List[str], output: Path = None, msg: str = "Subprocess f
         if output is not None:
             with open(output, 'w') as fout:
                 fout.write(result.stdout)
+
+
+
+def has_non_ascii(string_to_test: str) -> bool:
+    """
+    Check if a string contains any non-ASCII characters.
+
+    :param string_to_test: The string to check for non-ASCII characters.
+    :return: True if the string contains non-ASCII characters, False otherwise.
+    """
+    try:
+        string_to_test.encode('ascii')
+    except UnicodeEncodeError:
+        return True
+    return False
+
+def replace_non_ascii(string_with_ascii: str, replacement_string: str = "_") -> str:
+    """
+    Replace all non-ASCII characters in a string with a specified replacement string.
+
+    :param string_with_ascii: The string potentially containing non-ASCII characters.
+    :param replacement_string: The string to replace non-ASCII characters with (default is '_').
+    :return: A new string where all non-ASCII characters have been replaced.
+    """
+    return re.sub(r'[^\x00-\x7F]+', replacement_string, string_with_ascii)

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -7,8 +7,7 @@ import bz2
 import zipfile
 from typing import Generator
 
-from ppanggolin.utils import is_compressed, read_compressed_or_not, write_compressed_or_not
-
+from ppanggolin.utils import is_compressed, read_compressed_or_not, write_compressed_or_not,  has_non_ascii, replace_non_ascii
 
 class TestCompressed:
     """
@@ -157,3 +156,27 @@ class TestWriteCompressedOrNot:
             f.write("Test data")
         with open(plain_file_path, 'r') as f:
             assert f.read() == "Test data"
+
+
+# Test cases for has_non_ascii
+@pytest.mark.parametrize("input_string, expected", [
+    ("Escherichia_coli", False),  # All ASCII characters
+    ("Escherichia_colí", True),   # Contains non-ASCII character 'í'
+    ("simple_string", False),     # Simple ASCII string
+    ("Ωmega", True),              # Contains non-ASCII character 'Ω'
+    ("", False),                  # Empty string should return False
+])
+def test_has_non_ascii(input_string, expected):
+    assert has_non_ascii(input_string) == expected
+
+# Test cases for replace_non_ascii
+@pytest.mark.parametrize("input_string, replacement, expected", [
+    ("Escherichia_coli", "_", "Escherichia_coli"),  # All ASCII characters, no replacement needed
+    ("Escherichia_colí", "_", "Escherichia_col_"),  # Replace 'í' with '_'
+    ("Ωmega", "-", "-mega"),                        # Replace 'Ω' with '-'
+    ("Escherichia_Ωcoli", "X", "Escherichia_Xcoli"),# Replace 'Ω' with 'X'
+    ("", "_", ""),                                  # Empty string, no replacement
+])
+def test_replace_non_ascii(input_string, replacement, expected):
+    assert replace_non_ascii(input_string, replacement) == expected
+


### PR DESCRIPTION

We’ve noticed that many issues in PPanGGOLiN are caused by non-ASCII characters in the `product` field of CDS annotations. This often happens with genomes annotated by Bakta, where some COG annotations include these characters (check out the related Bakta issue [here](https://github.com/oschwengers/bakta/issues/215)).

### Problem

The HDF5 tables used by PPanGGOLiN can’t handle non-ASCII characters. When these characters show up in the `product` field, they cause confusing errors and failures in the tool.

### Implemented Solution

This PR fixes the problem by automatically checking for non-ASCII characters in the `product` field and replacing them with underscores (`_`). This change will help PPanGGOLiN run smoothly without errors related to non-ASCII characters.

### Related PPanGGOLiN Issues
- #95
- #175
- #222
- #233
- #252 
