### PR TITLE
Add RGP Score to Pangenome Table

### DIFF
--- a/ppanggolin/RGP/genomicIsland.py
+++ b/ppanggolin/RGP/genomicIsland.py
@@ -4,7 +4,7 @@
 import logging
 import argparse
 from pathlib import Path
-from typing import Set, Iterable, List, Tuple
+from typing import Set, Iterable
 
 # installed libraries
 from tqdm import tqdm

--- a/ppanggolin/formats/readBinaries.py
+++ b/ppanggolin/formats/readBinaries.py
@@ -971,7 +971,13 @@ def read_rgp(pangenome: Pangenome, h5f: tables.File, disable_bar: bool = False):
             region = pangenome.get_region(row["RGP"].decode())
         except KeyError:
             region = Region(row["RGP"].decode())
+
+            # starting from v2.2.1 score is part of RGP table in h5.
+            if "score" in row.dtype.names:
+                region.score = row["score"]
+
             pangenome.add_region(region)
+
         gene = pangenome.get_gene(row["gene"].decode())
         region.add(gene)
     pangenome.status["predictedRGP"] = "Loaded"

--- a/ppanggolin/formats/writeBinaries.py
+++ b/ppanggolin/formats/writeBinaries.py
@@ -299,6 +299,7 @@ def rgp_desc(max_rgp_len, max_gene_len):
     return {
         "RGP": tables.StringCol(itemsize=max_rgp_len),
         "gene": tables.StringCol(itemsize=max_gene_len),
+        "score": tables.UInt32Col(),
     }
 
 
@@ -355,6 +356,7 @@ def write_rgp(
         for gene in region.genes:
             rgp_row["RGP"] = region.name
             rgp_row["gene"] = gene.ID
+            rgp_row["score"] = region.score
             rgp_row.append()
     rgp_table.flush()
 

--- a/ppanggolin/region.py
+++ b/ppanggolin/region.py
@@ -51,7 +51,7 @@ class Region(MetaFeatures):
         super().__init__()
         self._genes_getter = {}
         self.name = name
-        self.score = 0
+        self.score = None
         self._starter = None
         self._stopper = None
         self._coordinates = None


### PR DESCRIPTION
Small PR following #303
- Added the RGP score to the pangenome table to include it in the RGP output file when it is produced with the `writepangenome` command.
- Changed the default RGP score from 0 to None to avoid incorrect scores in the output.
- Ensured compatibility with older pangenome files without RGP scores.