### PR TITLE
 Filter non ASCII character in several annotation fields

### DIFF
--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -1090,7 +1090,7 @@ def read_org_gff(
                     else:
                         is_partial = False
 
-                    product = attributes.pop("PRODUCT")
+                    product = attributes.pop("PRODUCT", "")
 
                     if contig is None or contig.name != fields_gff[gff_seqname]:
                         # get the current contig

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -102,14 +102,6 @@ def create_gene(
     :param genetic_code: Genetic code used
     :param protein_id: Protein identifier
     """
-    # check for non ascii character in product field
-    if has_non_ascii(product):
-
-        logging.getLogger("PPanGGOLiN").warning(
-            f"In genome '{org.name}', the 'product' field of gene '{gene_id}' contains non-ASCII characters: '{product}'. "
-            "These characters cannot be stored in the HDF5 file and will be replaced by underscores."
-        )
-        product = replace_non_ascii(product)
 
     start, stop = coordinates[0][0], coordinates[-1][1]
 
@@ -767,6 +759,16 @@ def read_org_gbff(
                     "will likely contain an internal stop codon when translated with PPanGGOLiN."
                 )
 
+            for field in ["product", "gene", "db_xref"]:
+
+                if field in feature and has_non_ascii(feature[field]):
+
+                    logging.getLogger("PPanGGOLiN").warning(
+                        f"In genome '{organism}', the '{field}' field of gene '{feature['locus_tag']}' contains non-ASCII characters: '{feature[field]}'. "
+                        "These characters cannot be stored in the HDF5 file and will be replaced by underscores."
+                    )
+                    feature[field] = replace_non_ascii(feature[field])
+
             if feature["feature_type"] == "CDS":
                 if feature["transl_table"] == "":
                     used_transl_table_arg += 1
@@ -1014,6 +1016,14 @@ def read_org_gff(
                     start=fields_gff[gff_start], stop=fields_gff[gff_end]
                 )
 
+                for field in ["PRODUCT", "NAME", "DB_XREF", "DBXREF"]:
+                    if field in attributes and has_non_ascii(attributes[field]):
+                        logging.getLogger("PPanGGOLiN").warning(
+                            f"In genome '{organism}', the '{field}' field of feature '{attributes['locus_tag']}' contains non-ASCII characters: '{attributes[field]}'. "
+                            "These characters cannot be stored in the HDF5 file and will be replaced by underscores."
+                        )
+                        attributes[field] = replace_non_ascii(attributes[field])
+
                 if fields_gff[gff_type] == "region":
                     # keep region attributes to add them as metadata of genome and contigs
                     # excluding some info as they are already contained in contig object.
@@ -1080,15 +1090,7 @@ def read_org_gff(
                     else:
                         is_partial = False
 
-                    product = attributes.pop("PRODUCT", "")
-
-                    if has_non_ascii(product):
-
-                        logging.getLogger("PPanGGOLiN").warning(
-                            f"In genome '{organism}', the 'product' field of gene '{gene_id}' contains non-ASCII characters: '{product}'. "
-                            "These characters cannot be stored in the HDF5 file and will be replaced by underscores."
-                        )
-                        product = replace_non_ascii(product)
+                    product = attributes.pop("PRODUCT")
 
                     if contig is None or contig.name != fields_gff[gff_seqname]:
                         # get the current contig

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -13,6 +13,7 @@ import inspect
 from io import TextIOWrapper
 from pathlib import Path
 from typing import (
+    Collection,
     TextIO,
     Union,
     BinaryIO,
@@ -265,7 +266,7 @@ def jaccard_similarities(mat: csc_matrix, jaccard_similarity_th) -> csc_matrix:
 
 
 def is_compressed(
-    file_or_file_path: Union[Path, BinaryIO, TextIOWrapper, TextIO]
+    file_or_file_path: Union[Path, BinaryIO, TextIOWrapper, TextIO],
 ) -> Tuple[bool, Union[str, None]]:
     """
     Detects if a file is compressed based on its file signature.
@@ -315,7 +316,7 @@ def is_compressed(
 
 
 def read_compressed_or_not(
-    file_or_file_path: Union[Path, BinaryIO, TextIOWrapper, TextIO]
+    file_or_file_path: Union[Path, BinaryIO, TextIOWrapper, TextIO],
 ) -> Union[TextIOWrapper, BinaryIO, TextIO]:
     """
     Opens and reads a file, decompressing it if necessary.
@@ -1345,7 +1346,7 @@ def parse_input_paths_file(
 
 
 def flatten_nested_dict(
-    nested_dict: Dict[str, Union[Dict, int, str, float]]
+    nested_dict: Dict[str, Union[Dict, int, str, float]],
 ) -> Dict[str, Union[int, str, float]]:
     """
     Flattens a nested dictionary into a flat dictionary by concatenating keys at different levels.
@@ -1535,29 +1536,42 @@ def run_subprocess(
                 fout.write(result.stdout)
 
 
-def has_non_ascii(string_to_test: str) -> bool:
+def has_non_ascii(string_to_test: Union[str, Collection[str]]) -> bool:
     """
-    Check if a string contains any non-ASCII characters.
+    Check if a string or a collection of strings contains any non-ASCII characters.
 
-    :param string_to_test: The string to check for non-ASCII characters.
-    :return: True if the string contains non-ASCII characters, False otherwise.
+    :param string_to_test: A single string or a collection of strings to check.
+    :return: True if any string contains non-ASCII characters, False otherwise.
     """
     try:
-        string_to_test.encode("ascii")
+        if isinstance(string_to_test, str):
+            string_to_test.encode("ascii")
+        else:
+            for item in string_to_test:
+                item.encode("ascii")
+        return False
     except UnicodeEncodeError:
         return True
-    return False
 
 
-def replace_non_ascii(string_with_ascii: str, replacement_string: str = "_") -> str:
+def replace_non_ascii(
+    string_with_ascii: Union[str, Collection[str]], replacement_string: str = "_"
+) -> Union[str, Collection[str]]:
     """
-    Replace all non-ASCII characters in a string with a specified replacement string.
+    Replace all non-ASCII characters in a string or a collection of strings
+    with a specified replacement string.
 
-    :param string_with_ascii: The string potentially containing non-ASCII characters.
+    :param string_with_ascii: A string or collection of strings potentially containing non-ASCII characters.
     :param replacement_string: The string to replace non-ASCII characters with (default is '_').
-    :return: A new string where all non-ASCII characters have been replaced.
+    :return: A new string or collection where all non-ASCII characters have been replaced.
     """
-    return re.sub(r"[^\x00-\x7F]+", replacement_string, string_with_ascii)
+
+    def replace(s: str) -> str:
+        return re.sub(r"[^\x00-\x7F]+", replacement_string, s)
+
+    if isinstance(string_with_ascii, str):
+        return replace(string_with_ascii)
+    return type(string_with_ascii)(replace(s) for s in string_with_ascii)
 
 
 def check_tools_availability(


### PR DESCRIPTION
In this PR (#291), non-ASCII characters have been removed from the **product** field to prevent errors when writing genomic data into the HDF5 file.  

However, similar issues can also occur in the **gene name** field when non-ASCII characters are present, as reported in issues #291 and #252.  

To prevent this, this PR ensures that any non-ASCII characters found in the **name**, **product**, and **dbxref** fields are replaced by an underscore (`_`) character. 