### PR TITLE
Open the pangenome read-only when only reading it

### DIFF
--- a/ppanggolin/info/info.py
+++ b/ppanggolin/info/info.py
@@ -91,7 +91,7 @@ def print_info(
     if not (status or content or parameters or metadata):
         status, content, parameters, metadata = (True, True, True, True)
 
-    h5f = tables.open_file(pangenome, "r+")
+    h5f = tables.open_file(pangenome, "r")
     if status:
         print_yaml(read_status(h5f))
     if content:

--- a/ppanggolin/metrics/metrics.py
+++ b/ppanggolin/metrics/metrics.py
@@ -28,7 +28,7 @@ def check_already_computed_metric(
     :param print_metric: Print metrics if already computed
     :param recompute: Are metrics going to be recompute
     """
-    with tables.open_file(pangenome.file, "a") as h5f:
+    with tables.open_file(pangenome.file, "r") as h5f:
         info_group = h5f.root.info
         if genomes_fluidity and "genomes_fluidity" in info_group._v_attrs._f_list():
             logging.getLogger("PPanGGOLiN").warning(

--- a/tests/functional_tests/test_read_only_pangenome.py
+++ b/tests/functional_tests/test_read_only_pangenome.py
@@ -1,0 +1,31 @@
+import os
+import shutil
+
+import pytest
+
+from tests.utils.run_ppanggolin import run_ppanggolin_command
+from tests.functional_tests.test_stepbystep import stepbystep_pangenome
+
+
+def test_read_only_pangenome(stepbystep_pangenome, tmp_path):
+    """Commands that only read a pangenome must not require write access to it.
+
+    Reference collections are distributed on read-only media, and making a
+    local copy read-only is the simplest way to keep a pangenome byte-identical
+    to the one it was downloaded from.
+    """
+    pangenome = tmp_path / "pangenome.h5"
+    shutil.copy(stepbystep_pangenome, pangenome)
+    pangenome.chmod(0o444)
+
+    if os.access(pangenome, os.W_OK):
+        # Running as root, or on a filesystem that ignores the mode. PyTables
+        # gates write modes on this very call, so the commands below would
+        # succeed even unfixed and the test would prove nothing.
+        pytest.skip("write access to the pangenome could not be revoked")
+
+    run_ppanggolin_command(f"ppanggolin info -p {pangenome}")
+
+    # Genome fluidity is already stored in the file, so this reads it back
+    # and prints it without recomputing anything.
+    run_ppanggolin_command(f"ppanggolin metrics -p {pangenome} --genome_fluidity")


### PR DESCRIPTION
## Problem

`ppanggolin info` opens the pangenome in `"r+"` and the "already computed?" check in `metrics` opens it in `"a"`, but neither writes. Both therefore fail on a pangenome the user cannot write:

```
$ chmod 444 pangenome.h5
$ ppanggolin info -p pangenome.h5 --content
PermissionError: file ``pangenome.h5`` exists but it can not be written
```

PyTables gates write modes at open time on `os.access(path, os.W_OK)`, so the failure happens even though nothing is ever written.

That rules out inspecting a pangenome on read-only media — a shared reference collection, a read-only mount, a container volume — and it rules out `chmod 444` as a guard against a command rewriting a `.h5` in place. `metrics --genome_fluidity` is affected even when the fluidity is already stored in the file and only needs printing, because the check runs before anything decides whether to compute and is not guarded by any flag.

## Fix

`info.py`: `"r+"` → `"r"`. `metrics.py`, `check_already_computed_metric`: `"a"` → `"r"`.

Both are leftovers. info needed write access only for the `Partitionned` → `Partitioned` repair: 78390bb1 raised the mode alongside that repair, which reopened the file in `"a"` to do its own write; the repair later moved into `fix_partitioned()`, lost its last caller in 5b2942ae, and the function was deleted in 82330abc. The metric check has opened `"a"` ever since `check_metric` was introduced in 3795e50d; 079bf877 dropped the `--force` guard in front of it, so it now runs on every invocation.

## These were the only two

After this change the package has five write-mode opens left, all in genuine writers (`write_pangenome`, `erase_pangenome`, `write_metadata`, `write_metrics`), reachable only from `annotate`, `cluster`, `graph`, `partition`, `rgp`, `spot`, `module`, `metadata`, the metrics write path and the workflows. `grep '"r+"'` over the tree returns nothing.

Measured on a `chmod 444` pangenome (21 genomes, 8098 families):

| command | before | after |
|---|---|---|
| `info` | PermissionError | ok |
| `metrics --genome_fluidity` | PermissionError | ok |
| `write_pangenome`, `write_genomes`, `draw`, `fasta`, `write_metadata`, `rgp_cluster`, `rarefaction` | ok | ok |

`projection` also reads the whole pangenome — annotations, families, RGPs, spots, modules, metadata — from a read-only file. The md5 was unchanged in every run.

The mutating commands still fail on a read-only file, which is the point: `partition` / `rgp` / `spot` / `module` fail early inside `erase_pangenome`, `metadata` and `metrics --recompute_metrics` fail at their final `"a"` open, and in every case the file is left byte-identical — no partial writes. So `chmod 444` becomes a usable guard: every reader survives it, only the writers stop.

## Test

`tests/functional_tests/test_read_only_pangenome.py` copies the fixture, chmods it 444, and runs both commands.

| tree | unprivileged | uid 0 |
|---|---|---|
| fixed | passed | — |
| both modes reverted | **failed** | **skipped** |
| only the metric mode reverted | **failed** | — |

The test skips itself when write access survives the chmod. `chmod 444` does not restrain root, and PyTables' only gate is that `os.access` call, so at uid 0 the commands succeed even unfixed and the test would report green while proving nothing — I checked this with `unshare -r` and it did report `1 passed` on the unfixed tree before the guard was added. There is no root-proof alternative: opening the file in `"r+"` and closing it leaves it byte-identical, so an integrity assertion would pass on the unfixed code too. Current CI is unaffected (GitHub-hosted runners are non-root), but the guard keeps the test honest for anyone running the suite in a container.

## Checks

- `black --check .` with black 24.10.0, the version `use_pyproject: true` resolves from `pyproject.toml`: 103 files unchanged.
- `ppanggolin info` output is byte-identical before and after on the same pangenome, and the file md5 is untouched.
- Unit suite unchanged (469 passed); the full functional suite shows the same pre-existing failures on this branch as on `dev`.
- The write path still works: recompute-and-persist verified both on a file that already carries `genomes_fluidity` and on a copy with the attribute removed, with the resulting files identical to the ones `dev` produces.
- `check_already_computed_metric` has a single caller, always preceded by `Pangenome.add_file()`, which already checks the file exists and is HDF5 — so the `"a"`-creates-a-missing-file behaviour it relied on was unreachable.

## Not in this PR

`info.py` still does `h5f = ...` / `h5f.close()` with no context manager, so a read that raises leaks the handle. And `metrics --recompute_metrics` on a read-only file still fails only after the computation has finished; failing early on a writability check would be a separate improvement. Happy to do either if you want them.
