### PR TITLE
Check when external tools are not installed

### DIFF
--- a/.github/workflows/black_lint.yml
+++ b/.github/workflows/black_lint.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
-          version: pyproject.toml
+          use_pyproject: true

--- a/.github/workflows/black_lint.yml
+++ b/.github/workflows/black_lint.yml
@@ -8,3 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
+        with:
+          version: pyproject.toml

--- a/ppanggolin/align/alignOnPang.py
+++ b/ppanggolin/align/alignOnPang.py
@@ -21,6 +21,7 @@ from ppanggolin.utils import (
     read_compressed_or_not,
     create_tmpdir,
     run_subprocess,
+    check_tools_availability,
 )
 from ppanggolin.pangenome import Pangenome
 from ppanggolin.region import Spot
@@ -721,6 +722,8 @@ def align(
     :param disable_bar: If True, disable the progress bar.
     :param keep_tmp: If True, keep temporary files.
     """
+
+    check_tools_availability(["mmseqs"])
 
     tmpdir = Path(tempfile.gettempdir()) if tmpdir is None else tmpdir
     if pangenome.status["geneFamilySequences"] not in ["inFile", "Loaded", "Computed"]:

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -36,6 +36,7 @@ from ppanggolin.utils import (
     check_input_files,
     has_non_ascii,
     replace_non_ascii,
+    check_tools_availability,
 )
 from ppanggolin.formats import write_pangenome
 from ppanggolin.metadata import Metadata

--- a/ppanggolin/cluster/cluster.py
+++ b/ppanggolin/cluster/cluster.py
@@ -25,6 +25,7 @@ from ppanggolin.utils import (
     restricted_float,
     run_subprocess,
     create_tmpdir,
+    check_tools_availability,
 )
 from ppanggolin.formats.writeBinaries import write_pangenome, erase_pangenome
 from ppanggolin.formats.readBinaries import (
@@ -464,6 +465,9 @@ def clustering(
     :param disable_bar: Disable the progress bar during clustering.
     :param keep_tmp_files: Keep temporary files (useful for debugging).
     """
+
+    check_tools_availability(["mmseqs"])
+
     date = time.strftime("_%Y-%m-%d_%H-%M-%S", time.localtime())
     dir_name = f"clustering_tmpdir_{date}_PID{os.getpid()}"
     with create_tmpdir(tmpdir, basename=dir_name, keep_tmp=keep_tmp_files) as tmp_path:
@@ -840,6 +844,7 @@ def launch(args: argparse.Namespace):
                 "--infer_singletons option is not compatible with clustering "
                 "creation. To infer singleton you should give a clustering"
             )
