### PR TITLE
Fix GEXF namespace so the pangenome graph can be parsed

### DIFF
--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -218,9 +218,9 @@ def write_gexf_header(gexf: TextIO, light: bool = True):
     if not light:
         index = pan.get_org_index()  # has been computed already
     gexf.write(
-        '<?xml version="1.1" encoding="UTF-8"?>\n<gexf xmlns:viz="https://www.gexf.net/1.2draft/viz"'
-        ' xmlns="https://www.gexf.net/1.2draft" version="1.2">\n'
-    )  # TODO update link
+        '<?xml version="1.1" encoding="UTF-8"?>\n<gexf xmlns:viz="http://www.gexf.net/1.2draft/viz"'
+        ' xmlns="http://www.gexf.net/1.2draft" version="1.2">\n'
+    )
     gexf.write('  <graph mode="static" defaultedgetype="undirected">\n')
     gexf.write('    <attributes class="node" mode="static">\n')
     gexf.write('      <attribute id="0" title="nb_genes" type="long" />\n')

--- a/tests/functional_tests/test_write_pangenome.py
+++ b/tests/functional_tests/test_write_pangenome.py
@@ -1,5 +1,6 @@
 # tests/functional_tests/test_stepbystep.py
 from pathlib import Path
+import networkx as nx
 import pytest
 
 from tests.utils.run_ppanggolin import run_ppanggolin_command
@@ -64,3 +65,17 @@ def test_stepbystep_outputs(
         fpath = Path(outdir) / fname
         assert fpath.exists(), f"Expected file {fname} not found after `{cmd}`"
         assert fpath.stat().st_size > 0, f"File {fname} is empty after `{cmd}`"
+
+        if ".gexf" in fname:
+            # Existence is not enough: a malformed header still writes a
+            # non-empty file that no namespace-aware parser can read.
+            try:
+                graph = nx.read_gexf(fpath)
+            except Exception as err:
+                pytest.fail(f"{fname} was written but could not be parsed back: {err}")
+            assert graph.number_of_nodes() > 0, f"{fname} parsed but has no nodes"
+            # Fixing only the default namespace and leaving xmlns:viz behind
+            # still parses, but drops every colour and size.
+            assert any(
+                "viz" in data for _, data in graph.nodes(data=True)
+            ), f"{fname} parsed but its viz attributes were dropped"


### PR DESCRIPTION
## Problem

`write_gexf_header` declares `xmlns="https://www.gexf.net/1.2draft"`. The GEXF 1.2draft schema declares `targetNamespace="http://www.gexf.net/1.2draft"`, so the `https` form matches nothing.

Gephi's importer dispatches on element local names and ignores the namespace URI, so the files still open there — which is presumably why this went unnoticed. A namespace-aware reader rejects them:

```python
>>> import networkx as nx
>>> nx.read_gexf("pangenomeGraph_light.gexf.gz")
networkx.exception.NetworkXError: No <graph> element in GEXF file.
```

A spec-conforming lxml or ElementTree query is worse: it returns zero nodes without raising.

This affects `pangenomeGraph.gexf` and `pangenomeGraph_light.gexf`, the two outputs of `write_pangenome --gexf` / `--light_gexf`. Introduced in 00978da1 (October 2021) and present in every release from 1.2.46 to 2.3.1.

## Fix

`https` → `http` on both `xmlns` and `xmlns:viz`.

This makes `write_gexf_header` consistent with the rest of the project: `RGP/spot.py`, `RGP/rgp_cluster.py`, `context/searchGeneContext.py` and `figures/draw_spot.py` all go through `nx.write_gexf`, which emits the correct namespace. `write_gexf_header` was the only hand-written GEXF header, and it has carried a `# TODO update link` on that same line ever since the commit that introduced the https URL.

## Test

The functional test asserted only that the gexf output exists and is larger than zero bytes — which a file with a malformed header satisfies. It now reads the file back with networkx (already a hard dependency, and it handles `.gexf.gz` directly, so the parametrisation is unchanged) and requires a non-empty graph whose nodes still carry their viz attributes.

The viz assertion is not redundant. Fixing only the default namespace and leaving `xmlns:viz` on https still parses to the full node count, but silently drops every partition colour and size — a node-count assertion alone would pass.

Verified against the `stepbystep` fixture:

| `write_gexf_header` | `pytest tests/functional_tests/test_write_pangenome.py --full` |
|---|---|
| fixed | 2 passed |
| both namespaces back on https | `Failed: pangenomeGraph.gexf.gz was written but could not be parsed back: No <graph> element in GEXF file.` |
| only `xmlns:viz` left on https | fails on the viz assertion |

## Checks

- `black --check --diff .` with black 24.10.0, the version `use_pyproject: true` resolves from `pyproject.toml`: 102 files unchanged.
- Parsing verified on networkx 3.0 (the declared minimum), 3.2.1 and 3.5, covering the whole `networkx>=3.0.0,<4.0.0` range.
- No golden checksum or expected-output file covers a gexf, so nothing else needs regenerating.

## Deliberately left out

Three pre-existing issues in the same header, two of which only became observable now that the file can be parsed at all:

- `<meta>` is written inside `<graph>` rather than as a sibling, so networkx drops the PPanGGOLiN version provenance.
- Every `viz:color` carries `a="0"`, which per the viz schema means fully transparent.
- The XML declaration says `version="1.1"`; Go's `encoding/xml` rejects such files outright and libxml2 warns.

Happy to open separate PRs for any of these.

Not switching to GEXF 1.3: networkx supports only 1.1draft and 1.2draft, so a 1.3 namespace would break the test this PR adds.
