### PR TITLE
feat: An export to graph-tools' gt format

### DIFF
--- a/docs/user/PangenomeAnalyses/pangenomeGraphOut.md
+++ b/docs/user/PangenomeAnalyses/pangenomeGraphOut.md
@@ -39,9 +39,9 @@ The json can be generated using the `write_pangenome` subcommand as such :
 ppanggolin write_pangenome -p pangenome.h5 -o output_dir --json
 ```
 
-#### `graph-tools` compressed gt format
+#### `graph-tool` compressed gt format
 
-The [graph-tools](https://graph-tool.skewed.de/static/docs/stable/) [`.gt` compressed graph format](https://graph-tool.skewed.de/static/docs/stable/gt_format.html) is a binary file format enabling a fast load of large graph structure from disk. 
+The [graph-tool](https://graph-tool.skewed.de/static/docs/stable/) [`.gt` compressed graph format](https://graph-tool.skewed.de/static/docs/stable/gt_format.html) is a binary file format enabling a fast load of large graph structure from disk. 
 
 The gt file can be built from a pangenome with the `write_pangenome` subcommand as such:
 
@@ -50,6 +50,11 @@ ppanggolin write_pangenome -p pangenome.h5 --gt
 ```
 
 The `ppanggolin` gt export contains the following edges and vertices [property maps](https://graph-tool.skewed.de/static/docs/stable/autosummary/graph_tool.PropertyMap.html#graph_tool.PropertyMap).
+
+```{warning}
+As `graph_tool` is not available from PyPI.org, to benefit from the graph-tool gt file format export feature, you will need to install the graph-tool dependency either from `conda-forge` or via your distribution package manager. See [graph_tool installation instruction](https://graph-tool.skewed.de/installation.html), or use the PPanGGOLiN conda environment file.
+``` 
+
 
 ##### Node property maps    
 

--- a/docs/user/PangenomeAnalyses/pangenomeGraphOut.md
+++ b/docs/user/PangenomeAnalyses/pangenomeGraphOut.md
@@ -49,7 +49,7 @@ The gt file can be built from a pangenome with the `write_pangenome` subcommand 
 ppanggolin write_pangenome -p pangenome.h5 --gt
 ```
 
-The `ppanggolin` gt export contains the following edges and [vertices property maps]()
+The `ppanggolin` gt export contains the following edges and vertices [property maps](https://graph-tool.skewed.de/static/docs/stable/autosummary/graph_tool.PropertyMap.html#graph_tool.PropertyMap).
 
 ##### Node property maps    
 
@@ -57,7 +57,7 @@ The `ppanggolin` gt export contains the following edges and [vertices property m
 - "partition" ∈ {'P', 'S', 'C'}: gene family partition (persistent, shell, cloud)
 - "strains": gene family strains
 
-Accessible with `graph_tool.Graph.vp` as such:
+These property maps are accessible with `graph_tool.Graph.vp` as such:
 
 ```python
 import graph_tool
@@ -75,7 +75,7 @@ For edge $(u, v)$
 - "strains": strains having the gene families $(u, v)$ colocalized
 
 
-Accessible with `graph_tool.Graph.ep` as such:
+These property maps are accessible with `graph_tool.Graph.ep` as such:
 ````python
 import graph_tool
 g = graph_tool.load("pangenomeGraph.gt")

--- a/docs/user/PangenomeAnalyses/pangenomeGraphOut.md
+++ b/docs/user/PangenomeAnalyses/pangenomeGraphOut.md
@@ -38,3 +38,49 @@ The json can be generated using the `write_pangenome` subcommand as such :
 ```bash
 ppanggolin write_pangenome -p pangenome.h5 -o output_dir --json
 ```
+
+#### `graph-tools` compressed gt format
+
+The [graph-tools](https://graph-tool.skewed.de/static/docs/stable/) [`.gt` compressed graph format](https://graph-tool.skewed.de/static/docs/stable/gt_format.html) is a binary file format enabling a fast load of large graph structure from disk. 
+
+The gt file can be built from a pangenome with the `write_pangenome` subcommand as such:
+
+```bash
+ppanggolin write_pangenome -p pangenome.h5 --gt
+```
+
+The `ppanggolin` gt export contains the following edges and [vertices property maps]()
+
+##### Node property maps    
+
+- "nid": gene family identifier
+- "partition" ∈ {'P', 'S', 'C'}: gene family partition (persistent, shell, cloud)
+- "strains": gene family strains
+
+Accessible with `graph_tool.Graph.vp` as such:
+
+```python
+import graph_tool
+g = graph_tool.load("pangenomeGraph.gt")
+for v in g.vertices():
+    family = g.vp["nid"][v]
+    partition = g.vp["partition"][v]
+    vertex_strains = g.vp["strains"][v]
+```
+
+
+##### Edge property maps
+
+For edge $(u, v)$
+- "strains": strains having the gene families $(u, v)$ colocalized
+
+
+Accessible with `graph_tool.Graph.ep` as such:
+````python
+import graph_tool
+g = graph_tool.load("pangenomeGraph.gt")
+for e in g.edges():
+    edge_strains = g.vp["strains"][e]
+```
+
+

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -12,10 +12,12 @@ from typing import TextIO
 from importlib.metadata import distribution
 from statistics import median, mean, stdev
 import os
+import sys
 import csv
 
 # installed libraries
 import pandas as pd
+import graph_tool
 from tqdm import tqdm
 
 # local libraries
@@ -440,6 +442,70 @@ def write_gexf(output: Path, light: bool = True, compress: bool = False):
             f"Done writing the gexf file : '{gexf.name}'"
         )
 
+def pangenome_to_gt(pangenome: Pangenome) -> graph_tool.Graph:
+    """
+    Prepare a graph-tool Graph object from a Pangenome object.
+
+    :param pangenome: Pangenome object to convert
+    :return: a graph-tool undirected graph representing the pangenome
+
+    ## Node property maps    
+    - "nid": gene family identifier
+    - "partition" ∈ {'P', 'S', 'C'}: gene family partition (persistent, shell, cloud)
+    - "strains": gene family strains
+
+    ## Edge property maps
+
+    For edge $(u, v)$
+    - "strains": strains having the gene families $(u, v)$ colocalized
+
+    """
+
+    g = graph_tool.Graph(directed=False)
+    g.vp["nid"] = g.new_vertex_property("string")
+    g.vp["partition"] = g.new_vertex_property("string")
+    g.vp["strains"] = g.new_vertex_property("vector<string>")
+    g.ep["strains"] = g.new_edge_property("vector<string>")
+
+    vmap = {}  # mapping from gene family name to vertex
+
+    named_partition_to_code = {
+        "persistent": "P",
+        "shell": "S",
+        "cloud": "C",
+    }
+
+
+    for fam in pangenome.gene_families:
+        v = g.add_vertex()
+        vmap[fam.ID] = v
+        g.vp["nid"][v] = fam.ID
+        g.vp["partition"][v] = named_partition_to_code[fam.named_partition]
+        g.vp["strains"][v] = {g.organism for g in fam.genes}
+
+    for edge in pangenome.edges:
+        u = vmap[edge.source.ID]
+        v = vmap[edge.target.ID]
+        e = g.add_edge(u, v)
+        g.ep["strains"][e] = {organism for organism in edge._organisms.keys()}
+    
+    return g
+
+
+def write_gt(output: Path, compressed: bool=False):
+    """
+    Write the pangenome graph in graph-tool .gt graph format.
+
+    :param output: Path to output directory
+    :param compressed: Compress the file in .gz
+
+    """
+    logging.getLogger("PPanGGOLiN").info("Writing the .gt file ...")
+    extension = ".gt.gz" if compressed else ".gt" 
+    outname = output / f"pangenomeGraph{extension}"
+    g = pangenome_to_gt(pan)
+    g.save(outname.as_posix())
+    
 
 def write_matrix(
     output: Path,
@@ -1358,6 +1424,7 @@ def write_pangenome_flat_files(
     gene_pa: bool = False,
     gexf: bool = False,
     light_gexf: bool = False,
+    gt: bool = False,
     stats: bool = False,
     json: bool = False,
     partitions: bool = False,
@@ -1383,6 +1450,7 @@ def write_pangenome_flat_files(
     :param gene_pa: write gene presence absence matrix
     :param gexf: write pangenome graph in gexf format
     :param light_gexf: write pangenome graph with only gene families
+    :param gt: write pangenome graph in graph-tool gt format
     :param stats: write statistics about pangenome
     :param json: write pangenome graph in json file
     :param partitions: write the gene families for each partition
@@ -1403,6 +1471,7 @@ def write_pangenome_flat_files(
             gene_pa,
             gexf,
             light_gexf,
+            gt,
             stats,
             json,
             partitions,
@@ -1437,6 +1506,7 @@ def write_pangenome_flat_files(
         or gene_pa
         or gexf
         or light_gexf
+        or gt
         or stats
         or json
         or partitions
@@ -1462,6 +1532,8 @@ def write_pangenome_flat_files(
             metatype = "families"
         else:
             needMetadata = False
+    if gt:
+        needGraph = True
     if spots or borders or spot_modules or regions or regions_families:
         needRegions = True
     if spots or borders or spot_modules:  # or projection:
@@ -1502,6 +1574,10 @@ def write_pangenome_flat_files(
         if light_gexf:
             processes.append(
                 p.apply_async(func=write_gexf, args=(output, True, compress))
+            )
+        if gt:
+            processes.append(
+                p.apply_async(func=write_gt, args=(output, compress))
             )
         if stats:
             processes.append(
@@ -1574,6 +1650,7 @@ def launch(args: argparse.Namespace):
         gene_pa=args.Rtab,
         gexf=args.gexf,
         light_gexf=args.light_gexf,
+        gt=args.gt,
         stats=args.stats,
         json=args.json,
         partitions=args.partitions,
@@ -1649,11 +1726,19 @@ def parser_flat(parser: argparse.ArgumentParser):
         action="store_true",
         help="Generate a detailed GEXF file with all genes and annotations for each family",
     )
+
     optional.add_argument(
         "--light_gexf",
         required=False,
         action="store_true",
         help="Generate a simplified GEXF file with basic gene family information",
+    )
+
+    optional.add_argument(
+        "--gt",
+        required=False,
+        action="store_true",
+        help="Generate a simplified graph-tool GT file with basic gene family and pangenome organism strains information"
     )
 
     optional.add_argument(
@@ -1672,6 +1757,7 @@ def parser_flat(parser: argparse.ArgumentParser):
             "Uses partitions as alternative gene IDs if available."
         ),
     )
+    
     optional.add_argument(
         "--Rtab",
         required=False,

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -442,6 +442,7 @@ def write_gexf(output: Path, light: bool = True, compress: bool = False):
             f"Done writing the gexf file : '{gexf.name}'"
         )
 
+
 def pangenome_to_gt(pangenome: Pangenome) -> graph_tool.Graph:
     """
     Prepare a graph-tool Graph object from a Pangenome object.
@@ -449,7 +450,7 @@ def pangenome_to_gt(pangenome: Pangenome) -> graph_tool.Graph:
     :param pangenome: Pangenome object to convert
     :return: a graph-tool undirected graph representing the pangenome
 
-    ## Node property maps    
+    ## Node property maps
     - "nid": gene family identifier
     - "partition" ∈ {'P', 'S', 'C'}: gene family partition (persistent, shell, cloud)
     - "strains": gene family strains
@@ -475,7 +476,6 @@ def pangenome_to_gt(pangenome: Pangenome) -> graph_tool.Graph:
         "cloud": "C",
     }
 
-
     for fam in pangenome.gene_families:
         v = g.add_vertex()
         vmap[fam.ID] = v
@@ -488,11 +488,11 @@ def pangenome_to_gt(pangenome: Pangenome) -> graph_tool.Graph:
         v = vmap[edge.target.ID]
         e = g.add_edge(u, v)
         g.ep["strains"][e] = {organism for organism in edge._organisms.keys()}
-    
+
     return g
 
 
-def write_gt(output: Path, compressed: bool=False):
+def write_gt(output: Path, compressed: bool = False):
     """
     Write the pangenome graph in graph-tool .gt graph format.
 
@@ -501,11 +501,11 @@ def write_gt(output: Path, compressed: bool=False):
 
     """
     logging.getLogger("PPanGGOLiN").info("Writing the .gt file ...")
-    extension = ".gt.gz" if compressed else ".gt" 
+    extension = ".gt.gz" if compressed else ".gt"
     outname = output / f"pangenomeGraph{extension}"
     g = pangenome_to_gt(pan)
     g.save(outname.as_posix())
-    
+
 
 def write_matrix(
     output: Path,
@@ -1576,9 +1576,7 @@ def write_pangenome_flat_files(
                 p.apply_async(func=write_gexf, args=(output, True, compress))
             )
         if gt:
-            processes.append(
-                p.apply_async(func=write_gt, args=(output, compress))
-            )
+            processes.append(p.apply_async(func=write_gt, args=(output, compress)))
         if stats:
             processes.append(
                 p.apply_async(
@@ -1738,7 +1736,7 @@ def parser_flat(parser: argparse.ArgumentParser):
         "--gt",
         required=False,
         action="store_true",
-        help="Generate a simplified graph-tool GT file with basic gene family and pangenome organism strains information"
+        help="Generate a simplified graph-tool GT file with basic gene family and pangenome organism strains information",
     )
 
     optional.add_argument(
@@ -1757,7 +1755,7 @@ def parser_flat(parser: argparse.ArgumentParser):
             "Uses partitions as alternative gene IDs if available."
         ),
     )
-    
+
     optional.add_argument(
         "--Rtab",
         required=False,

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -20,6 +20,7 @@ import pandas as pd
 from tqdm import tqdm
 
 # local libraries
+from ppanggolin.utils import check_module_availability
 from ppanggolin.edge import Edge
 from ppanggolin.geneFamily import GeneFamily
 from ppanggolin.genome import Organism
@@ -1534,12 +1535,11 @@ def write_pangenome_flat_files(
             needMetadata = False
     if gt:
         # Check required graph_tool dependency before loading the pangenome HDF5.
-        try:
-            import graph_tool
-        except ImportError as exc:
-            raise ImportError(
-                "Export in graph_tool binary .gt format (option --gt) requires the optional dependency 'graph_tool'."
-            )
+        assert check_module_availability(
+            {
+                "graph_tool": "graph_tool Python module is used to export the PPanGGGOLiN pangenome to a graph-tool binary gt file."
+            }
+        )
         needGraph = True
     if spots or borders or spot_modules or regions or regions_families:
         needRegions = True

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -1535,12 +1535,12 @@ def write_pangenome_flat_files(
             needMetadata = False
     if gt:
         # Check required graph_tool dependency before loading the pangenome HDF5.
-        available = check_module_availability(
+        availability = check_module_availability(
             {
                 "graph_tool": "which is used to export the PPanGGGOLiN pangenome to a graph-tool binary gt file"
             }
         )
-        if not available["graph_tool"]:
+        if not availability["graph_tool"]:
             raise ImportError(
                 "The graph-tool module is not available. Please install it to use the gt export feature."
             )

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -1535,11 +1535,15 @@ def write_pangenome_flat_files(
             needMetadata = False
     if gt:
         # Check required graph_tool dependency before loading the pangenome HDF5.
-        assert check_module_availability(
+        available = check_module_availability(
             {
-                "graph_tool": "graph_tool Python module is used to export the PPanGGGOLiN pangenome to a graph-tool binary gt file."
+                "graph_tool": "which is used to export the PPanGGGOLiN pangenome to a graph-tool binary gt file"
             }
         )
+        if not available["graph_tool"]:
+            raise ImportError(
+                "The graph-tool module is not available. Please install it to use the gt export feature."
+            )
         needGraph = True
     if spots or borders or spot_modules or regions or regions_families:
         needRegions = True

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -268,7 +268,7 @@ def write_gexf_header(gexf: TextIO, light: bool = True):
     gexf.write("    </attributes>\n")
     gexf.write("    <meta>\n")
     gexf.write(
-        f'      <creator>PPanGGOLiN {distribution("ppanggolin").version}</creator>\n'
+        f"      <creator>PPanGGOLiN {distribution('ppanggolin').version}</creator>\n"
     )
     gexf.write("    </meta>\n")
 
@@ -465,7 +465,6 @@ def pangenome_to_gt(pangenome: Pangenome):
     except ImportError as exc:
         raise ImportError("This feature requires the optional dependency 'graph_tool'.")
 
-
     g = graph_tool.Graph(directed=False)
     g.vp["nid"] = g.new_vertex_property("string")
     g.vp["partition"] = g.new_vertex_property("string")
@@ -531,7 +530,6 @@ def write_matrix(
     logging.getLogger("PPanGGOLiN").info(f"Writing the .{ext} file ...")
     outname = output / f"matrix.{ext}"
     with write_compressed_or_not(outname, compress) as matrix:
-
         index_org = {}
         default_dat = []
         for index, org in enumerate(pan.organisms):
@@ -943,7 +941,6 @@ def write_stats(
     summaries = []
 
     for organism in pan.organisms:
-
         rgp_count = (
             organism.number_of_regions if pan.status["predictedRGP"] != "No" else None
         )
@@ -1360,7 +1357,6 @@ def write_spot_modules(output: Path, compress: bool = False):
                         curr_mods[fam.module].add(fam)
 
             for module, mod_families_in_spot in curr_mods.items():
-
                 if mod_families_in_spot == set(module.families):
                     # if all the families in the module are found in the spot, write the association
                     fout.write(f"module_{module.ID}\tspot_{spot.ID}\n")
@@ -1541,7 +1537,9 @@ def write_pangenome_flat_files(
         try:
             import graph_tool
         except ImportError as exc:
-            raise ImportError("Export in graph_tool binary .gt format (option --gt) requires the optional dependency 'graph_tool'.")
+            raise ImportError(
+                "Export in graph_tool binary .gt format (option --gt) requires the optional dependency 'graph_tool'."
+            )
         needGraph = True
     if spots or borders or spot_modules or regions or regions_families:
         needRegions = True

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -17,7 +17,6 @@ import csv
 
 # installed libraries
 import pandas as pd
-import graph_tool
 from tqdm import tqdm
 
 # local libraries
@@ -443,7 +442,7 @@ def write_gexf(output: Path, light: bool = True, compress: bool = False):
         )
 
 
-def pangenome_to_gt(pangenome: Pangenome) -> graph_tool.Graph:
+def pangenome_to_gt(pangenome: Pangenome):
     """
     Prepare a graph-tool Graph object from a Pangenome object.
 
@@ -461,6 +460,11 @@ def pangenome_to_gt(pangenome: Pangenome) -> graph_tool.Graph:
     - "strains": strains having the gene families $(u, v)$ colocalized
 
     """
+    try:
+        import graph_tool
+    except ImportError as exc:
+        raise ImportError("This feature requires the optional dependency 'graph_tool'.")
+
 
     g = graph_tool.Graph(directed=False)
     g.vp["nid"] = g.new_vertex_property("string")
@@ -1533,6 +1537,11 @@ def write_pangenome_flat_files(
         else:
             needMetadata = False
     if gt:
+        # Check required graph_tool dependency before loading the pangenome HDF5.
+        try:
+            import graph_tool
+        except ImportError as exc:
+            raise ImportError("Export in graph_tool binary .gt format (option --gt) requires the optional dependency 'graph_tool'.")
         needGraph = True
     if spots or borders or spot_modules or regions or regions_families:
         needRegions = True

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -1625,6 +1625,40 @@ def check_tools_availability(
     return availability
 
 
+def check_module(module_name: str) -> bool:
+    try:
+        __import__(module_name)
+    except ImportError:
+        return False
+    return True
+
+
+def check_module_availability(
+    module_to_description: Union[Dict[str, str], List[str]],
+) -> dict[str, bool]:
+    """
+    Check if a python module is available.
+
+    :param module_to_description: A dictionary where keys are module names and values are the description of their purpose, or a list of python module name
+    """
+    if isinstance(module_to_description, list):
+        module_to_description = {module: "" for module in module_to_description}
+    availability = {
+        module: check_module(module) is not None for module in module_to_description
+    }
+    for module, module_decription in module_to_description.items():
+        caller_frame = inspect.stack()[1]
+        caller_module = caller_frame.frame.f_globals["__name__"]
+        caller_function = caller_frame.function
+
+        logging.getLogger("PPanGGOLiN").warning(
+            f"Missing required python module: '{module}' {module_decription}."
+            f"This check was triggered in '{caller_function} inside module '{caller_module}'. "
+            "Please install the missing module to enable the (optional) feature requiring it."
+        )
+    return availability
+
+
 def check_translation_table_to_use(
     pangenome: "Pangenome",
     is_user_specified: bool,

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -1652,7 +1652,7 @@ def check_module_availability(
             caller_function = caller_frame.function
 
             logging.getLogger("PPanGGOLiN").warning(
-                f"Missing required python module: '{module}' {module_decription}."
+                f"Missing required python module: '{module}' {module_decription}. "
                 f"This check was triggered in '{caller_function}' inside module '{caller_module}'. "
                 "Please install the missing module to enable the (optional) feature requiring it."
             )

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -1643,19 +1643,19 @@ def check_module_availability(
     """
     if isinstance(module_to_description, list):
         module_to_description = {module: "" for module in module_to_description}
-    availability = {
-        module: check_module(module) is not None for module in module_to_description
-    }
-    for module, module_decription in module_to_description.items():
-        caller_frame = inspect.stack()[1]
-        caller_module = caller_frame.frame.f_globals["__name__"]
-        caller_function = caller_frame.function
+    availability = {module: check_module(module) for module in module_to_description}
 
-        logging.getLogger("PPanGGOLiN").warning(
-            f"Missing required python module: '{module}' {module_decription}."
-            f"This check was triggered in '{caller_function} inside module '{caller_module}'. "
-            "Please install the missing module to enable the (optional) feature requiring it."
-        )
+    for module, module_decription in module_to_description.items():
+        if not availability[module]:
+            caller_frame = inspect.stack()[1]
+            caller_module = caller_frame.frame.f_globals["__name__"]
+            caller_function = caller_frame.function
+
+            logging.getLogger("PPanGGOLiN").warning(
+                f"Missing required python module: '{module}' {module_decription}."
+                f"This check was triggered in '{caller_function}' inside module '{caller_module}'. "
+                "Please install the missing module to enable the (optional) feature requiring it."
+            )
     return availability
 
 

--- a/ppanggolin_env.yaml
+++ b/ppanggolin_env.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pandas>=2.0.0,<3.0.0
   - numpy>1.24.0,<2.0.0
   - bokeh>=3.0.0,<4.0.0
-  - graph-tool
+  - graph-tool>=2
   # Tools that are not in Python 
   - infernal=1
   - aragorn=1

--- a/ppanggolin_env.yaml
+++ b/ppanggolin_env.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pandas>=2.0.0,<3.0.0
   - numpy>1.24.0,<2.0.0
   - bokeh>=3.0.0,<4.0.0
-  - graph_tool
+  - graph-tool
   # Tools that are not in Python 
   - infernal=1
   - aragorn=1

--- a/ppanggolin_env.yaml
+++ b/ppanggolin_env.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pandas>=2.0.0,<3.0.0
   - numpy>1.24.0,<2.0.0
   - bokeh>=3.0.0,<4.0.0
+  - graph_tool
   # Tools that are not in Python 
   - infernal=1
   - aragorn=1

--- a/tests/functional_tests/test_write_pangenome.py
+++ b/tests/functional_tests/test_write_pangenome.py
@@ -34,7 +34,6 @@ OUTDIR_COMMANDS_AND_FILES = [
             "partitions/shell.txt",
             "partitions/soft_accessory.txt",
             "partitions/soft_core.txt",
-            
         ],
     ),
     (

--- a/tests/functional_tests/test_write_pangenome.py
+++ b/tests/functional_tests/test_write_pangenome.py
@@ -9,12 +9,13 @@ OUTDIR_COMMANDS_AND_FILES = [
     (
         "write_pangenome_outdir",
         "ppanggolin write_pangenome -p {pangenome} --output {outdir} -f "
-        "--soft_core 0.9 --dup_margin 0.06 --gexf --light_gexf --csv --Rtab --stats "
+        "--soft_core 0.9 --dup_margin 0.06 --gexf --light_gexf --gt --csv --Rtab --stats "
         "--partitions --compress --json --spots --regions --borders --families_tsv --cpu 1",
         [
             "border_protein_genes.fasta.gz",
             "genomes_statistics.tsv.gz",
             "pangenomeGraph.gexf.gz",
+            "pangenomeGraph.gt.gz",
             "gene_families.tsv.gz",
             "matrix.csv.gz",
             "pangenomeGraph.json.gz",
@@ -33,6 +34,7 @@ OUTDIR_COMMANDS_AND_FILES = [
             "partitions/shell.txt",
             "partitions/soft_accessory.txt",
             "partitions/soft_core.txt",
+            
         ],
     ),
     (


### PR DESCRIPTION
Add a new option `--gt` to export a PPanGGOLiN pangenome graph in [graph-tools](https://graph-tool.skewed.de/)' gt binary format. This allows to convert HDF5 to .gt, with a subset of the HDF5 pangenome file content (namely, the graph topology, graph vertices gene family identifiers, strains and partition), and edges strains.

This option makes use of `graph-tool` save function, which means graph-tools would become another dependency of PPanGGOLiN.