+
         clustering(
             pangenome,
             args.tmpdir,

--- a/ppanggolin/context/searchGeneContext.py
+++ b/ppanggolin/context/searchGeneContext.py
@@ -25,6 +25,7 @@ from ppanggolin.utils import (
     create_tmpdir,
     read_compressed_or_not,
     extract_contig_window,
+    check_tools_availability,
 )
 from ppanggolin.pangenome import Pangenome
 from ppanggolin.align.alignOnPang import (
@@ -91,6 +92,8 @@ def align_sequences_to_families(
 
     :return: Set of gene families of interest and dict which link gene families to sequence ID
     """
+    check_tools_availability(["mmseqs"])
+
     # Alignment of sequences on pangenome families
     families_of_interest = set()
     family_2_input_seqid = {}

--- a/ppanggolin/formats/writeMSA.py
+++ b/ppanggolin/formats/writeMSA.py
@@ -16,7 +16,12 @@ from tqdm import tqdm
 from ppanggolin.genome import Gene
 from ppanggolin.geneFamily import GeneFamily
 from ppanggolin.pangenome import Pangenome
-from ppanggolin.utils import mk_outdir, restricted_float, run_subprocess
+from ppanggolin.utils import (
+    mk_outdir,
+    restricted_float,
+    run_subprocess,
+    check_tools_availability,
+)
 from ppanggolin.formats.readBinaries import check_pangenome_info
 from ppanggolin.genetic_codes import genetic_codes
 
@@ -354,6 +359,8 @@ def write_msa_files(
     :param force: force to write in the directory
     :param disable_bar: Disable progress bar
     """
+    check_tools_availability(["mafft"])
+
     tmpdir = Path(tempfile.gettempdir()) if tmpdir is None else tmpdir
 
     need_partitions = False

--- a/ppanggolin/formats/writeSequences.py
+++ b/ppanggolin/formats/writeSequences.py
@@ -24,6 +24,7 @@ from ppanggolin.utils import (
     restricted_float,
     detect_filetype,
     run_subprocess,
+    check_tools_availability,
 )
 from ppanggolin.formats.readBinaries import (
     check_pangenome_info,
@@ -135,6 +136,8 @@ def translate_genes(
 
     :return: Path to the MMSeqs2 database
     """
+    check_tools_availability(["mmseqs"])
+
     seq_nucdb = create_mmseqs_db(
         [sequences] if isinstance(sequences, Path) else sequences,
         "nucleotides_db",
@@ -188,6 +191,9 @@ def write_gene_protein_sequences(
     :param code: Genetic code use to translate nucleotide sequences to protein sequences
     :param disable_bar: Disable progress bar
     """
+
+    check_tools_availability(["mmseqs"])
+
     with create_tmpdir(
         tmp if tmp is not None else Path(tempfile.gettempdir()),
         basename="translateGenes",

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -8,6 +8,8 @@ import gzip
 import bz2
 import zipfile
 import argparse
+import inspect
+
 from io import TextIOWrapper
 from pathlib import Path
 from typing import (
@@ -1559,7 +1561,7 @@ def replace_non_ascii(string_with_ascii: str, replacement_string: str = "_") -> 
 
 
 def check_tools_availability(
-    tool_to_description: Union[Dict[str, str], List[str]]
+    tool_to_description: Union[Dict[str, str], List[str]],
 ) -> dict[str, bool]:
     """
     Check if the given command-line tools are available in the system's PATH.
@@ -1576,8 +1578,14 @@ def check_tools_availability(
 
     for tool, is_available in availability.items():
         if not is_available:
-            logging.getLogger("PPanGGOLiN").error(
-                f"The command '{tool}'{tool_to_description[tool]} is not found. Please install it to ensure proper functionality of PPanGGOLiN."
+            caller_frame = inspect.stack()[1]
+            caller_module = caller_frame.frame.f_globals["__name__"]
+            caller_function = caller_frame.function
+
+            logging.getLogger("PPanGGOLiN").warning(
+                f"Missing required command: '{tool}' {tool_to_description[tool]}. "
+                f"This check was triggered in '{caller_function}' inside module '{caller_module}'. "
+                "Please install the missing command to ensure proper functionality of PPanGGOLiN."
             )
 
     return availability

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -10,13 +10,25 @@ import zipfile
 import argparse
 from io import TextIOWrapper
 from pathlib import Path
-from typing import TextIO, Union, BinaryIO, Tuple, List, Set, Iterable, Dict, Any
+from typing import (
+    TextIO,
+    Union,
+    BinaryIO,
+    Tuple,
+    List,
+    Set,
+    Iterable,
+    Dict,
+    Any,
+    Optional,
+)
 from contextlib import contextmanager
 import tempfile
 import time
 from itertools import zip_longest
 import re
 import subprocess
+import shutil
 
 import networkx as nx
 from importlib.metadata import distribution
@@ -1488,28 +1500,35 @@ def get_consecutive_region_positions(
 
 def run_subprocess(
     cmd: List[str],
-    output: Path = None,
+    output: Optional[Path] = None,
     msg: str = "Subprocess failed with the following error:\n",
 ):
-    """Run a subprocess command and write the output to the given path.
-
-    :param cmd: list of program arguments
-    :param output: path to write the subprocess output
-    :param msg: message to print if the subprocess fails
-
-    :return:
-
-    :raises subprocess.CalledProcessError: raise when the subprocess return a non-zero exit code
     """
-    logging.getLogger("PPanGGOLiN").debug(" ".join(cmd))
+    Run a subprocess command and write the output to the given path.
+
+    :param cmd: List of program arguments.
+    :param output: Path to write the subprocess output (optional).
+    :param msg: Message to print if the subprocess fails.
+
+    :raises FileNotFoundError: If the command's executable is not found.
+    :raises subprocess.CalledProcessError: If the subprocess returns a non-zero exit code.
+    """
+    if not cmd or shutil.which(cmd[0]) is None:
+        raise FileNotFoundError(
+            f"Command '{cmd[0]}' not found. Please install it and try again."
+        )
+
+    logging.getLogger("PPanGGOLiN").debug(f"Running command: {' '.join(cmd)}")
+
     try:
         result = subprocess.run(cmd, check=True, capture_output=True, text=True)
     except subprocess.CalledProcessError as subprocess_err:
-        for line in subprocess_err.stdout.split("\n"):
+        logging.getLogger("PPanGGOLiN").error(msg)
+        for line in subprocess_err.stderr.strip().split("\n"):
             logging.getLogger("PPanGGOLiN").error(line)
-        raise Exception(msg + subprocess_err.stderr)
+        raise
     else:
-        if output is not None:
+        if output:
             with open(output, "w") as fout:
                 fout.write(result.stdout)
 
@@ -1537,3 +1556,28 @@ def replace_non_ascii(string_with_ascii: str, replacement_string: str = "_") -> 
     :return: A new string where all non-ASCII characters have been replaced.
     """
     return re.sub(r"[^\x00-\x7F]+", replacement_string, string_with_ascii)
+
+
+def check_tools_availability(
+    tool_to_description: Union[Dict[str, str], List[str]]
+) -> dict[str, bool]:
+    """
+    Check if the given command-line tools are available in the system's PATH.
+
+    :param tool_to_description: A dictionary where keys are tool names and values are descriptions of their purpose, or a list of tool names.
+    :return: A dictionary with tool names as keys and boolean values indicating availability.
+    """
+    if isinstance(tool_to_description, list):
+        tool_to_description = {tool: "" for tool in tool_to_description}
+
+    availability = {
+        tool: shutil.which(tool) is not None for tool in tool_to_description
+    }
+
+    for tool, is_available in availability.items():
+        if not is_available:
+            logging.getLogger("PPanGGOLiN").error(
+                f"The command '{tool}'{tool_to_description[tool]} is not found. Please install it to ensure proper functionality of PPanGGOLiN."
+            )
+
+    return availability


### PR DESCRIPTION
This PR does two things:
- Ensure external required tools are available in PATH in function that need them, logging an error if missing.
- Improve error messages when calling tools in PPanGGOLiN, explicitly stating they need to be installed.
