### PR TITLE
Adjust logging and fix unwanted progress bar

### DIFF
--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -823,7 +823,7 @@ def read_org_gbff(
         contig.add_metadata(Metadata(source="annotation_file", **metadata_dict))
 
     if used_transl_table_arg:
-        logging.getLogger("PPanGGOLiN").info(
+        logging.getLogger("PPanGGOLiN").debug(
             f"transl_table tag was not found for {used_transl_table_arg} CDS "
             f"in {gbff_file_path}. Provided translation_table argument value was used instead: {translation_table}."
         )

--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -795,6 +795,7 @@ def annotate_input_genes_with_pangenome_families(
                 identity=identity,
                 coverage=coverage,
                 translation_table=translation_table,
+                disable_bar=disable_bar,
             )
         else:
             _, seqid_to_gene_family = get_input_seq_to_family_with_all(


### PR DESCRIPTION
This small PR addresses two issues:
- Changes the log level for missing translation table entries in input genome files from INFO to DEBUG to reduce log clutter when this info is absent across files.
- Fixed a missing application of the `disable_bar` flag in the projection step when using the `fast` flag. This prevent unwanted progress bars from appearing when `--disable_prog_bar` is enabled.