### PR TITLE
Fix incorrect argument handling for spot drawing in workflow commands

### DIFF
--- a/ppanggolin/workflow/all.py
+++ b/ppanggolin/workflow/all.py
@@ -283,7 +283,7 @@ def launch_workflow(
             draw_spots(
                 pangenome=pangenome,
                 output=args.output / "spot_figures",
-                spot_list="all",
+                spot_list=args.draw.spots,
                 disable_bar=args.disable_prog_bar,
             )
             spot_time += time.time() - start_spot_drawing

--- a/ppanggolin/workflow/all.py
+++ b/ppanggolin/workflow/all.py
@@ -277,7 +277,7 @@ def launch_workflow(
 
     if not args.no_flat_files:
 
-        if panrgp and args.draw.spots:
+        if panrgp and args.draw.draw_spots:
             start_spot_drawing = time.time()
             mk_outdir(args.output / "spot_figures", force=True)
             draw_spots(


### PR DESCRIPTION
### Description of the Issue  
The workflow commands incorrectly handle the argument for controlling whether spots should be drawn.  

In the `draw` command, the correct argument to enable spot drawing is `--draw_spots`. However, in the workflow code, the check to decide whether to draw spots mistakenly uses the `spots` argument instead.  

The `spots` argument is a valid parameter of the `draw` command, but it serves a different purpose: specifying which spots to draw (defaulting to all). This mismatch means it’s currently impossible to skip drawing spots unless the `--no_flat_files` option is used. As a result, users cannot selectively avoid `draw_spots` while still generating parts of the flat file output.  

### Fix  
This PR resolves the issue by ensuring the workflow commands use the correct `--draw_spots` argument to control spot drawing.  