### PR TITLE
Raise errors when sequence-region pragma is poorly formatted

### DIFF
--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -977,6 +977,11 @@ def read_org_gff(
                     has_fasta = True
                 elif line.startswith("sequence-region", 2, 17):
                     fields = [el.strip() for el in line.split()]
+                    if len(fields) != 4:
+                        raise Exception(
+                            "Pragma '##sequence-region' has an unexpected format. "
+                            f"Expecting the format '##sequence-region seqid start stop', and got the following: '{line.strip()}'"
+                        )
                     with contig_counter.get_lock():
                         contig = Contig(
                             contig_counter.value,


### PR DESCRIPTION

This small PR adds an explicit error for cases when the sequence-region pragma in gff3 is poorly formatted, such as in #294.

Since PGAP is heavily used by the community, I'm expecting this kind of errors to happen again in the futur. This should make things easier for users to understand what is wrong.