### PR TITLE
correction of numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ classifiers=[
 requires-python = ">=3.9"
 
 dependencies = [
+    "numpy>1.24.0,<2.0.0",
+    "pandas>=2.0.0,<3.0.0",
     "tqdm>=4.0.0,<5.0.0",
     "tables>=3.0.0,<4.0.0",
     "pyrodigal>=3.0.0,<4.0.0",
@@ -43,8 +45,6 @@ dependencies = [
     "scipy>=1.0.0,<2.0.0",
     "plotly>=5.0.0,<6.0.0",
     "gmpy2>=2.0.0,<3.0.0",
-    "pandas>=2.0.0,<3.0.0",
-    "numpy>1.24.0,<3.0.0",
     "bokeh>=3.0.0,<4.0.0"
 ]
 


### PR DESCRIPTION
In the pyproject.toml file, the numpy version is between 1.24.0 and 3.0.0, but it is not the same in the ppanggolin_env.yaml file.

Also, I encounter some problems when installing with `pip install .`, without conda, because there is an incompatibility between numpy >= 2.0.0 and pytable. https://github.com/PyTables/PyTables/issues/1172

So I put the correct numpy version in the pyproject.toml