### PR TITLE
Improve python dependencies

### DIFF
--- a/.github/workflows/check_doc.yml
+++ b/.github/workflows/check_doc.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: '3.9'
     - name: install ppanggolin with python deps and doc deps
-      run: pip install .[doc,python_deps]
+      run: pip install .[doc]
 
     - name: Complete workflow
       shell: bash -l {0}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,6 @@ python:
       path: .
       extra_requirements:
         - doc
-        - python_deps
 
 # Set the OS, Python version and other tools you might need
 build:

--- a/ppanggolin_env.yaml
+++ b/ppanggolin_env.yaml
@@ -4,18 +4,18 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - tqdm=4
-  - pytables=3
-  - pyrodigal=3
-  - networkx=3
+  - tqdm>=4.0.0,<5.0.0
+  - pytables>=3.0.0,<4.0.0
+  - pyrodigal>=3.0.0,<4.0.0
+  - networkx>=3.0.0,<4.0.0
   - dataclasses=0.8
-  - scipy=1
-  - plotly=5
-  - gmpy2=2
-  - pandas=2
-  - numpy=1
-  - bokeh=3
-  # Tool that are not in python 
+  - scipy>=1.0.0,<2.0.0
+  - plotly>=5.0.0,<6.0.0
+  - gmpy2>=2.0.0,<3.0.0
+  - pandas>=2.0.0,<3.0.0
+  - numpy>1.24.0,<2.0.0
+  - bokeh>=3.0.0,<4.0.0
+  # Tools that are not in Python 
   - infernal=1
   - aragorn=1
   - mmseqs2=15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,8 @@ Documentation = "https://ppanggolin.readthedocs.io"
 [project.scripts]
 ppanggolin = "ppanggolin.main:main"
 
-[tool.setuptools]
-packages = ["ppanggolin"]
+[tool.setuptools.packages.find]
+include = ["ppanggolin*"]
 
 #[tool.setuptools.package-data]
 #mypkg = ["*.txt", "*.rst"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,20 @@ classifiers=[
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Bio-Informatics"]
 requires-python = ">=3.9"
+
+dependencies = [
+    "tqdm>=4.0.0,<5.0.0",
+    "tables>=3.0.0,<4.0.0",
+    "pyrodigal>=3.0.0,<4.0.0",
+    "networkx>=3.0.0,<4.0.0",
+    "scipy>=1.0.0,<2.0.0",
+    "plotly>=5.0.0,<6.0.0",
+    "gmpy2>=2.0.0,<3.0.0",
+    "pandas>=2.0.0,<3.0.0",
+    "numpy>1.24.0,<3.0.0",
+    "bokeh>=3.0.0,<4.0.0"
+]
+
 license = {file="LICENSE.txt"}
 
 [project.optional-dependencies]
@@ -51,18 +65,7 @@ test = [
     "pytest==7",
     "black==24.*"
 ]
-python_deps = [
-    "tqdm==4.*",
-    "tables==3.*",
-    "pyrodigal==3.*",
-    "networkx==3.*",
-    "scipy==1.*",
-    "plotly==5.*",
-    "gmpy2==2.*",
-    "pandas==2.*",
-    "numpy==1.24",
-    "bokeh==3.*"
-]
+
 #
 [project.urls]
 Homepage = "https://labgem.genoscope.cns.fr/2023/04/27/ppanggolin/"


### PR DESCRIPTION
This PR makes the following updates:
- Moves all Python dependencies from optional to main in `pyproject.toml`.
- Enforces `numpy > 1.24` to ensure compatibility with Python 1.12.
- Ensures all sub-packages of `ppanggolin` are included during installation.
