### PR TITLE
Fix gene coordinate update in `correct_putative_overlaps`

### DIFF
--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -1404,6 +1404,9 @@ def correct_putative_overlaps(contigs: Iterable[Contig]):
 
                 gene.coordinates = new_coordinates
 
+                gene.start = new_coordinates[0][0]
+                gene.stop = new_coordinates[-1][1]
+
 
 def read_anno_file(
     organism_name: str,


### PR DESCRIPTION
Genes from GFF files that overlap the start and end of a contig have coordinates exceeding the contig length. These genes need to be processed by PPanGGOLiN to split their coordinates into multiple parts that remain within the contig boundaries( eg:  `[(1041794, 1042393), (1, 1176)]` )

This correction is handled by the `correct_putative_overlaps` function, which updates the `coordinate` attribute of a gene. However, it was not also updating the gene’s `start` and `stop` attributes, leading to inconsistent data.

This PR fixes the issue by ensuring that both the `start` and `stop` attributes are properly updated alongside the `coordinate` attribute.

Thanks @ggautreau for reporting this bug.