### PR TITLE
Fix translation table type handling

### DIFF
--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -1644,8 +1644,9 @@ def check_translation_table_to_use(
     :param user_translation_table: The translation table value provided by the user
                                    (default or explicitly specified)
 
-    :return: The translation table to use for translation
+    :return: The translation table to use for translation, normalized to an int
     """
+
     logger = logging.getLogger("PPanGGOLiN")
 
     pangenome_translation_table = pangenome.status.get("translation_table", None)
@@ -1716,18 +1717,19 @@ def check_translation_table_to_use(
             logger.debug(
                 f"Using user-specified translation table: {user_translation_table}"
             )
-        return user_translation_table
+        return int(user_translation_table)
 
     # Case 2: No user specification, use genetic code from previous steps if available
     if pangenome_translation_table is not None:
         logger.debug(
             f"Using translation table from previous pangenome analysis: {pangenome_translation_table}"
         )
-        return pangenome_translation_table
+
+        return int(pangenome_translation_table)
 
     # Case 3: No user specification and no previous data, use default
     logger.info(
         f"No translation table information found in previous pangenome analysis. "
         f"Using the default translation table: {user_translation_table}."
     )
-    return user_translation_table
+    return int(user_translation_table)


### PR DESCRIPTION
This PR fixes translation table handling when working with pangenomes created by older PPanGGOLiN versions (versions earlier than 2.3.0).

In pangenome created with ppanggolin < 2.3.0, the translation table is not stored in the pangenome status field. In that situation, the helper function check_translation_table_to_use falls back to values stored in the pangenome parameters section of the HDF5 file. Those values could be read as strings instead of integers.

In projection command, that caused downstream failures in pyrodigal, which expects an integer translation table and crashes when given a string.

The fix ensures that check_translation_table_to_use always returns an int, regardless of whether the value comes from the status field, the parameters section, or the user-provided default. This makes projection and other commands that infer the translation table safe to run on older pangenomes that do not have the status field populated.