### PR TITLE
remove RGP from gene when they are discarded by their size

### DIFF
--- a/ppanggolin/RGP/genomicIsland.py
+++ b/ppanggolin/RGP/genomicIsland.py
@@ -218,6 +218,11 @@ def mk_regions(
         new_region.score = val
         if new_region.length > min_length:
             contig_regions.add(new_region)
+        else:
+            # Remove region reference in genes to not consider them when iterating genome RGP
+            for gene in new_region.genes:
+                gene._RGP = None
+
         rewrite_matrix(contig, matrix, index, persistent, continuity, multi)
         val, index = max_index_node(matrix)
     return contig_regions


### PR DESCRIPTION
This PR fixes a bug affecting the reported number of RGPs in output files (`genome_statistics.tsv`, GFF, Proksee, and gene Table). The number of RGPs differed depending on whether the files were generated directly within a workflow or via the `ppanggolin write_pangenome` or `ppanggolin write_genomes` commands.

The problem comes from how RGPs are initially created and linked to genes. Small RGPs are filtered out later based on their size, but in workflow executions, those small RGPs remain associated with the genes and are still counted. In contrast, when using `write_pangenome` and  `write_genomes` outside a workflow, only valid RGPs are written to the HDF5 file, so the final count is correct.

## Implemented Solution

The fix introduced in this PR ensures that small RGPs are no longer linked to genes during the filtering step. This guarantees that only valid RGPs are taken into account in all output files, regardless of whether they are generated during the workflow or as a post-processing step.