### PR TITLE
Test new macos runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         echo "NUM_CPUS=$nb_cpu_linux" >> "$GITHUB_ENV"
 
     - name: Get core number on macos
-      if: matrix.os == 'macos-13'
+      if: matrix.os == 'macos-latest'
       run: |
         nb_cpu_macos=`sysctl -n hw.ncpu`
         echo "Number of cores avalaible on the current macos runner $nb_cpu_macos"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-13']
+        os: ['ubuntu-latest', 'macos-latest']
         python-version: ['3.8', '3.12']
  
     steps:


### PR DESCRIPTION
Hello,

This is a draft PR to see how the arm-based CPU macOS runners do, now that bioconda supports arm64 recipes on macOS as well (so that we don't get stuck on macos-13, which is the lowest github runner version nowadays).

Will merge only if it goes well in the CI.

Adelme