### PR TITLE
Fix undefined contig length in workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NUM_CPUS: 1
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,7 +22,7 @@ on:
   pull_request:
   push:
     branches:
-      - dev
+      - master
   release:
     types:
       - released # Run only on release events, use 'published' to run on draft or pre-release

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,6 +20,8 @@ on:
     
 
   pull_request:
+    branches:
+      - master
   push:
     branches:
       - master

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -1820,6 +1820,17 @@ def launch(args: argparse.Namespace):
                     "You will be able to proceed with your analysis "
                     "ONLY if you provide the clustering results in the next step."
                 )
+
+            if pangenome.contig_lengths_unavailable():
+                raise ValueError(
+                    "Unable to determine contig lengths from the provided GFF files. "
+                    "Contig length must be specified using the ##sequence-region pragma. "
+                    "Additionally, no FASTA sequences were provided. "
+                    "As a result, contig lengths cannot be inferred.\n"
+                    "To resolve this, please provide a FASTA file using the '--fasta' option, "
+                    "or modify your GFF files to include sufficient information to deduce contig lengths."
+                )
+
         else:
             if args.fasta:
                 logging.getLogger("PPanGGOLiN").warning(

--- a/ppanggolin/genome.py
+++ b/ppanggolin/genome.py
@@ -583,6 +583,10 @@ class Contig(MetaFeatures):
 
         :todo: It could be better that len return the number of genes in the contig
         """
+        if self.length is None:
+            raise ValueError(
+                f"Contig length of {self.name} from genome {self.organism} has not been defined. Getting its length is then impossible."
+            )
         return self.length
 
     # retrieve gene by start position

--- a/ppanggolin/pangenome.py
+++ b/ppanggolin/pangenome.py
@@ -931,3 +931,10 @@ class Pangenome:
         for elem in self.select_elem(metatype):
             if elem.has_source(source):
                 yield elem
+
+    def contig_lengths_unavailable(self) -> bool:
+        """Check if the pangenome has contig lengths unavailable
+
+        :return: True if contig lengths are unavailable, False otherwise
+        """
+        return any(contig.length is None for contig in self.contigs)

--- a/ppanggolin/workflow/all.py
+++ b/ppanggolin/workflow/all.py
@@ -78,12 +78,6 @@ def launch_workflow(
         )
         anno_time = time.time() - start_anno
 
-        start_writing = time.time()
-        write_pangenome(
-            pangenome, filename, args.force, disable_bar=args.disable_prog_bar
-        )
-        writing_time = time.time() - start_writing
-
         if args.clusters is not None:
             start_clust = time.time()
             read_clustering(
@@ -122,6 +116,12 @@ def launch_workflow(
                 keep_tmp_files=args.cluster.keep_tmp,
             )
         clust_time = time.time() - start_clust
+
+        start_writing = time.time()
+        write_pangenome(
+            pangenome, filename, args.force, disable_bar=args.disable_prog_bar
+        )
+        writing_time = time.time() - start_writing
 
     elif args.fasta is not None:
         if args.clusters is not None:


### PR DESCRIPTION
This PR fixes a bug where contig lengths were required when writing to the HDF5 file, but not yet available if they were missing from the GFF files and only parsed later from FASTA files. This was happening in workflow commands. 

### Fix:
Writing to the HDF5 file, is now called after parsing the FASTA files to ensure contig lengths are available. 


### Other changes:
- Triggers PYPI CI  only on master branch PR and push, release and when manually triggered to lower CI load. 
- Adds a concurrency group to the main CI to ensure that only the latest workflow run for a given branch is executed. Any previously queued or in-progress runs will be automatically cancelled when new commits are pushed, saving resources and reducing CI noise.