### PR TITLE
Fix the workflow checking bioconda install

### DIFF
--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -4,7 +4,7 @@ name: conda recipe
 on:
   # Triggers the workflow on schedule but only for the default branch (which is master)
   schedule:
-   - cron: '0 7 * * 1-5'
+   - cron: '0 7 1 * *'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -24,7 +24,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
       # Setting up miniconda
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           channels: bioconda,conda-forge

--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest','macos-13']
-        python-version: ['3.9','3.10','3.11']
+        os: ['ubuntu-latest','macos-latest']
+        python-version: ['3.10'] #['3.9','3.10','3.11']
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -27,7 +27,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
-          channels: bioconda,conda-forge,anaconda,defaults
+          channels: bioconda,conda-forge
           activate-environment: test
       - name: Set up test environment
         shell: bash -l {0}

--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest','macos-latest']
-        python-version: ['3.10'] #['3.9','3.10','3.11']
+        python-version: ['3.9','3.10', '3.11', '3.12']
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,11 +51,15 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
         python-version: ['3.9', '3.12']
+    defaults:
+      run:
+        shell: conda run --no-capture-output -n ppanggolin bash -e {0}
     steps:
 
     # Get number of cpu available on the current runner
     - name: Get core number on linux
       if: matrix.os == 'ubuntu-latest'
+      shell: bash
       run: |
         nb_cpu_linux=`nproc`
         echo "Number of cores avalaible on the current linux runner $nb_cpu_linux"
@@ -63,42 +67,43 @@ jobs:
 
     - name: Get core number on macos
       if: matrix.os == 'macos-latest'
+      shell: bash
       run: |
         nb_cpu_macos=`sysctl -n hw.ncpu`
         echo "Number of cores avalaible on the current macos runner $nb_cpu_macos"
         echo "NUM_CPUS=$nb_cpu_macos" >> "$GITHUB_ENV"
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     # Install requirements with miniconda
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: conda-incubator/setup-miniconda@v4
       with:
         python-version: ${{ matrix.python-version }}
-        channels: conda-forge,bioconda,defaults
+        channels: conda-forge,bioconda
         environment-file: ppanggolin_env.yaml
         activate-environment: ppanggolin
+        conda-remove-defaults: "true"
 
     - name: Install ppanggolin
-      shell: bash -l {0}
       run: |
-        pip install .[test]
-        mmseqs version
+        python -m pip install .[test]
+
 
     # Check that it is installed and displays help without error
     - name: Check that PPanGGOLiN is installed
-      shell: bash -l {0}
       run: |
         ppanggolin --version
         ppanggolin --help
+        mmseqs version
+        python -V
 
     # Check that unit tests are all passing
     - name: Unit and functional tests
-      shell: bash -l {0}
-      run: pytest --full --cov=ppanggolin --cov-report=term --cpu $NUM_CPUS 
+      run: python -m pytest --cov=ppanggolin --cov-report=term --cpu $NUM_CPUS --full
 
     - name: Archive diff files
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: comparison-results_${{ matrix.os }}_python${{ matrix.python-version }}
         path: testingDataset/info_to_test/*

--- a/ppanggolin_env.yaml
+++ b/ppanggolin_env.yaml
@@ -3,11 +3,11 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
+  - pip
   - tqdm>=4.0.0,<5.0.0
   - pytables>=3.8.0,<4.0.0
   - pyrodigal>=3.0.0,<4.0.0
   - networkx>=3.0.0,<4.0.0
-  - dataclasses=0.8
   - scipy>=1.0.0,<2.0.0
   - plotly>=5.0.0,<6.0.0
   - gmpy2>=2.0.0,<3.0.0


### PR DESCRIPTION
The bioconda install check was failing due to dependency conflicts, likely caused by the `defaults` channel.

**Changes:**
- Removed the `defaults` channel (requires a license, unnecessary for PPanGGOLiN — already removed from docs in #323 and #358)
- Updated Python versions matrix to 3.9–3.12
- Updated `conda-incubator/setup-miniconda` to v4
- Changed schedule from weekly to monthly


Check the workflow manually using the workflow_dispatch and it now succeed with no fails here: https://github.com/labgem/PPanGGOLiN/actions/runs/26450200152 