### PR TITLE
 Fix CGView warnings when using Proksee maps in custom web apps

### DIFF
--- a/ppanggolin/formats/write_proksee.py
+++ b/ppanggolin/formats/write_proksee.py
@@ -109,7 +109,7 @@ def write_tracks(features: List[str]):
         tracks.append(
             {
                 "name": "RGP",
-                "separateFeaturesBy": "None",
+                "separateFeaturesBy": "none",
                 "position": "inside",
                 "thicknessRatio": 1,
                 "dataType": "feature",
@@ -122,7 +122,7 @@ def write_tracks(features: List[str]):
         tracks.append(
             {
                 "name": "Module",
-                "separateFeaturesBy": "None",
+                "separateFeaturesBy": "none",
                 "position": "inside",
                 "thicknessRatio": 1,
                 "dataType": "feature",


### PR DESCRIPTION
When visualizing Proksee maps with CGView in a custom web application, some warnings appear:

> `value(s) 'None' is/are not one of the following valid options: none, strand, readingFrame`

This was due to the `separateFeaturesBy` field being set to `"None"`instead of the string `"none"` for Modules and RGPs tracks.

These warnings are harmless but can be confusing or noisy.
This PR updates the value to the correct string `"none"` to prevent the warnings from appearing.
