### PR TITLE
Correctly handle overlapping RNA genes on circular contigs

### DIFF
--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -4,6 +4,7 @@
 import argparse
 import logging
 from concurrent.futures import ProcessPoolExecutor
+from itertools import chain
 
 from multiprocessing import get_context
 import os
@@ -37,7 +38,6 @@ from ppanggolin.utils import (
     check_input_files,
     has_non_ascii,
     replace_non_ascii,
-    check_tools_availability,
 )
 from ppanggolin.formats import write_pangenome
 from ppanggolin.metadata import Metadata
@@ -1359,7 +1359,8 @@ def correct_putative_overlaps(contigs: Iterable[Contig]):
     """
 
     for contig in contigs:
-        for gene in contig.genes:
+
+        for gene in chain(contig.genes, contig.RNAs):
             if gene.stop > len(contig):
                 # Adjust gene coordinates to handle circular contig
                 gene.start = 1  # Start gene at the beginning of the contig


### PR DESCRIPTION
This PR fixes an issue where RNA features overlapping the start/end boundary of circular contigs were not properly managed.

In GFF files, overlapping features can exceed the contig length. This case was already handled for CDS features, but not for RNA.

With this fix, RNA genes are now treated consistently with CDS features, and their coordinates are corrected when overlapping circular boundaries.

Should fix #350.