### PR TITLE
Fix regex warning

### DIFF
--- a/.github/workflows/black_lint.yml
+++ b/.github/workflows/black_lint.yml
@@ -8,3 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
+        with:
+          use_pyproject: true

--- a/ppanggolin/meta/meta.py
+++ b/ppanggolin/meta/meta.py
@@ -83,7 +83,7 @@ def check_metadata_format(metadata: Path, metatype: str) -> pd.DataFrame:
         "spots",
         "modules",
     ]
-    colname_check = re.compile("^[a-zA-Z_]\w*$")  # \w = [A-Za-z0-9_]
+    colname_check = re.compile(r"^[a-zA-Z_]\w*$")  # \w = [A-Za-z0-9_]
     metadata_df = pd.read_csv(
         metadata, sep="\t", header=0, quoting=csv.QUOTE_NONE, dtype={metatype: str}
     )


### PR DESCRIPTION
Declare regex pattern as a raw string to comply with Python 3.12 syntax and silence SyntaxWarning. 