### PR TITLE
Add `__version__` to ppanggolin module to comply with standard

### DIFF
--- a/ppanggolin/__init__.py
+++ b/ppanggolin/__init__.py
@@ -44,6 +44,7 @@ SUBCOMMAND_TO_SUBPARSER = {
 
 
 version = distribution("ppanggolin").version
+__version__ = version
 
 epilog = f"""
 PPanGGOLiN ({version}) is an open-source bioinformatics tool developed by the LABGeM team, and distributed under the CeCILL Free Software License Agreement.


### PR DESCRIPTION
Add `__version__` attribute to ppanggolin module to get the version in a standardized way:

```python
import ppanggolin

print(ppanggolin.__version__)
```

