### PR TITLE
Add a workflow for automatic publishing on PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         # macos-13 is an Intel runner, macos-14 is an Apple Silicon runner
         # Should we support Linux ARM? If so, add 'ubuntu-24.04-arm'
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-13, macos-14, ubuntu-24.04-arm]
 
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
         # - MUSL builds (NEM does not support musl libc)
         # - PyPy builds (check if ppanggolin works on PyPy first)
         env:
-          CIBW_SKIP: "*-manylinux_i686 *-musllinux_* pp*"
+          CIBW_SKIP: "*-manylinux_i686 pp*"
       
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -38,10 +38,9 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.0
         # We skip: 
         # - 32-bit builds
-        # - MUSL builds (NEM does not support musl libc)
         # - PyPy builds (check if ppanggolin works on PyPy first)
         env:
-          CIBW_SKIP: "*-manylinux_i686 pp*"
+          CIBW_SKIP: "*_i686 pp*"
       
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,88 @@
+name: Build and upload to PyPI
+
+# With the current configuration, the workflow (except PyPI upload)
+# will run on every pull request and on every push to dev branch.
+# This way we can track if some changes break the wheel builds.
+#
+# The PyPI publishing job will only run on release events.
+on:
+  workflow_dispatch: # This allows manual triggering of the workflow for testing on test.pypi.org
+    inputs:
+      publish_test:
+        description: "Publish on test.pypi.org"
+        required: false
+        default: false
+
+  pull_request:
+  push:
+    branches:
+      - dev
+  release:
+    types:
+      - released # Run only on release events, use 'published' to run on draft or pre-release
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # macos-13 is an Intel runner, macos-14 is an Apple Silicon runner
+        # Should we support Linux ARM? If so, add 'ubuntu-24.04-arm'
+        os: [ubuntu-latest, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.23.0
+        # We skip: 
+        # - 32-bit builds
+        # - MUSL builds (NEM does not support musl libc)
+        # - PyPy builds (check if ppanggolin works on PyPy first)
+        env:
+          CIBW_SKIP: "*-manylinux_i686 *-musllinux_* pp*"
+      
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    # Publish on PyPI only on release events
+    if: (github.event_name == 'release' && github.event.action == 'released') || (github.event_name == 'workflow_dispatch' && inputs.publish_test == 'true')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        if: github.event_name == 'release' && github.event.action == 'released'
+        uses: pypa/gh-action-pypi-publish@release/v1
+      
+      - name: Publish to test.pypi.org
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_test == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/ppanggolin/nem/NEM/nem_alg.c
+++ b/ppanggolin/nem/NEM/nem_alg.c
@@ -1508,7 +1508,8 @@ static void StartLogFile( const char* LogName, int Npt, FILE** FlogP )
 
         if ( ( (*FlogP) = fopen( LogName, "w" ) ) == NULL )
         { 
-            setbuf(FlogP, NULL);
+            // FIX: setbuf requires a FILE*, not a FILE**
+            setbuf(*FlogP, NULL);
             fprintf( out_stderr, "Could not open file '%s' in write mode\n", 
                      LogName ) ; if(out_stderr) fflush( out_stderr );
 

--- a/ppanggolin/nem/NEM/nem_exe.c
+++ b/ppanggolin/nem/NEM/nem_exe.c
@@ -87,6 +87,8 @@ Vers-mod  Date         Who  Description
 1.08-a    20-JUI-2017  GG   Add param input by file rather than by arguments
 \*/
 
+#define _GNU_SOURCE // FIX: Required for musl build because srandom is not POSIX
+#include <stdlib.h> 
 #include "nem_exe.h"   /* Prototype of exported mainfunc() */
 
 /* ==================== LOCAL FUNCTION PROTOTYPING =================== */
@@ -513,7 +515,7 @@ int nem(const char* Fname,
         if ( ( err = ReadMatrixFile( NemPara.StartName,     /*V1.04-a*/
 				                     Data.NbPts,
                                      StatModel.Spec.K, 
-                                     ClassifM ) ) != STS_OK )
+                                     &ClassifM ) ) != STS_OK ) // FIX: ReadMatrixFile needs a float**
             return err ;
         break ;
 
@@ -539,7 +541,7 @@ int nem(const char* Fname,
       if ( ( err = ReadLabelFile( NemPara.LabelName, Data.NbPts, 
 				                  & klabelfile,
                                   & Data.LabelV,
-                                  ClassifM ) ) != STS_OK )
+                                  &ClassifM ) ) != STS_OK ) // FIX: ReadMatrixFile needs a float**
         return err ;
 
       if ( klabelfile != StatModel.Spec.K ) {

--- a/ppanggolin/nem/NEM/nem_rnd.c
+++ b/ppanggolin/nem/NEM/nem_rnd.c
@@ -16,6 +16,7 @@ Vers-mod  Date         Who  Description
 
 #include <sys/types.h>   /* time_t */
 #include <time.h>        /* time() */
+#define _GNU_SOURCE      // FIX: Required for musl build because srandom is not POSIX
 #include <stdlib.h>      /* srand48(), lrand48() */
 
 #include "nem_rnd.h"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires = [
     "cython"
 ]
 build-backend = "setuptools.build_meta"
-py_modules=["ppanggolin"]
 
 [project]
 name = "PPanGGOLiN"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ NEM_DIR_PATH = "ppanggolin/nem/NEM/"
 setup(
     ext_modules=[
         Extension(
-            extra_compile_args=["-fcommon", "-Wno-int-conversion"],
+            # Force c99, NEM uses features deprecated in recent C standards
+            extra_compile_args=["-fcommon", "-Wno-int-conversion", "-std=c99"],
             name="nem_stats",
             sources=[
                 NEM_DIR_PATH + "nem_stats.pyx",


### PR DESCRIPTION
## Add a workflow for automatic publishing on PyPI

- The workflow tries to build wheels on every pull request and every push to `dev` branch. The PyPI publishing only runs on release events. 
- It can be triggered manually to test publishing on test.pypi.org.
- Platforms
    - macos x86-64/ARM
    - linux x86-64 (add `ubuntu-24.04-arm` runner to add Linux ARM support)
    - PyPy builds are disabled, we need to check if ppanggolin works on PyPy
    - MUSL builds are disabled. NEM does not compile with musl libc but I already have a patch if we want to support it. MUSL is mainly used on Alpine Linux, widely used as a base image for lightweight containers.