### PR TITLE
Increase recursion limit in draw spot to prevent error

### DIFF
--- a/ppanggolin/figures/draw_spot.py
+++ b/ppanggolin/figures/draw_spot.py
@@ -100,8 +100,9 @@ def row_order_gene_lists(gene_lists: list) -> list:
         return gene_lists
 
     if len(gene_lists) > sys.getrecursionlimit():
+        print("NO changin...")
         sys.setrecursionlimit(
-            len(gene_lists)
+            len(gene_lists) * 2 - 1
         )  # we need the recursion limit to be higher than the number of regions.
 
     for index, genelist in enumerate([genelist[0] for genelist in gene_lists]):

--- a/ppanggolin/figures/draw_spot.py
+++ b/ppanggolin/figures/draw_spot.py
@@ -100,7 +100,6 @@ def row_order_gene_lists(gene_lists: list) -> list:
         return gene_lists
 
     if len(gene_lists) > sys.getrecursionlimit():
-        print("NO changin...")
         sys.setrecursionlimit(
             len(gene_lists) * 2 - 1
         )  # we need the recursion limit to be higher than the number of regions.


### PR DESCRIPTION
I ran into a `RecursionError: maximum recursion depth exceeded while calling a Python object` while generating spot figures for a Listeria monocytogenes pangenome with ~2k genomes.  

This issue was already reported in issue #96 

To fix it, I’ve increased the recursion limit to twice the number of RGPs in the dendrogram. This should ensure we don’t hit the limit again, even with large pangenomes.  
