### PR TITLE
Fix Contig Length Detection for GFF Parsing

### DIFF
--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -1034,15 +1034,22 @@ def read_org_gff(
                             dbxref_metadata
                         )
 
-                    if contig is not None and (
+                    if (
                         "IS_CIRCULAR" in attributes
                         and attributes["IS_CIRCULAR"] == "true"
                     ):
-                        logging.getLogger("PPanGGOLiN").debug(
-                            f"Contig {contig.name} is circular."
-                        )
-                        contig.is_circular = True
-                        assert contig.name == fields_gff[gff_seqname]
+                        contig_name = fields_gff[gff_seqname]
+
+                        if contig is not None:
+                            logging.getLogger("PPanGGOLiN").debug(
+                                f"Contig {contig.name} is circular."
+                            )
+                            contig.is_circular = True
+                            assert contig.name == contig_name
+                        else:
+                            # contig object has not been initialized yet.
+                            # let's keep the circularity info in the circular_contigs list
+                            circular_contigs.append(contig_name)
 
                 elif fields_gff[gff_type] == "CDS" or "RNA" in fields_gff[gff_type]:
 

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -1220,7 +1220,7 @@ def read_org_gff(
         add_metadata_from_gff_file(contig_name_to_region_info, org, gff_file_path)
 
     if used_transl_table_arg:
-        logging.getLogger("PPanGGOLiN").info(
+        logging.getLogger("PPanGGOLiN").debug(
             f"transl_table tag was not found for {used_transl_table_arg} CDS "
             f"in {gff_file_path}. Provided translation_table argument value was used instead: {translation_table}."
         )

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -1120,9 +1120,9 @@ def read_org_gff(
                             gene_frame = int(fields_gff[frame])
 
                         if (
-                            gene_id in id_attr_to_gene_id
+                            id_attribute in id_attr_to_gene_id
                         ):  # the ID has already been seen at least once in this genome
-                            existing_gene = id_attr_to_gene_id[gene_id]
+                            existing_gene = id_attr_to_gene_id[id_attribute]
                             new_gene_info = {
                                 "strand": fields_gff[gff_strand],
                                 "type": fields_gff[gff_type],
@@ -1141,7 +1141,7 @@ def read_org_gff(
 
                         gene = Gene(org.name + "_CDS_" + str(gene_counter).zfill(4))
 
-                        id_attr_to_gene_id[gene_id] = gene
+                        id_attr_to_gene_id[id_attribute] = gene
 
                         # here contig is filled in order, so position is the number of genes already stored in the contig.
                         gene.fill_annotations(

--- a/ppanggolin/genome.py
+++ b/ppanggolin/genome.py
@@ -553,8 +553,6 @@ class Contig(MetaFeatures):
     @property
     def length(self) -> Union[int, None]:
         """Get the length of the contig"""
-        if self._length is None:
-            logging.getLogger("PPanGGOLiN").warning("Contig length is unknown")
         return self._length
 
     @length.setter

--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -20,7 +20,7 @@ import networkx as nx
 import yaml
 
 # # local libraries
-from ppanggolin.annotate.synta import read_fasta, get_dna_sequence
+from ppanggolin.annotate.synta import get_contigs_from_fasta_file, get_dna_sequence
 from ppanggolin.annotate.annotate import (
     init_contig_counter,
     read_anno_file,
@@ -679,7 +679,7 @@ def get_gene_sequences_from_fasta_files(organisms, genome_name_to_annot_path):
         org_fasta_file = genome_name_to_annot_path[org.name]["path"]
 
         with read_compressed_or_not(org_fasta_file) as currFastaFile:
-            org_contig_to_seq = read_fasta(org, currFastaFile)
+            org_contig_to_seq = get_contigs_from_fasta_file(org, currFastaFile)
 
         for contig in org.contigs:
             try:
@@ -997,7 +997,7 @@ def retrieve_gene_sequences_from_fasta_file(input_organism, fasta_file):
     """
 
     with read_compressed_or_not(fasta_file) as currFastaFile:
-        contig_id2seq = read_fasta(input_organism, currFastaFile)
+        contig_id2seq = get_contigs_from_fasta_file(input_organism, currFastaFile)
 
     for contig in input_organism.contigs:
         try:

--- a/tests/annotate/test_annotate.py
+++ b/tests/annotate/test_annotate.py
@@ -16,6 +16,8 @@ from ppanggolin.annotate.annotate import (
     shift_end_coordinates,
 )
 
+from ppanggolin.annotate.synta import check_sequence_tuple, parse_fasta
+
 
 @pytest.mark.parametrize(
     "input_string, expected_positions, expected_complement, expected_partialgene_start, expected_partialgene_end",
@@ -531,3 +533,39 @@ def test_shift_start_coordinates(coordinates, shift, expected):
 def test_shift_end_coordinates(coordinates, shift, expected):
     result = shift_end_coordinates(coordinates, shift)
     assert result == expected
+
+
+def test_check_sequence_tuple_valid():
+    name, sequence = check_sequence_tuple("seq1", "ATGC")
+    assert name == "seq1"
+    assert sequence == "ATGC"
+
+
+def test_check_sequence_tuple_empty_name():
+    with pytest.raises(ValueError):
+        check_sequence_tuple("", "ATGC")
+
+
+def test_check_sequence_tuple_empty_sequence():
+    with pytest.raises(ValueError):
+        check_sequence_tuple("seq1", "")
+
+
+def test_parse_fasta_valid():
+    fasta_data = ">seq1\nATGC\n>seq2\nGCTA"
+
+    result = list(parse_fasta(fasta_data.split("\n")))
+
+    assert result == [("seq1", "ATGC"), ("seq2", "GCTA")]
+
+
+def test_parse_fasta_empty_sequence():
+    fasta_data = ">seq1\n>seq2\nGCTA"
+    with pytest.raises(ValueError):
+        list(parse_fasta(fasta_data.split("\n")))
+
+
+def test_parse_fasta_no_header():
+    fasta_data = "seq1\nATGC\nseq2\nGCTA".split("\n")
+    with pytest.raises(ValueError):
+        list(parse_fasta(fasta_data))


### PR DESCRIPTION
This PR fixes the bug reported in [issue #299](https://github.com/labgem/PPanGGOLiN/issues/299).

### Problem Description

When parsing a GFF file, the contig length is usually extracted from the line:

```
##sequence-region <contig name> 1 <end position>
```

This length is used to adjust gene coordinates that overlap the contig edge, splitting such genes into two parts to ensure they remain within the contig boundaries (as introduced in [PR #206](https://github.com/labgem/PPanGGOLiN/pull/206)).

However, this line is optional according to the [GFF3 specification](https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md). As a result, when this line is missing, the contig length is undefined, causing errors during the correction of overlapping gene coordinates.

### Solution

To resolve this issue, the correction of overlapping gene coordinates is now performed only after defining the contig length through one of these methods : 

1. **Primary check**: Extract the contig length from the GFF file if the `##sequence-region` line is present.
2. **Fallback check**: Parse the contig length from the FASTA sequences, whether embedded in the GFF file or provided as an external FASTA file.

If no FASTA sequence is provided, the coordinate correction step is skipped. This omission does not pose a problem since the correction is primarily necessary when extracting gene sequences from the FASTA file.
