### PR TITLE
Refactor command line documentation and improve RGP clustering details

### DIFF
--- a/.github/workflows/check_doc.yml
+++ b/.github/workflows/check_doc.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
     - name: install ppanggolin with python deps and doc deps
       run: pip install .[doc]
 

--- a/docs/_scripts/generate_command_reference.py
+++ b/docs/_scripts/generate_command_reference.py
@@ -91,9 +91,9 @@ def _iter_actions(parser: argparse.ArgumentParser) -> Iterable[argparse.Action]:
 def _generate_command_section(
     command_name: str, parser: argparse.ArgumentParser
 ) -> str:
-    title = f"## `ppanggolin {command_name}`"
+    title = f"### `ppanggolin {command_name}`"
     description = (
-        parser.description
+        getattr(parser, "description", None)
         or "Command description is not explicitly set in this parser."
     )
     lines = [
@@ -101,7 +101,7 @@ def _generate_command_section(
         "",
         description.strip(),
         "",
-        "### Parameters",
+        "#### Parameters",
         "",
         "| Parameter | Type | Default | Required | Choices | Description |",
         "|---|---|---|---|---|---|",
@@ -115,8 +115,6 @@ def _generate_command_section(
     for action in actions:
         info = _describe_action(action)
         help_text = info["help"]
-        if info["is_flag"] and help_text:
-            help_text = help_text
         if not help_text:
             help_text = "—"
         lines.append(
@@ -163,9 +161,27 @@ def generate_reference(output_path: Path | str | None = None) -> str:
         "",
     ]
 
+    category_order = [
+        "Basic",
+        "Expert",
+        "Output",
+        "Regions of Genomic Plasticity",
+        "Analysis using reference pangenomes",
+        "Utility command",
+    ]
+    grouped_commands: dict[str, List[tuple[str, argparse.ArgumentParser]]] = {}
     for command_name, command_parser in commands:
-        sections.append(_generate_command_section(command_name, command_parser))
+        category = getattr(command_parser, "category", "General")
+        grouped_commands.setdefault(category, []).append((command_name, command_parser))
+
+    for category in category_order:
+        if category not in grouped_commands:
+            continue
+        sections.append(f"## {category}")
         sections.append("")
+        for command_name, command_parser in grouped_commands[category]:
+            sections.append(_generate_command_section(command_name, command_parser))
+            sections.append("")
 
     rendered = "\n".join(sections).strip() + "\n"
 

--- a/docs/_scripts/generate_command_reference.py
+++ b/docs/_scripts/generate_command_reference.py
@@ -4,7 +4,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Union
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -204,7 +204,7 @@ def _collect_subcommands(
     return commands
 
 
-def generate_reference(output_path: Optional[Path | str] = None) -> str:
+def generate_reference(output_path: Optional[Union[Path, str]] = None) -> str:
     parser = build_parser()
     commands = _collect_subcommands(parser)
 

--- a/docs/_scripts/generate_command_reference.py
+++ b/docs/_scripts/generate_command_reference.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import re
 import sys
 from pathlib import Path
 from typing import Iterable, List
@@ -41,6 +42,12 @@ def _format_default(action: argparse.Action) -> str:
     if action.default is True and action.option_strings:
         return "True"
     if isinstance(action.default, Path):
+        value = str(action.default)
+        pattern = r"^(ppanggolin_[A-Za-z0-9_]+)DATE\d{4}-\d{2}-\d{2}_HOUR\d{2}\.\d{2}\.\d{2}_PID\d+$"
+        match = re.match(pattern, value)
+        if match:
+            prefix = match.group(1)
+            return f"`{prefix}<date>_<pid>`"
         return str(action.default)
     if isinstance(action.default, (list, tuple, set)):
         return str(list(action.default))
@@ -52,7 +59,7 @@ def _format_default(action: argparse.Action) -> str:
 def _format_choices(action: argparse.Action) -> str:
     if not action.choices:
         return "—"
-    return ", ".join(str(choice) for choice in action.choices)
+    return ", ".join(f"`{choice}`" for choice in action.choices)
 
 
 def _format_param_name(action: argparse.Action) -> str:
@@ -88,6 +95,38 @@ def _iter_actions(parser: argparse.ArgumentParser) -> Iterable[argparse.Action]:
             yield action
 
 
+def _generate_action_table(
+    title: str, actions: list[argparse.Action], command_name: str | None = None
+) -> list[str]:
+    heading = (
+        title if command_name is None else f"{title} for ppanggolin {command_name}"
+    )
+    lines = [
+        f"#### {heading}",
+        "",
+        "| Parameter | Type | Default | Description |",
+        "|---|---|---|---|",
+    ]
+
+    for action in actions:
+        info = _describe_action(action)
+        description_parts = []
+        help_text = info["help"].strip() if info["help"] else "—"
+        description_parts.append(help_text)
+
+        if info["required"] == "Yes":
+            description_parts.append("Required: Yes")
+        if info["choices"] != "—":
+            description_parts.append(f"Choices: {info['choices']}")
+
+        description = " ".join(part for part in description_parts if part)
+        lines.append(
+            f"| `{info['name']}` | {info['type']} | {info['default']} | {description} |"
+        )
+
+    return lines
+
+
 def _generate_command_section(
     command_name: str, parser: argparse.ArgumentParser
 ) -> str:
@@ -101,10 +140,6 @@ def _generate_command_section(
         "",
         description.strip(),
         "",
-        "#### Parameters",
-        "",
-        "| Parameter | Type | Default | Required | Choices | Description |",
-        "|---|---|---|---|---|---|",
     ]
 
     actions = list(_iter_actions(parser))
@@ -112,16 +147,25 @@ def _generate_command_section(
         lines.append("No parameters are defined for this command.")
         return "\n".join(lines) + "\n"
 
-    for action in actions:
-        info = _describe_action(action)
-        help_text = info["help"]
-        if not help_text:
-            help_text = "—"
-        lines.append(
-            f"| `{info['name']}` | {info['type']} | {info['default']} | {info['required']} | {info['choices']} | {help_text} |"
-        )
+    required_actions = [action for action in actions if action.required]
+    optional_actions = [action for action in actions if not action.required]
 
-    return "\n".join(lines) + "\n"
+    if required_actions:
+        lines.extend(
+            _generate_action_table(
+                "Required parameters", required_actions, command_name
+            )
+        )
+        lines.append("")
+    if optional_actions:
+        lines.extend(
+            _generate_action_table(
+                "Optional parameters", optional_actions, command_name
+            )
+        )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def _collect_subcommands(

--- a/docs/_scripts/generate_command_reference.py
+++ b/docs/_scripts/generate_command_reference.py
@@ -4,7 +4,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -14,43 +14,59 @@ from ppanggolin.main import build_parser
 
 
 def _format_type(action: argparse.Action) -> str:
-    if action.nargs in (None, "?"):
-        if isinstance(action.type, type):
-            return action.type.__name__
-        if action.type is not None:
-            return getattr(action.type, "__name__", str(action.type))
-        if action.const is not None and action.default is False:
-            return "bool"
-        if action.default is not None:
-            return type(action.default).__name__
-        return "str"
+    if action.option_strings and action.nargs == 0:
+        return "bool"
 
-    if action.nargs == "*":
-        return "list"
-    if action.nargs == "+":
-        return "list"
-    if action.nargs == "?":
-        return "optional"
-    return str(action.nargs)
+    if isinstance(action.type, type):
+        return action.type.__name__
+
+    if action.type is not None:
+        type_name = getattr(action.type, "__name__", None)
+        if type_name in {"check_log", "restricted_float", "min_one", "filter_values"}:
+            return {
+                "check_log": "str",
+                "restricted_float": "float",
+                "min_one": "int",
+                "filter_values": "str",
+            }[type_name]
+        if type_name:
+            return type_name
+        if hasattr(action.type, "__call__"):
+            return "str"
+
+    if action.default is not None:
+        if isinstance(action.default, bool):
+            return "bool"
+        return type(action.default).__name__
+
+    if action.const is not None:
+        return type(action.const).__name__
+
+    return "str"
 
 
 def _format_default(action: argparse.Action) -> str:
+
     if action.default is None:
         return "—"
     if action.default is False and action.option_strings:
         return "False"
     if action.default is True and action.option_strings:
         return "True"
+
+    value = str(action.default)
+    pattern = (
+        r"^(?P<prefix>.*?)(?:_?DATE\d{4}-\d{2}-\d{2}_HOUR\d{2}\.\d{2}\.\d{2}_PID\d+)$"
+    )
+    match = re.match(pattern, value)
+    if match:
+        prefix = match.group("prefix").rstrip("_")
+        return f"`{prefix}_<date>_<pid>`"
+
     if isinstance(action.default, Path):
-        value = str(action.default)
-        pattern = r"^(ppanggolin_[A-Za-z0-9_]+)DATE\d{4}-\d{2}-\d{2}_HOUR\d{2}\.\d{2}\.\d{2}_PID\d+$"
-        match = re.match(pattern, value)
-        if match:
-            prefix = match.group(1)
-            return f"`{prefix}<date>_<pid>`"
-        return str(action.default)
+        return f"`{action.default}`"
     if isinstance(action.default, (list, tuple, set)):
-        return str(list(action.default))
+        return f"`{str(list(action.default))}`"
     if isinstance(action.default, str):
         return f"`{action.default}`"
     return str(action.default)
@@ -106,7 +122,7 @@ def _iter_action_groups(
 
 
 def _generate_action_table(
-    title: str, actions: list[argparse.Action], command_name: str | None = None
+    title: str, actions: list[argparse.Action], command_name: Optional[str] = None
 ) -> list[str]:
     heading = (
         title if command_name is None else f"{title} for ppanggolin {command_name}"
@@ -188,7 +204,7 @@ def _collect_subcommands(
     return commands
 
 
-def generate_reference(output_path: Path | str | None = None) -> str:
+def generate_reference(output_path: Optional[Path | str] = None) -> str:
     parser = build_parser()
     commands = _collect_subcommands(parser)
 

--- a/docs/_scripts/generate_command_reference.py
+++ b/docs/_scripts/generate_command_reference.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from ppanggolin.main import build_parser
+
+
+def _format_type(action: argparse.Action) -> str:
+    if action.nargs in (None, "?"):
+        if isinstance(action.type, type):
+            return action.type.__name__
+        if action.type is not None:
+            return getattr(action.type, "__name__", str(action.type))
+        if action.const is not None and action.default is False:
+            return "bool"
+        if action.default is not None:
+            return type(action.default).__name__
+        return "str"
+
+    if action.nargs == "*":
+        return "list"
+    if action.nargs == "+":
+        return "list"
+    if action.nargs == "?":
+        return "optional"
+    return str(action.nargs)
+
+
+def _format_default(action: argparse.Action) -> str:
+    if action.default is None:
+        return "—"
+    if action.default is False and action.option_strings:
+        return "False"
+    if action.default is True and action.option_strings:
+        return "True"
+    if isinstance(action.default, Path):
+        return str(action.default)
+    if isinstance(action.default, (list, tuple, set)):
+        return str(list(action.default))
+    if isinstance(action.default, str):
+        return f"`{action.default}`"
+    return str(action.default)
+
+
+def _format_choices(action: argparse.Action) -> str:
+    if not action.choices:
+        return "—"
+    return ", ".join(str(choice) for choice in action.choices)
+
+
+def _format_param_name(action: argparse.Action) -> str:
+    names = [opt for opt in action.option_strings]
+    if not names:
+        if action.metavar:
+            return action.metavar
+        return action.dest
+    return ", ".join(names)
+
+
+def _describe_action(action: argparse.Action) -> dict:
+    return {
+        "name": _format_param_name(action),
+        "type": _format_type(action),
+        "default": _format_default(action),
+        "required": "Yes" if action.required else "No",
+        "choices": _format_choices(action),
+        "help": (action.help or "").replace("\n", " ").strip(),
+        "is_flag": action.option_strings and action.nargs == 0,
+    }
+
+
+def _iter_actions(parser: argparse.ArgumentParser) -> Iterable[argparse.Action]:
+    seen = set()
+    for action_group in parser._action_groups:
+        for action in action_group._group_actions:
+            if action.dest == "help":
+                continue
+            if action.dest in seen:
+                continue
+            seen.add(action.dest)
+            yield action
+
+
+def _generate_command_section(
+    command_name: str, parser: argparse.ArgumentParser
+) -> str:
+    title = f"## `ppanggolin {command_name}`"
+    description = (
+        parser.description
+        or "Command description is not explicitly set in this parser."
+    )
+    lines = [
+        title,
+        "",
+        description.strip(),
+        "",
+        "### Parameters",
+        "",
+        "| Parameter | Type | Default | Required | Choices | Description |",
+        "|---|---|---|---|---|---|",
+    ]
+
+    actions = list(_iter_actions(parser))
+    if not actions:
+        lines.append("No parameters are defined for this command.")
+        return "\n".join(lines) + "\n"
+
+    for action in actions:
+        info = _describe_action(action)
+        help_text = info["help"]
+        if info["is_flag"] and help_text:
+            help_text = help_text
+        if not help_text:
+            help_text = "—"
+        lines.append(
+            f"| `{info['name']}` | {info['type']} | {info['default']} | {info['required']} | {info['choices']} | {help_text} |"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def _collect_subcommands(
+    parser: argparse.ArgumentParser,
+) -> List[tuple[str, argparse.ArgumentParser]]:
+    subparsers_action = next(
+        (
+            group
+            for group in parser._action_groups
+            if isinstance(group, argparse._ArgumentGroup)
+        ),
+        None,
+    )
+    subparsers = []
+    for action in getattr(parser, "_actions", []):
+        if isinstance(action, argparse._SubParsersAction):
+            subparsers = action.choices.items()
+            break
+
+    commands = []
+    for command_name, command_parser in subparsers:
+        commands.append((command_name, command_parser))
+    commands.sort(key=lambda item: item[0])
+    return commands
+
+
+def generate_reference(output_path: Path | str | None = None) -> str:
+    parser = build_parser()
+    commands = _collect_subcommands(parser)
+
+    sections = [
+        "# Command-line reference",
+        "",
+        "Complete reference of the PPanGGOLiN command-line interface.",
+        "",
+        "This page is automatically generated from the PPanGGOLiN command-line parser.",
+        "",
+    ]
+
+    for command_name, command_parser in commands:
+        sections.append(_generate_command_section(command_name, command_parser))
+        sections.append("")
+
+    rendered = "\n".join(sections).strip() + "\n"
+
+    if output_path is not None:
+        output_file = Path(output_path)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(rendered, encoding="utf-8")
+    return rendered
+
+
+if __name__ == "__main__":
+    script_path = Path(__file__).resolve().parents[1] / "user" / "command_reference.md"
+    generate_reference(script_path)

--- a/docs/_scripts/generate_command_reference.py
+++ b/docs/_scripts/generate_command_reference.py
@@ -83,16 +83,26 @@ def _describe_action(action: argparse.Action) -> dict:
     }
 
 
-def _iter_actions(parser: argparse.ArgumentParser) -> Iterable[argparse.Action]:
+def _iter_action_groups(
+    parser: argparse.ArgumentParser,
+) -> Iterable[tuple[str, list[argparse.Action]]]:
     seen = set()
     for action_group in parser._action_groups:
+        group_title = action_group.title or "Arguments"
+        if group_title in {"positional arguments", "options"}:
+            continue
+
+        actions = []
         for action in action_group._group_actions:
             if action.dest == "help":
                 continue
             if action.dest in seen:
                 continue
             seen.add(action.dest)
-            yield action
+            actions.append(action)
+
+        if actions:
+            yield group_title, actions
 
 
 def _generate_action_table(
@@ -117,7 +127,7 @@ def _generate_action_table(
         if info["required"] == "Yes":
             description_parts.append("Required: Yes")
         if info["choices"] != "—":
-            description_parts.append(f"Choices: {info['choices']}")
+            description_parts.append(f"<br>Choices: {info['choices']}")
 
         description = " ".join(part for part in description_parts if part)
         lines.append(
@@ -142,27 +152,13 @@ def _generate_command_section(
         "",
     ]
 
-    actions = list(_iter_actions(parser))
-    if not actions:
+    action_groups = list(_iter_action_groups(parser))
+    if not action_groups:
         lines.append("No parameters are defined for this command.")
         return "\n".join(lines) + "\n"
 
-    required_actions = [action for action in actions if action.required]
-    optional_actions = [action for action in actions if not action.required]
-
-    if required_actions:
-        lines.extend(
-            _generate_action_table(
-                "Required parameters", required_actions, command_name
-            )
-        )
-        lines.append("")
-    if optional_actions:
-        lines.extend(
-            _generate_action_table(
-                "Optional parameters", optional_actions, command_name
-            )
-        )
+    for group_title, actions in action_groups:
+        lines.extend(_generate_action_table(group_title, actions, command_name))
         lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,36 @@
+.wy-table-responsive table {
+  width: 100% !important;
+  table-layout: fixed;
+}
+
+/* .wy-table-responsive {
+  overflow-x: auto;
+} */
+
+.rst-content table.docutils td,
+.rst-content table.docutils th {
+  white-space: normal;
+  /* word-wrap: break-word; */
+  overflow-wrap: anywhere;
+  /* vertical-align: top; */
+}
+
+.rst-content table.docutils th:nth-child(1),
+.rst-content table.docutils td:nth-child(1) {
+  width: 18%;
+}
+
+.rst-content table.docutils th:nth-child(2),
+.rst-content table.docutils td:nth-child(2) {
+  width: 12%;
+}
+
+.rst-content table.docutils th:nth-child(3),
+.rst-content table.docutils td:nth-child(3) {
+  width: 15%;
+}
+
+.rst-content table.docutils th:nth-child(4),
+.rst-content table.docutils td:nth-child(4) {
+  width: 55%;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,3 +81,4 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,22 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import subprocess
+import sys
 from pathlib import Path
+
+
+def generate_command_reference(_app):
+    script = (
+        Path(__file__).resolve().parent / "_scripts" / "generate_command_reference.py"
+    )
+    if script.exists():
+        subprocess.check_call([sys.executable, str(script)])
+
+
+def setup(app):
+    app.connect("builder-inited", generate_command_reference)
+
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ Those RGPs can be further divided in conserved modules by panModule ([Bazin et a
 :maxdepth: 2
 
 user/install
+user/command_reference
 user/QuickUsage/quickAnalyses
 user/practicalInformation
 user/PangenomeAnalyses/pangenomeAnalyses

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,6 @@ Those RGPs can be further divided in conserved modules by panModule ([Bazin et a
 :maxdepth: 2
 
 user/install
-user/command_reference
 user/QuickUsage/quickAnalyses
 user/practicalInformation
 user/PangenomeAnalyses/pangenomeAnalyses
@@ -81,6 +80,7 @@ user/projection
 user/genomicContext
 user/MSA
 user/metadata
+user/command_reference
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ Those RGPs can be further divided in conserved modules by panModule ([Bazin et a
 :maxdepth: 2
 
 user/install
+user/whatsNewInV2
 user/QuickUsage/quickAnalyses
 user/practicalInformation
 user/PangenomeAnalyses/pangenomeAnalyses

--- a/docs/user/PangenomeAnalyses/pangenomeAnnotation.md
+++ b/docs/user/PangenomeAnalyses/pangenomeAnnotation.md
@@ -46,6 +46,7 @@ You can prevent this filtering by using the `--allow_overlap` option.
 Additionally, the `--kingdom archaea` option can be provided when working with archaea genomes
 to specify Infernal's RNA annotation model. 
 
+(annot-gff)=
 ### Use annotation files for your pangenome
 
 You can provide annotation files in either gff3 files or .gbk/.gbff files, or a mix of them. They should be provided through as a list in a tab-separated file that follows the same format as described for the fasta files. You can check [this example input file](https://github.com/labgem/PPanGGOLiN/blob/master/testingDataset/genomes.gbff.list).

--- a/docs/user/RGP/rgpClustering.md
+++ b/docs/user/RGP/rgpClustering.md
@@ -10,7 +10,7 @@ The ppanggolin `rgp_cluster` command performs the following steps to cluster RGP
 
 There are three modes available for calculating the GRR value: `min_grr`, `max_grr`, or `incomplete_aware_grr`.
 - `min_grr` mode: This mode computes the number of gene families shared between two RGPs and divides it by the smaller number of gene families among the two RGPs.
-- `max_grr` mode: In this mode, the number of gene families shared between two RGPs is calculated and divided by the larger number of gene families among the two RGPs.
+- `max_grr` mode: In this mode, the number of gene families shared between two RGPs is calculated and divided by the larger number of gene families between the two RGPs.
 - `incomplete_aware_grr` (default) mode: If at least one RGP is considered incomplete, which typically happens when it is located at the border of a contig, the `min_grr` mode is used. Otherwise, the `max_grr` mode is applied. This mode is useful to correctly cluster incomplete RGP.
 
 
@@ -18,11 +18,11 @@ By default, the output files are written in a directory named `rgp_clustering` c
 
 The resulting RGP clusters are stored in a tsv file (`rgp_cluster.tsv`) with the following columns:
 
-| column  | description                  |
-|---------|------------------------------|
-|RGP|The unique region identifier.|
-|cluster|The cluster id of the RGP.|
-|spot_id|The spot ID of the RGP.|
+| column  | description                   |
+|---------|-------------------------------|
+| RGP     | The unique region identifier. |
+| cluster | The cluster id of the RGP.    |
+| spot_id | The spot ID of the RGP.       |
 
 
-The command also generates the RGP graph in the gexf format, which can be used to explore the RGP clusters along with their spots of insertion. In this graph, identical RGPs with the same family content and with the same spot are merged into a single node to simplify the graph representation. This feature can be disable with the parameter `--no_identical_rgp_merging`.
+The command also generates the RGP graph in the gexf format, which can be used to explore the RGP clusters along with their spots of insertion. In this graph, identical RGPs with the same family content and with the same spot are merged into a single node to simplify the graph representation. This feature can be disabled with the parameter `--no_identical_rgp_merging`.

--- a/docs/user/RGP/rgpClustering.md
+++ b/docs/user/RGP/rgpClustering.md
@@ -14,7 +14,9 @@ There are three modes available for calculating the GRR value: `min_grr`, `max_g
 - `incomplete_aware_grr` (default) mode: If at least one RGP is considered incomplete, which typically happens when it is located at the border of a contig, the `min_grr` mode is used. Otherwise, the `max_grr` mode is applied. This mode is useful to correctly cluster incomplete RGP.
 
 
-The resulting RGP clusters are stored in a tsv file with the following columns:
+By default, the output files are written in a directory named `rgp_clustering` created in the working directory, which can be changed with the `--output` parameter. The files themselves are named after the `--basename` parameter (`rgp_cluster` by default).
+
+The resulting RGP clusters are stored in a tsv file (`rgp_cluster.tsv`) with the following columns:
 
 | column  | description                  |
 |---------|------------------------------|

--- a/docs/user/command_reference.md
+++ b/docs/user/command_reference.md
@@ -4,47 +4,20 @@ Complete reference of the PPanGGOLiN command-line interface.
 
 This page is automatically generated from the PPanGGOLiN command-line parser.
 
-## `ppanggolin align`
+## Basic
 
-Command description is not explicitly set in this parser.
+### `ppanggolin all`
 
-### Parameters
+Easy workflow to run all possible analysis
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-S, --sequences` | Path | — | No | — | sequences (nucleotides or amino acids) to align on the pangenome gene families |
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. (default: False) |
-| `--identity` | float | 0.5 | No | — | min identity percentage threshold |
-| `--coverage` | float | 0.8 | No | — | min coverage percentage threshold |
-| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `--getinfo` | 0 | False | No | — | Use this option to extract info related to the best hit of each query, such as the RGP it is in, or the spots. |
-| `--draw_related` | 0 | False | No | — | Draw figures and provide graphs in a gexf format of the eventual spots associated to the input sequences |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin all`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
+#### Parameters
 
 | Parameter | Type | Default | Required | Choices | Description |
 |---|---|---|---|---|---|
 | `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
 | `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
 | `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
 | `--basename` | str | `pangenome` | No | — | basename for the output file |
 | `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
 | `-c, --cpu` | int | 1 | No | — | Number of available cpus |
@@ -66,17 +39,118 @@ Command description is not explicitly set in this parser.
 | `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
 
 
-## `ppanggolin annotate`
+### `ppanggolin panmodule`
 
-Command description is not explicitly set in this parser.
+Easy workflow to run a pangenome analysis with module prediction
 
-### Parameters
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
+| `--basename` | str | `pangenome` | No | — | basename for the output file |
+| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
+| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
+| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin panrgp`
+
+Easy workflow to run a pangenome analysis with genomic islands and spots of insertion detection
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
+| `--basename` | str | `pangenome` | No | — | basename for the output file |
+| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
+| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
+| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin workflow`
+
+Easy workflow to run a pangenome analysis in one go
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
+| `--basename` | str | `pangenome` | No | — | basename for the output file |
+| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
+| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
+| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## Expert
+
+### `ppanggolin annotate`
+
+Annotate genomes
+
+#### Parameters
 
 | Parameter | Type | Default | Required | Choices | Description |
 |---|---|---|---|---|---|
 | `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
 | `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
 | `--allow_overlap` | 0 | False | No | — | Use to not remove genes overlapping with RNA features. |
 | `--norna` | 0 | False | No | — | Use to avoid annotating RNA features. |
 | `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
@@ -93,11 +167,11 @@ Command description is not explicitly set in this parser.
 | `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
 
 
-## `ppanggolin cluster`
+### `ppanggolin cluster`
 
-Command description is not explicitly set in this parser.
+Cluster genes into gene families
 
-### Parameters
+#### Parameters
 
 | Parameter | Type | Default | Required | Choices | Description |
 |---|---|---|---|---|---|
@@ -119,30 +193,16 @@ Command description is not explicitly set in this parser.
 | `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
 
 
-## `ppanggolin context`
+### `ppanggolin graph`
 
-Command description is not explicitly set in this parser.
+Create the pangenome graph
 
-### Parameters
+#### Parameters
 
 | Parameter | Type | Default | Required | Choices | Description |
 |---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
-| `-o, --output` | Path | `ppanggolin_context_DATE2026-08-13_HOUR11.43.03_PID660761` | No | — | Output directory where the file(s) will be written |
-| `-S, --sequences` | Path | — | No | — | Fasta file with the sequences of interest |
-| `-F, --family` | Path | — | No | — | List of family IDs of interest from the pangenome |
-| `-t, --transitive` | int | 4 | No | — | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
-| `-w, --window_size` | int | 5 | No | — | Number of neighboring genes that are considered on each side of a gene of interest when searching for conserved genomic contexts. |
-| `-s, --jaccard` | restricted_float | 0.85 | No | — | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
-| `--graph_format` | str | `graphml` | No | gexf, graphml | Format of the context graph. Can be gexf or graphml. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. |
-| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is recommended for faster processing but may be less sensitive. By default, all pangenome genes are used for alignment. |
-| `--identity` | float | 0.8 | No | — | min identity percentage threshold |
-| `--coverage` | float | 0.8 | No | — | min coverage percentage threshold |
-| `--translation_table` | int | 11 | No | — | The translation table to use when the input sequences are nucleotide sequences. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-r, --remove_high_copy_number` | int | 0 | No | — | Positive Number: Remove families having a number of copy of gene in a single genome above or equal to this threshold in at least one genome (0 or negative values are ignored). |
 | `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
 | `--log` | check_log | `stdout` | No | — | log output file |
 | `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
@@ -150,16 +210,98 @@ Command description is not explicitly set in this parser.
 | `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
 
 
-## `ppanggolin draw`
+### `ppanggolin metadata`
 
-Command description is not explicitly set in this parser.
+Add metadata to elements in yout pangenome
 
-### Parameters
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-m, --metadata` | Path | — | No | — | Metadata in TSV file. See our github for more detail about format |
+| `-s, --source` | str | — | No | — | Name of the metadata source |
+| `-a, --assign` | str | — | No | families, genomes, contigs, genes, RGPs, spots, modules | Select to which pangenome element metadata will be assigned |
+| `--omit` | 0 | False | No | — | Allow to pass if a key in metadata is not find in pangenome |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin partition`
+
+Partition the pangenome graph
+
+#### Parameters
 
 | Parameter | Type | Default | Required | Choices | Description |
 |---|---|---|---|---|---|
 | `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `-b, --beta` | float | 2.5 | No | — | beta is the strength of the smoothing using the graph topology during partitioning. 0 will deactivate spatial smoothing. |
+| `-ms, --max_degree_smoothing` | float | 10 | No | — | max. degree of the nodes to be included in the smoothing process. |
+| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
+| `-fd, --free_dispersion` | 0 | False | No | — | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
+| `-ck, --chunk_size` | int | 500 | No | — | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `-Kmm, --krange` | 2 | [3, 20] | No | — | Range of K values to test when detecting K automatically. |
+| `-im, --ICL_margin` | float | 0.05 | No | — | K is detected automatically by maximizing ICL. However at some point the ICL reaches a plateau. Therefore we are looking for the minimal value of K without significant gain from the larger values of K measured by ICL. For that we take the lowest K that is found within a given 'margin' of the maximal ICL value. Basically, change this option only if you truly understand it, otherwise just leave it be. |
+| `--draw_ICL` | 0 | False | No | — | Use if you want to draw the ICL curve for all the tested K values. Will not be done if K is given. |
+| `--keep_tmp_files` | 0 | False | No | — | Use if you want to keep the temporary NEM files |
+| `-se, --seed` | int | 42 | No | — | seed used to generate random numbers |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin rarefaction`
+
+Compute the rarefaction curve of the pangenome
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-b, --beta` | float | 2.5 | No | — | beta is the strength of the smoothing using the graph topology during  partitioning. 0 will deactivate spatial smoothing. |
+| `--depth` | int | 30 | No | — | Number of samplings at each sampling point |
+| `--min` | int | 1 | No | — | Minimum number of genomes in a sample |
+| `--max` | float | 100 | No | — | Maximum number of genomes in a sample (if above the number of provided genomes, the provided genomes will be the maximum) |
+| `-ms, --max_degree_smoothing` | float | 10 | No | — | max. degree of the nodes to be included in the smoothing process. |
+| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
+| `-fd, --free_dispersion` | 0 | False | No | — | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
+| `-ck, --chunk_size` | int | 500 | No | — | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. By default reuse K if it exists else compute it. |
+| `--reestimate_K` | 0 | False | No | — | Will recompute the number of partitions for each sample (between the values provided by --krange) (VERY intensive. Can take a long time.) |
+| `-Kmm, --krange` | 2 | [3, -1] | No | — | Range of K values to test when detecting K automatically. Default between 3 and the K previously computed if there is one, or 20 if there are none. |
+| `--soft_core` | float | 0.95 | No | — | Soft core threshold |
+| `-se, --seed` | int | 42 | No | — | seed used to generate random numbers |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## Output
+
+### `ppanggolin draw`
+
+Draw figures representing the pangenome through different aspects
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
 | `--tile_plot` | 0 | False | No | — | draw the tile plot of the pangenome |
 | `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use |
 | `--ucurve` | 0 | False | No | — | draw the U-curve of the pangenome |
@@ -176,11 +318,11 @@ Command description is not explicitly set in this parser.
 | `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
 
 
-## `ppanggolin fasta`
+### `ppanggolin fasta`
 
-Command description is not explicitly set in this parser.
+Writes fasta files for different elements of the pangenome.
 
-### Parameters
+#### Parameters
 
 | Parameter | Type | Default | Required | Choices | Description |
 |---|---|---|---|---|---|
@@ -206,63 +348,11 @@ Command description is not explicitly set in this parser.
 | `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
 
 
-## `ppanggolin graph`
+### `ppanggolin metrics`
 
-Command description is not explicitly set in this parser.
+Compute several metrics on a given pangenome.
 
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-r, --remove_high_copy_number` | int | 0 | No | — | Positive Number: Remove families having a number of copy of gene in a single genome above or equal to this threshold in at least one genome (0 or negative values are ignored). |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin info`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | Yes | — | Path to the pangenome .h5 file |
-| `-a, --parameters` | 0 | False | No | — | Display the parameters used or computed for each step of pangenome generation |
-| `-c, --content` | 0 | False | No | — | Display detailed information about the pangenome's content |
-| `-s, --status` | 0 | False | No | — | Display information about the statuses of different elements in the pangenome, indicating what has been computed or not |
-| `-m, --metadata` | 0 | False | No | — | Display a summary of the metadata saved in the pangenome |
-
-
-## `ppanggolin metadata`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-m, --metadata` | Path | — | No | — | Metadata in TSV file. See our github for more detail about format |
-| `-s, --source` | str | — | No | — | Name of the metadata source |
-| `-a, --assign` | str | — | No | families, genomes, contigs, genes, RGPs, spots, modules | Select to which pangenome element metadata will be assigned |
-| `--omit` | 0 | False | No | — | Allow to pass if a key in metadata is not find in pangenome |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin metrics`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
+#### Parameters
 
 | Parameter | Type | Default | Required | Choices | Description |
 |---|---|---|---|---|---|
@@ -277,345 +367,11 @@ Command description is not explicitly set in this parser.
 | `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
 
 
-## `ppanggolin module`
+### `ppanggolin write_genomes`
 
-Command description is not explicitly set in this parser.
+Writes 'flat' files that represent the genomes along with their associated pangenome elements.
 
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `--size` | int | 3 | No | — | Minimal number of gene family in a module |
-| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
-| `-m, --min_presence` | int | 2 | No | — | Minimum number of times the module needs to be present in the pangenome to be reported. Increasing it will improve precision but lower sensitivity. |
-| `-t, --transitive` | int | 4 | No | — | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
-| `-s, --jaccard` | restricted_float | 0.85 | No | — | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin msa`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
-| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use if 'softcore' partition is chosen |
-| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
-| `--single_copy` | 0 | False | No | — | Use report gene families that are considered 'single copy', for details see option --dup_margin |
-| `--partition` | str | `core` | No | all, persistent, shell, cloud, core, accessory, softcore | compute Multiple Sequence Alignment of the gene families in the given partition |
-| `--source` | str | `protein` | No | dna, protein | indicates whether to use protein or dna sequences to compute the msa |
-| `--phylo` | 0 | False | No | — | Writes a whole genome msa file for additional phylogenetic analysis |
-| `--use_gene_id` | 0 | False | No | — | Use gene identifiers rather than genome names for sequences in the family MSA (genome names are used by default) |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin panmodule`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
-| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
-| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
-| `--basename` | str | `pangenome` | No | — | basename for the output file |
-| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
-| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
-| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin panrgp`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
-| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
-| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
-| `--basename` | str | `pangenome` | No | — | basename for the output file |
-| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
-| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
-| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin partition`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
-| `-b, --beta` | float | 2.5 | No | — | beta is the strength of the smoothing using the graph topology during partitioning. 0 will deactivate spatial smoothing. |
-| `-ms, --max_degree_smoothing` | float | 10 | No | — | max. degree of the nodes to be included in the smoothing process. |
-| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
-| `-fd, --free_dispersion` | 0 | False | No | — | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
-| `-ck, --chunk_size` | int | 500 | No | — | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `-Kmm, --krange` | 2 | [3, 20] | No | — | Range of K values to test when detecting K automatically. |
-| `-im, --ICL_margin` | float | 0.05 | No | — | K is detected automatically by maximizing ICL. However at some point the ICL reaches a plateau. Therefore we are looking for the minimal value of K without significant gain from the larger values of K measured by ICL. For that we take the lowest K that is found within a given 'margin' of the maximal ICL value. Basically, change this option only if you truly understand it, otherwise just leave it be. |
-| `--draw_ICL` | 0 | False | No | — | Use if you want to draw the ICL curve for all the tested K values. Will not be done if K is given. |
-| `--keep_tmp_files` | 0 | False | No | — | Use if you want to keep the temporary NEM files |
-| `-se, --seed` | int | 42 | No | — | seed used to generate random numbers |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin projection`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
-| `--fasta` | Path | — | No | — | Specify a FASTA file containing the genomic sequences of the genome(s) you wish to annotate, or provide a tab-separated file listing genome names alongside their respective FASTA filepaths, with one line per genome. |
-| `--anno` | Path | — | No | — | Specify an annotation file in GFF/GBFF format for the genome you wish to annotate. Alternatively, you can provide a tab-separated file listing genome names alongside their respective annotation filepaths, with one line per genome. If both an annotation file and a FASTA file are provided, the annotation file will take precedence. |
-| `-n, --genome_name` | str | `input_genome` | No | — | Specify the name of the genome whose genome you want to annotate when providing a single FASTA or annotation file. |
-| `--circular_contigs` | list | — | No | — | Specify the contigs of the input genome that should be treated as circular when providing a single FASTA or annotation file. |
-| `-o, --output` | Path | `ppanggolin_projection_DATE2026-08-13_HOUR11.43.03_PID660761` | No | — | Output directory |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. (default: False) |
-| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
-| `--identity` | restricted_float | 0.8 | No | — | min identity percentage threshold |
-| `--coverage` | restricted_float | 0.8 | No | — | min coverage percentage threshold |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated'. This metric is used to compute completeness and duplication of the input genomes |
-| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold used when generating general statistics on the projected genome. This threshold does not influence PPanGGOLiN's partitioning. The value determines the minimum fraction of genomes that must possess a gene family for it to be considered part of the soft core. |
-| `--spot_graph` | 0 | False | No | — | Write the spot graph to a file, with pairs of blocks of single copy markers flanking RGPs as nodes. This graph can be used to visualize nodes that have RGPs from the input genome. |
-| `--graph_formats` | list | ['gexf'] | No | gexf, graphml | Format of the output graph. |
-| `--gff` | 0 | False | No | — | Generate GFF files with projected pangenome annotations for each input genome. |
-| `--proksee` | 0 | False | No | — | Generate JSON map files for PROKSEE with projected pangenome annotations for each input genome. |
-| `--table` | 0 | False | No | — | Generate a tsv file for each input genome with pangenome annotations. |
-| `--compress` | 0 | False | No | — | Compress the files in .gz |
-| `--add_sequences` | 0 | False | No | — | Include input genome DNA sequences in GFF and Proksee output. |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
-| `--add_metadata` | 0 | False | No | — | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
-| `--metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
-| `--metadata_sep` | str | `|` | No | — | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin rarefaction`
-
-Compute the rarefaction curve of the pangenome
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-b, --beta` | float | 2.5 | No | — | beta is the strength of the smoothing using the graph topology during  partitioning. 0 will deactivate spatial smoothing. |
-| `--depth` | int | 30 | No | — | Number of samplings at each sampling point |
-| `--min` | int | 1 | No | — | Minimum number of genomes in a sample |
-| `--max` | float | 100 | No | — | Maximum number of genomes in a sample (if above the number of provided genomes, the provided genomes will be the maximum) |
-| `-ms, --max_degree_smoothing` | float | 10 | No | — | max. degree of the nodes to be included in the smoothing process. |
-| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
-| `-fd, --free_dispersion` | 0 | False | No | — | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
-| `-ck, --chunk_size` | int | 500 | No | — | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. By default reuse K if it exists else compute it. |
-| `--reestimate_K` | 0 | False | No | — | Will recompute the number of partitions for each sample (between the values provided by --krange) (VERY intensive. Can take a long time.) |
-| `-Kmm, --krange` | 2 | [3, -1] | No | — | Range of K values to test when detecting K automatically. Default between 3 and the K previously computed if there is one, or 20 if there are none. |
-| `--soft_core` | float | 0.95 | No | — | Soft core threshold |
-| `-se, --seed` | int | 42 | No | — | seed used to generate random numbers |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin rgp`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `--persistent_penalty` | int | 3 | No | — | Penalty score to apply to persistent genes |
-| `--variable_gain` | int | 1 | No | — | Gain score to apply to variable genes |
-| `--min_score` | int | 4 | No | — | Minimal score wanted for considering a region as being a RGP |
-| `--min_length` | int | 3000 | No | — | Minimum length (bp) of a region to be considered a RGP |
-| `--dup_margin` | restricted_float | 0.05 | No | — | Minimum ratio of genomes where the family is present in which the family must have multiple genes for it to be considered 'duplicated' |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin rgp_cluster`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | Yes | — | The pangenome .h5 file |
-| `--grr_cutoff` | restricted_float | 0.8 | No | — | Min gene repertoire relatedness metric used in the rgp clustering |
-| `--grr_metric` | str | `incomplete_aware_grr` | No | incomplete_aware_grr, min_grr, max_grr | The grr (Gene Repertoire Relatedness) is used to assess the similarity between two RGPs based on their gene families.There are three different modes for calculating the grr value: 'min_grr', 'max_grr' or  'incomplete_aware_grr'.'min_grr': Computes the number of gene families shared between the two RGPs and divides it by the smaller number of gene families among the two RGPs.'max_grr': Calculates the number of gene families shared between the two RGPs and divides it by the larger number of gene families among the two RGPs.'incomplete_aware_grr' (default): If at least one RGP is considered incomplete, which occurs when it is located at the border of a contig,the 'min_grr' mode is used. Otherwise, the 'max_grr' mode is applied. |
-| `--ignore_incomplete_rgp` | 0 | False | No | — | Do not cluster RGPs located on a contig border which are likely incomplete. |
-| `--no_identical_rgp_merging` | 0 | False | No | — | Do not merge in one node identical RGP (i.e. having the same family content) before clustering. |
-| `--basename` | str | `rgp_cluster` | No | — | basename for the output file |
-| `-o, --output` | Path | `rgp_clustering` | No | — | Output directory |
-| `--graph_formats` | list | ['gexf', 'graphml'] | No | gexf, graphml | Format of the output graph. |
-| `--add_metadata` | 0 | False | No | — | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
-| `--metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
-| `--metadata_sep` | str | `|` | No | — | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin spot`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
-| `--spot_graph` | 0 | False | No | — | Writes a graph of pairs of blocks of single copy markers flanking RGPs, supposedly belonging to the same hotspot |
-| `--overlapping_match` | int | 2 | No | — | The number of 'missing' persistent genes allowed when comparing flanking genes during hotspot computations |
-| `--set_size` | int | 3 | No | — | Number of single copy markers to use as flanking genes for a RGP during hotspot computation |
-| `--exact_match_size` | int | 1 | No | — | Number of perfectly matching flanking single copy markers required to associate RGPs during hotspot computation (Ex: If set to 1, two RGPs are in the same hotspot if both their 1st flanking genes are the same) |
-| `--graph_formats` | list | ['gexf'] | No | gexf, graphml | Format of the output graph. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin utils`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `--default_config` | str | — | No | annotate, cluster, graph, partition, rarefaction, workflow, panrgp, panmodule, all, draw, write_pangenome, write_genomes, write_metadata, fasta, msa, metrics, align, rgp, spot, module, context, projection, rgp_cluster, metadata | Generate a config file with default values for the given subcommand. |
-| `-o, --output` | Path | `default_config.yaml` | No | — | name and path of the config file with default parameters written in yaml. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-f, --force` | 0 | False | No | — | Overwrite the given output file if it exists. |
-
-
-## `ppanggolin workflow`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
-
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
-| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
-| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
-| `--basename` | str | `pangenome` | No | — | basename for the output file |
-| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
-| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
-| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
-
-
-## `ppanggolin write_genomes`
-
-Command description is not explicitly set in this parser.
-
-### Parameters
+#### Parameters
 
 | Parameter | Type | Default | Required | Choices | Description |
 |---|---|---|---|---|---|
@@ -639,18 +395,18 @@ Command description is not explicitly set in this parser.
 | `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
 
 
-## `ppanggolin write_metadata`
+### `ppanggolin write_metadata`
 
-Command description is not explicitly set in this parser.
+Writes 'TSV' files that represent the metadata associated with elements of the pangenome.
 
-### Parameters
+#### Parameters
 
 | Parameter | Type | Default | Required | Choices | Description |
 |---|---|---|---|---|---|
 | `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
 | `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
 | `--compress` | 0 | False | No | — | Compress the files in .gz |
-| `-e, --pangenome_elements` | list | ['contigs', 'families', 'modules', 'genomes', 'RGPs', 'spots', 'genes'] | No | contigs, families, modules, genomes, RGPs, spots, genes | Specify pangenome elements for which to write metadata. default is all element with metadata. |
+| `-e, --pangenome_elements` | list | ['families', 'genes', 'spots', 'genomes', 'RGPs', 'modules', 'contigs'] | No | families, genes, spots, genomes, RGPs, modules, contigs | Specify pangenome elements for which to write metadata. default is all element with metadata. |
 | `-s, --metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
 | `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
 | `--log` | check_log | `stdout` | No | — | log output file |
@@ -659,11 +415,11 @@ Command description is not explicitly set in this parser.
 | `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
 
 
-## `ppanggolin write_pangenome`
+### `ppanggolin write_pangenome`
 
-Command description is not explicitly set in this parser.
+Writes 'flat' files that represent the pangenome and its elements for use with other software.
 
-### Parameters
+#### Parameters
 
 | Parameter | Type | Default | Required | Choices | Description |
 |---|---|---|---|---|---|
@@ -688,6 +444,230 @@ Command description is not explicitly set in this parser.
 | `--spot_modules` | 0 | False | No | — | Generate two files comparing module presence across spots |
 | `--compress` | 0 | False | No | — | Compress output files using gzip (.gz) |
 | `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## Regions of Genomic Plasticity
+
+### `ppanggolin module`
+
+Predicts functional modules in your pangenome.
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `--size` | int | 3 | No | — | Minimal number of gene family in a module |
+| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `-m, --min_presence` | int | 2 | No | — | Minimum number of times the module needs to be present in the pangenome to be reported. Increasing it will improve precision but lower sensitivity. |
+| `-t, --transitive` | int | 4 | No | — | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
+| `-s, --jaccard` | restricted_float | 0.85 | No | — | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin rgp`
+
+Predicts Regions of Genomic Plasticity in the genomes of your pangenome.
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `--persistent_penalty` | int | 3 | No | — | Penalty score to apply to persistent genes |
+| `--variable_gain` | int | 1 | No | — | Gain score to apply to variable genes |
+| `--min_score` | int | 4 | No | — | Minimal score wanted for considering a region as being a RGP |
+| `--min_length` | int | 3000 | No | — | Minimum length (bp) of a region to be considered a RGP |
+| `--dup_margin` | restricted_float | 0.05 | No | — | Minimum ratio of genomes where the family is present in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin rgp_cluster`
+
+Cluster RGPs based on their gene families.
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | Yes | — | The pangenome .h5 file |
+| `--grr_cutoff` | restricted_float | 0.8 | No | — | Min gene repertoire relatedness metric used in the rgp clustering |
+| `--grr_metric` | str | `incomplete_aware_grr` | No | incomplete_aware_grr, min_grr, max_grr | The grr (Gene Repertoire Relatedness) is used to assess the similarity between two RGPs based on their gene families.There are three different modes for calculating the grr value: 'min_grr', 'max_grr' or  'incomplete_aware_grr'.'min_grr': Computes the number of gene families shared between the two RGPs and divides it by the smaller number of gene families among the two RGPs.'max_grr': Calculates the number of gene families shared between the two RGPs and divides it by the larger number of gene families among the two RGPs.'incomplete_aware_grr' (default): If at least one RGP is considered incomplete, which occurs when it is located at the border of a contig,the 'min_grr' mode is used. Otherwise, the 'max_grr' mode is applied. |
+| `--ignore_incomplete_rgp` | 0 | False | No | — | Do not cluster RGPs located on a contig border which are likely incomplete. |
+| `--no_identical_rgp_merging` | 0 | False | No | — | Do not merge in one node identical RGP (i.e. having the same family content) before clustering. |
+| `--basename` | str | `rgp_cluster` | No | — | basename for the output file |
+| `-o, --output` | Path | `rgp_clustering` | No | — | Output directory |
+| `--graph_formats` | list | ['gexf', 'graphml'] | No | gexf, graphml | Format of the output graph. |
+| `--add_metadata` | 0 | False | No | — | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--metadata_sep` | str | `|` | No | — | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin spot`
+
+Predicts spots in your pangenome.
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
+| `--spot_graph` | 0 | False | No | — | Writes a graph of pairs of blocks of single copy markers flanking RGPs, supposedly belonging to the same hotspot |
+| `--overlapping_match` | int | 2 | No | — | The number of 'missing' persistent genes allowed when comparing flanking genes during hotspot computations |
+| `--set_size` | int | 3 | No | — | Number of single copy markers to use as flanking genes for a RGP during hotspot computation |
+| `--exact_match_size` | int | 1 | No | — | Number of perfectly matching flanking single copy markers required to associate RGPs during hotspot computation (Ex: If set to 1, two RGPs are in the same hotspot if both their 1st flanking genes are the same) |
+| `--graph_formats` | list | ['gexf'] | No | gexf, graphml | Format of the output graph. |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## Analysis using reference pangenomes
+
+### `ppanggolin align`
+
+Aligns a genome or a set of proteins to the pangenome gene families and predicts information from it.
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-S, --sequences` | Path | — | No | — | sequences (nucleotides or amino acids) to align on the pangenome gene families |
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. (default: False) |
+| `--identity` | float | 0.5 | No | — | min identity percentage threshold |
+| `--coverage` | float | 0.8 | No | — | min coverage percentage threshold |
+| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--getinfo` | 0 | False | No | — | Use this option to extract info related to the best hit of each query, such as the RGP it is in, or the spots. |
+| `--draw_related` | 0 | False | No | — | Draw figures and provide graphs in a gexf format of the eventual spots associated to the input sequences |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin context`
+
+Local genomic context analysis.
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
+| `-o, --output` | Path | `ppanggolin_context_DATE2026-08-13_HOUR12.55.19_PID729243` | No | — | Output directory where the file(s) will be written |
+| `-S, --sequences` | Path | — | No | — | Fasta file with the sequences of interest |
+| `-F, --family` | Path | — | No | — | List of family IDs of interest from the pangenome |
+| `-t, --transitive` | int | 4 | No | — | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
+| `-w, --window_size` | int | 5 | No | — | Number of neighboring genes that are considered on each side of a gene of interest when searching for conserved genomic contexts. |
+| `-s, --jaccard` | restricted_float | 0.85 | No | — | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
+| `--graph_format` | str | `graphml` | No | gexf, graphml | Format of the context graph. Can be gexf or graphml. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. |
+| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is recommended for faster processing but may be less sensitive. By default, all pangenome genes are used for alignment. |
+| `--identity` | float | 0.8 | No | — | min identity percentage threshold |
+| `--coverage` | float | 0.8 | No | — | min coverage percentage threshold |
+| `--translation_table` | int | 11 | No | — | The translation table to use when the input sequences are nucleotide sequences. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin msa`
+
+Compute Multiple Sequence Alignments for pangenome gene families.
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
+| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use if 'softcore' partition is chosen |
+| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--single_copy` | 0 | False | No | — | Use report gene families that are considered 'single copy', for details see option --dup_margin |
+| `--partition` | str | `core` | No | all, persistent, shell, cloud, core, accessory, softcore | compute Multiple Sequence Alignment of the gene families in the given partition |
+| `--source` | str | `protein` | No | dna, protein | indicates whether to use protein or dna sequences to compute the msa |
+| `--phylo` | 0 | False | No | — | Writes a whole genome msa file for additional phylogenetic analysis |
+| `--use_gene_id` | 0 | False | No | — | Use gene identifiers rather than genome names for sequences in the family MSA (genome names are used by default) |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin projection`
+
+Annotates external genomes with an existing pangenome.
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
+| `--fasta` | Path | — | No | — | Specify a FASTA file containing the genomic sequences of the genome(s) you wish to annotate, or provide a tab-separated file listing genome names alongside their respective FASTA filepaths, with one line per genome. |
+| `--anno` | Path | — | No | — | Specify an annotation file in GFF/GBFF format for the genome you wish to annotate. Alternatively, you can provide a tab-separated file listing genome names alongside their respective annotation filepaths, with one line per genome. If both an annotation file and a FASTA file are provided, the annotation file will take precedence. |
+| `-n, --genome_name` | str | `input_genome` | No | — | Specify the name of the genome whose genome you want to annotate when providing a single FASTA or annotation file. |
+| `--circular_contigs` | list | — | No | — | Specify the contigs of the input genome that should be treated as circular when providing a single FASTA or annotation file. |
+| `-o, --output` | Path | `ppanggolin_projection_DATE2026-08-13_HOUR12.55.19_PID729243` | No | — | Output directory |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. (default: False) |
+| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
+| `--identity` | restricted_float | 0.8 | No | — | min identity percentage threshold |
+| `--coverage` | restricted_float | 0.8 | No | — | min coverage percentage threshold |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated'. This metric is used to compute completeness and duplication of the input genomes |
+| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold used when generating general statistics on the projected genome. This threshold does not influence PPanGGOLiN's partitioning. The value determines the minimum fraction of genomes that must possess a gene family for it to be considered part of the soft core. |
+| `--spot_graph` | 0 | False | No | — | Write the spot graph to a file, with pairs of blocks of single copy markers flanking RGPs as nodes. This graph can be used to visualize nodes that have RGPs from the input genome. |
+| `--graph_formats` | list | ['gexf'] | No | gexf, graphml | Format of the output graph. |
+| `--gff` | 0 | False | No | — | Generate GFF files with projected pangenome annotations for each input genome. |
+| `--proksee` | 0 | False | No | — | Generate JSON map files for PROKSEE with projected pangenome annotations for each input genome. |
+| `--table` | 0 | False | No | — | Generate a tsv file for each input genome with pangenome annotations. |
+| `--compress` | 0 | False | No | — | Compress the files in .gz |
+| `--add_sequences` | 0 | False | No | — | Include input genome DNA sequences in GFF and Proksee output. |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
+| `--add_metadata` | 0 | False | No | — | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--metadata_sep` | str | `|` | No | — | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
 | `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
 | `--log` | check_log | `stdout` | No | — | log output file |
 | `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |

--- a/docs/user/command_reference.md
+++ b/docs/user/command_reference.md
@@ -24,29 +24,29 @@ Easy workflow to run all possible analysis
 |---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
 | `--basename` | str | `pangenome` | basename for the output file |
-| `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `--rarefaction` | bool | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
 | `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. <br>Choices: `bacteria`, `archaea` |
 | `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) <br>Choices: `0`, `1`, `2`, `3` |
-| `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `--coverage` | float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | bool | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | bool | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
 | `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--no_defrag` | bool | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | bool | False | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | `/tmp` | directory for storing temporary files |
 
 #### Common arguments for ppanggolin all
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin panmodule`
@@ -67,29 +67,29 @@ Easy workflow to run a pangenome analysis with module prediction
 |---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
 | `--basename` | str | `pangenome` | basename for the output file |
-| `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `--rarefaction` | bool | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
 | `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. <br>Choices: `bacteria`, `archaea` |
 | `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) <br>Choices: `0`, `1`, `2`, `3` |
-| `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `--coverage` | float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | bool | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | bool | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
 | `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--no_defrag` | bool | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | bool | False | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | `/tmp` | directory for storing temporary files |
 
 #### Common arguments for ppanggolin panmodule
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin panrgp`
@@ -110,29 +110,29 @@ Easy workflow to run a pangenome analysis with genomic islands and spots of inse
 |---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
 | `--basename` | str | `pangenome` | basename for the output file |
-| `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `--rarefaction` | bool | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
 | `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. <br>Choices: `bacteria`, `archaea` |
 | `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) <br>Choices: `0`, `1`, `2`, `3` |
-| `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `--coverage` | float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | bool | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | bool | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
 | `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--no_defrag` | bool | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | bool | False | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | `/tmp` | directory for storing temporary files |
 
 #### Common arguments for ppanggolin panrgp
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin workflow`
@@ -153,29 +153,29 @@ Easy workflow to run a pangenome analysis in one go
 |---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
 | `--basename` | str | `pangenome` | basename for the output file |
-| `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `--rarefaction` | bool | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
 | `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. <br>Choices: `bacteria`, `archaea` |
 | `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) <br>Choices: `0`, `1`, `2`, `3` |
-| `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `--coverage` | float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | bool | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | bool | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
 | `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--no_defrag` | bool | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | bool | False | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | `/tmp` | directory for storing temporary files |
 
 #### Common arguments for ppanggolin workflow
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ## Expert
@@ -196,25 +196,25 @@ Annotate genomes
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
-| `--allow_overlap` | 0 | False | Use to not remove genes overlapping with RNA features. |
-| `--norna` | 0 | False | Use to avoid annotating RNA features. |
+| `--allow_overlap` | bool | False | Use to not remove genes overlapping with RNA features. |
+| `--norna` | bool | False | Use to avoid annotating RNA features. |
 | `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. <br>Choices: `bacteria`, `archaea` |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
 | `--basename` | str | `pangenome` | basename for the output file |
-| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `--use_pseudo` | bool | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
 | `-p, --prodigal_procedure` | lower | — | Allow to force the prodigal procedure. If nothing given, PPanGGOLiN will decide in function of contig length <br>Choices: `single`, `meta` |
 | `-c, --cpu` | int | 1 | Number of available cpus |
-| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--tmpdir` | str | `/tmp` | directory for storing temporary files |
 
 #### Common arguments for ppanggolin annotate
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin cluster`
@@ -231,17 +231,17 @@ Cluster genes into gene families
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
-| `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
+| `--coverage` | float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
 | `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) <br>Choices: `0`, `1`, `2`, `3` |
-| `--no_defrag` | 0 | False | DO NOT Use the defragmentation strategy to link potential fragments with their original gene family. |
+| `--no_defrag` | bool | False | DO NOT Use the defragmentation strategy to link potential fragments with their original gene family. |
 
 #### Read clustering arguments for ppanggolin cluster
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--clusters` | Path | — | A tab-separated list containing the result of a clustering. One line per gene. First column is cluster ID, and second is gene ID |
-| `--infer_singletons` | 0 | False | When reading a clustering result with --clusters, if a gene is not in the provided file it will be placed in a cluster where the gene is the only member. |
+| `--infer_singletons` | bool | False | When reading a clustering result with --clusters, if a gene is not in the provided file it will be placed in a cluster where the gene is the only member. |
 
 #### Optional arguments for ppanggolin cluster
 
@@ -249,18 +249,18 @@ Cluster genes into gene families
 |---|---|---|---|
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
 | `-c, --cpu` | int | 1 | Number of available cpus |
-| `--tmpdir` | Path | /tmp | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
+| `--tmpdir` | Path | `/tmp` | directory for storing temporary files |
+| `--keep_tmp` | bool | False | Keeping temporary files (useful for debugging). |
 
 #### Common arguments for ppanggolin cluster
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin graph`
@@ -284,10 +284,10 @@ Create the pangenome graph
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin metadata`
@@ -307,17 +307,17 @@ Add metadata to elements in yout pangenome
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--omit` | 0 | False | Allow to pass if a key in metadata is not find in pangenome |
+| `--omit` | bool | False | Allow to pass if a key in metadata is not find in pangenome |
 
 #### Common arguments for ppanggolin metadata
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin partition`
@@ -336,27 +336,27 @@ Partition the pangenome graph
 |---|---|---|---|
 | `-b, --beta` | float | 2.5 | beta is the strength of the smoothing using the graph topology during partitioning. 0 will deactivate spatial smoothing. |
 | `-ms, --max_degree_smoothing` | float | 10 | max. degree of the nodes to be included in the smoothing process. |
-| `-o, --output` | Path | `ppanggolin_output<date>_<pid>` | Output directory |
-| `-fd, --free_dispersion` | 0 | False | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
+| `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
+| `-fd, --free_dispersion` | bool | False | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
 | `-ck, --chunk_size` | int | 500 | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
 | `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `-Kmm, --krange` | 2 | [3, 20] | Range of K values to test when detecting K automatically. |
+| `-Kmm, --krange` | int | `[3, 20]` | Range of K values to test when detecting K automatically. |
 | `-im, --ICL_margin` | float | 0.05 | K is detected automatically by maximizing ICL. However at some point the ICL reaches a plateau. Therefore we are looking for the minimal value of K without significant gain from the larger values of K measured by ICL. For that we take the lowest K that is found within a given 'margin' of the maximal ICL value. Basically, change this option only if you truly understand it, otherwise just leave it be. |
-| `--draw_ICL` | 0 | False | Use if you want to draw the ICL curve for all the tested K values. Will not be done if K is given. |
-| `--keep_tmp_files` | 0 | False | Use if you want to keep the temporary NEM files |
+| `--draw_ICL` | bool | False | Use if you want to draw the ICL curve for all the tested K values. Will not be done if K is given. |
+| `--keep_tmp_files` | bool | False | Use if you want to keep the temporary NEM files |
 | `-se, --seed` | int | 42 | seed used to generate random numbers |
 | `-c, --cpu` | int | 1 | Number of available cpus |
-| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--tmpdir` | str | `/tmp` | directory for storing temporary files |
 
 #### Common arguments for ppanggolin partition
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin rarefaction`
@@ -378,26 +378,26 @@ Compute the rarefaction curve of the pangenome
 | `--min` | int | 1 | Minimum number of genomes in a sample |
 | `--max` | float | 100 | Maximum number of genomes in a sample (if above the number of provided genomes, the provided genomes will be the maximum) |
 | `-ms, --max_degree_smoothing` | float | 10 | max. degree of the nodes to be included in the smoothing process. |
-| `-o, --output` | Path | `ppanggolin_output<date>_<pid>` | Output directory |
-| `-fd, --free_dispersion` | 0 | False | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
+| `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
+| `-fd, --free_dispersion` | bool | False | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
 | `-ck, --chunk_size` | int | 500 | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
 | `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. By default reuse K if it exists else compute it. |
-| `--reestimate_K` | 0 | False | Will recompute the number of partitions for each sample (between the values provided by --krange) (VERY intensive. Can take a long time.) |
-| `-Kmm, --krange` | 2 | [3, -1] | Range of K values to test when detecting K automatically. Default between 3 and the K previously computed if there is one, or 20 if there are none. |
+| `--reestimate_K` | bool | False | Will recompute the number of partitions for each sample (between the values provided by --krange) (VERY intensive. Can take a long time.) |
+| `-Kmm, --krange` | int | `[3, -1]` | Range of K values to test when detecting K automatically. Default between 3 and the K previously computed if there is one, or 20 if there are none. |
 | `--soft_core` | float | 0.95 | Soft core threshold |
 | `-se, --seed` | int | 42 | seed used to generate random numbers |
 | `-c, --cpu` | int | 1 | Number of available cpus |
-| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--tmpdir` | str | `/tmp` | directory for storing temporary files |
 
 #### Common arguments for ppanggolin rarefaction
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ## Output
@@ -417,25 +417,25 @@ Draw figures representing the pangenome through different aspects
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
-| `--tile_plot` | 0 | False | draw the tile plot of the pangenome |
-| `--soft_core` | restricted_float | 0.95 | Soft core threshold to use |
-| `--ucurve` | 0 | False | draw the U-curve of the pangenome |
-| `--draw_spots` | 0 | False | draw plots for spots of the pangenome |
-| `--spots` | list | `all` | a comma-separated list of spots to draw (or 'all' to draw all spots, or 'synteny' to draw spots with different RGP syntenies). |
-| `--nocloud` | 0 | False | Do not draw the cloud genes in the tile plot |
-| `--add_dendrogram` | 0 | False | Include a dendrogram for genomes in the tile plot based on the presence/absence of gene families. |
-| `--add_metadata` | 0 | False | Display gene metadata as hover text for each cell in the tile plot. |
-| `--metadata_sources` | list | — | Which source of metadata should be written in the tile plot. By default all metadata sources are included. |
+| `--tile_plot` | bool | False | draw the tile plot of the pangenome |
+| `--soft_core` | float | 0.95 | Soft core threshold to use |
+| `--ucurve` | bool | False | draw the U-curve of the pangenome |
+| `--draw_spots` | bool | False | draw plots for spots of the pangenome |
+| `--spots` | str | `all` | a comma-separated list of spots to draw (or 'all' to draw all spots, or 'synteny' to draw spots with different RGP syntenies). |
+| `--nocloud` | bool | False | Do not draw the cloud genes in the tile plot |
+| `--add_dendrogram` | bool | False | Include a dendrogram for genomes in the tile plot based on the presence/absence of gene families. |
+| `--add_metadata` | bool | False | Display gene metadata as hover text for each cell in the tile plot. |
+| `--metadata_sources` | str | — | Which source of metadata should be written in the tile plot. By default all metadata sources are included. |
 
 #### Common arguments for ppanggolin draw
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin fasta`
@@ -460,32 +460,32 @@ Writes fasta files for different elements of the pangenome.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--genes` | filter_values | — | Write all nucleotide CDS sequences. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
-| `--proteins` | filter_values | — | Write representative amino acid sequences of genes. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
-| `--prot_families` | filter_values | — | Write representative amino acid sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
-| `--gene_families` | filter_values | — | Write representative nucleotide sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--genes` | str | — | Write all nucleotide CDS sequences. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--proteins` | str | — | Write representative amino acid sequences of genes. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--prot_families` | str | — | Write representative amino acid sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--gene_families` | str | — | Write representative nucleotide sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
 
 #### Optional arguments for ppanggolin fasta
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--regions` | str | — | Write the RGP nucleotide sequences (requires --anno or --fasta used to compute the pangenome to be given) <br>Choices: `all`, `complete` |
-| `--soft_core` | restricted_float | 0.95 | Soft core threshold to use if 'softcore' partition is chosen |
-| `--compress` | 0 | False | Compress the files in .gz |
+| `--soft_core` | float | 0.95 | Soft core threshold to use if 'softcore' partition is chosen |
+| `--compress` | bool | False | Compress the files in .gz |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
 | `--cpu` | int | 1 | Number of available threads |
-| `--tmpdir` | Path | /tmp | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
+| `--tmpdir` | Path | `/tmp` | directory for storing temporary files |
+| `--keep_tmp` | bool | False | Keeping temporary files (useful for debugging). |
 
 #### Common arguments for ppanggolin fasta
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin info`
@@ -502,20 +502,20 @@ Prints information about a given pangenome graph file.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `-a, --parameters` | 0 | False | Display the parameters used or computed for each step of pangenome generation |
-| `-c, --content` | 0 | False | Display detailed information about the pangenome's content |
-| `-s, --status` | 0 | False | Display information about the statuses of different elements in the pangenome, indicating what has been computed or not |
-| `-m, --metadata` | 0 | False | Display a summary of the metadata saved in the pangenome |
+| `-a, --parameters` | bool | False | Display the parameters used or computed for each step of pangenome generation |
+| `-c, --content` | bool | False | Display detailed information about the pangenome's content |
+| `-s, --status` | bool | False | Display information about the statuses of different elements in the pangenome, indicating what has been computed or not |
+| `-m, --metadata` | bool | False | Display a summary of the metadata saved in the pangenome |
 
 #### Common arguments for ppanggolin info
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin metrics`
@@ -532,24 +532,24 @@ Compute several metrics on a given pangenome.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--genome_fluidity` | 0 | False | Compute the pangenome genomic fluidity. |
+| `--genome_fluidity` | bool | False | Compute the pangenome genomic fluidity. |
 
 #### Optional arguments for ppanggolin metrics
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--no_print_info` | 0 | False | Suppress printing the metrics result. Metrics are saved in the pangenome and viewable using 'ppanggolin info'. |
-| `--recompute_metrics` | 0 | False | Force re-computation of metrics if already computed. |
+| `--no_print_info` | bool | False | Suppress printing the metrics result. Metrics are saved in the pangenome and viewable using 'ppanggolin info'. |
+| `--recompute_metrics` | bool | False | Force re-computation of metrics if already computed. |
 
 #### Common arguments for ppanggolin metrics
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin write_genomes`
@@ -567,13 +567,13 @@ Writes 'flat' files that represent the genomes along with their associated pange
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--table` | 0 | False | Generate a tsv file for each genome with pangenome annotations. |
-| `--gff` | 0 | False | Generate a gff file for each genome containing pangenome annotations. |
-| `--proksee` | 0 | False | Generate JSON map files for PROKSEE for each genome containing pangenome annotations to be used in proksee. |
-| `--compress` | 0 | False | Compress the files in .gz |
+| `--table` | bool | False | Generate a tsv file for each genome with pangenome annotations. |
+| `--gff` | bool | False | Generate a gff file for each genome containing pangenome annotations. |
+| `--proksee` | bool | False | Generate JSON map files for PROKSEE for each genome containing pangenome annotations to be used in proksee. |
+| `--compress` | bool | False | Compress the files in .gz |
 | `--genomes` | str | `all` | Specify the genomes for which to generate output. You can provide a list of genome names either directly in the command line separated by commas, or by referencing a file containing the list of genome names, with one name per line. |
-| `--add_metadata` | 0 | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
-| `--metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--add_metadata` | bool | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | str | — | Which source of metadata should be written. By default all metadata sources are included. |
 | `--metadata_sep` | str | `|` | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 
@@ -589,10 +589,10 @@ Writes 'flat' files that represent the genomes along with their associated pange
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin write_metadata`
@@ -610,19 +610,19 @@ Writes 'TSV' files that represent the metadata associated with elements of the p
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--compress` | 0 | False | Compress the files in .gz |
-| `-e, --pangenome_elements` | list | ['modules', 'genomes', 'families', 'genes', 'contigs', 'spots', 'RGPs'] | Specify pangenome elements for which to write metadata. default is all element with metadata. <br>Choices: `modules`, `genomes`, `families`, `genes`, `contigs`, `spots`, `RGPs` |
-| `-s, --metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--compress` | bool | False | Compress the files in .gz |
+| `-e, --pangenome_elements` | set | `['contigs', 'families', 'genomes', 'modules', 'spots', 'RGPs', 'genes']` | Specify pangenome elements for which to write metadata. default is all element with metadata. <br>Choices: `contigs`, `families`, `genomes`, `modules`, `spots`, `RGPs`, `genes` |
+| `-s, --metadata_sources` | str | — | Which source of metadata should be written. By default all metadata sources are included. |
 
 #### Common arguments for ppanggolin write_metadata
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin write_pangenome`
@@ -640,24 +640,24 @@ Writes 'flat' files that represent the pangenome and its elements for use with o
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--soft_core` | restricted_float | 0.95 | Soft core threshold to use |
-| `--dup_margin` | restricted_float | 0.05 | Minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
-| `--gexf` | 0 | False | Generate a detailed GEXF file with all genes and annotations for each family |
-| `--light_gexf` | 0 | False | Generate a simplified GEXF file with basic gene family information |
-| `--gt` | 0 | False | Generate a simplified graph-tool GT file with basic gene family and pangenome organism strains information |
-| `--json` | 0 | False | Export the graph in JSON file format |
-| `--csv` | 0 | False | Export gene presence/absence in CSV format (compatible with Roary). Uses partitions as alternative gene IDs if available. |
-| `--Rtab` | 0 | False | Export gene presence/absence as a tabular binary matrix |
-| `--stats` | 0 | False | Generate genome statistics ('genome_statistics.tsv') and duplication summary of persistent families ('mean_persistent_duplication.tsv') |
-| `--partitions` | 0 | False | Generate one file per partition listing the gene families it contains |
-| `--families_tsv` | 0 | False | Write a TSV file mapping genes to their corresponding gene families |
-| `--regions` | 0 | False | Write predicted RGPs (Regions of Genomic Plasticity) and metrics to 'plastic_regions.tsv' |
-| `--regions_families` | 0 | False | Write a TSV file mapping each RGP to its gene family content in 'rgp_families.tsv' |
-| `--spots` | 0 | False | Write spot summary and list all RGPs (Regions of Genomic Plasticity) per spot |
-| `--borders` | 0 | False | List all borders of each spot |
-| `--modules` | 0 | False | Write a TSV file listing functional modules and their associated gene families |
-| `--spot_modules` | 0 | False | Generate two files comparing module presence across spots |
-| `--compress` | 0 | False | Compress output files using gzip (.gz) |
+| `--soft_core` | float | 0.95 | Soft core threshold to use |
+| `--dup_margin` | float | 0.05 | Minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--gexf` | bool | False | Generate a detailed GEXF file with all genes and annotations for each family |
+| `--light_gexf` | bool | False | Generate a simplified GEXF file with basic gene family information |
+| `--gt` | bool | False | Generate a simplified graph-tool GT file with basic gene family and pangenome organism strains information |
+| `--json` | bool | False | Export the graph in JSON file format |
+| `--csv` | bool | False | Export gene presence/absence in CSV format (compatible with Roary). Uses partitions as alternative gene IDs if available. |
+| `--Rtab` | bool | False | Export gene presence/absence as a tabular binary matrix |
+| `--stats` | bool | False | Generate genome statistics ('genome_statistics.tsv') and duplication summary of persistent families ('mean_persistent_duplication.tsv') |
+| `--partitions` | bool | False | Generate one file per partition listing the gene families it contains |
+| `--families_tsv` | bool | False | Write a TSV file mapping genes to their corresponding gene families |
+| `--regions` | bool | False | Write predicted RGPs (Regions of Genomic Plasticity) and metrics to 'plastic_regions.tsv' |
+| `--regions_families` | bool | False | Write a TSV file mapping each RGP to its gene family content in 'rgp_families.tsv' |
+| `--spots` | bool | False | Write spot summary and list all RGPs (Regions of Genomic Plasticity) per spot |
+| `--borders` | bool | False | List all borders of each spot |
+| `--modules` | bool | False | Write a TSV file listing functional modules and their associated gene families |
+| `--spot_modules` | bool | False | Generate two files comparing module presence across spots |
+| `--compress` | bool | False | Compress output files using gzip (.gz) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 
 #### Common arguments for ppanggolin write_pangenome
@@ -665,10 +665,10 @@ Writes 'flat' files that represent the pangenome and its elements for use with o
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ## Regions of Genomic Plasticity
@@ -688,10 +688,10 @@ Predicts functional modules in your pangenome.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--size` | int | 3 | Minimal number of gene family in a module |
-| `--dup_margin` | restricted_float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--dup_margin` | float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
 | `-m, --min_presence` | int | 2 | Minimum number of times the module needs to be present in the pangenome to be reported. Increasing it will improve precision but lower sensitivity. |
 | `-t, --transitive` | int | 4 | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
-| `-s, --jaccard` | restricted_float | 0.85 | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
+| `-s, --jaccard` | float | 0.85 | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 
 #### Common arguments for ppanggolin module
@@ -699,10 +699,10 @@ Predicts functional modules in your pangenome.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin rgp`
@@ -723,17 +723,17 @@ Predicts Regions of Genomic Plasticity in the genomes of your pangenome.
 | `--variable_gain` | int | 1 | Gain score to apply to variable genes |
 | `--min_score` | int | 4 | Minimal score wanted for considering a region as being a RGP |
 | `--min_length` | int | 3000 | Minimum length (bp) of a region to be considered a RGP |
-| `--dup_margin` | restricted_float | 0.05 | Minimum ratio of genomes where the family is present in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--dup_margin` | float | 0.05 | Minimum ratio of genomes where the family is present in which the family must have multiple genes for it to be considered 'duplicated' |
 
 #### Common arguments for ppanggolin rgp
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin rgp_cluster`
@@ -750,15 +750,15 @@ Cluster RGPs based on their gene families.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--grr_cutoff` | restricted_float | 0.8 | Min gene repertoire relatedness metric used in the rgp clustering |
+| `--grr_cutoff` | float | 0.8 | Min gene repertoire relatedness metric used in the rgp clustering |
 | `--grr_metric` | str | `incomplete_aware_grr` | The grr (Gene Repertoire Relatedness) is used to assess the similarity between two RGPs based on their gene families.There are three different modes for calculating the grr value: 'min_grr', 'max_grr' or  'incomplete_aware_grr'.'min_grr': Computes the number of gene families shared between the two RGPs and divides it by the smaller number of gene families among the two RGPs.'max_grr': Calculates the number of gene families shared between the two RGPs and divides it by the larger number of gene families among the two RGPs.'incomplete_aware_grr' (default): If at least one RGP is considered incomplete, which occurs when it is located at the border of a contig,the 'min_grr' mode is used. Otherwise, the 'max_grr' mode is applied. <br>Choices: `incomplete_aware_grr`, `min_grr`, `max_grr` |
-| `--ignore_incomplete_rgp` | 0 | False | Do not cluster RGPs located on a contig border which are likely incomplete. |
-| `--no_identical_rgp_merging` | 0 | False | Do not merge in one node identical RGP (i.e. having the same family content) before clustering. |
+| `--ignore_incomplete_rgp` | bool | False | Do not cluster RGPs located on a contig border which are likely incomplete. |
+| `--no_identical_rgp_merging` | bool | False | Do not merge in one node identical RGP (i.e. having the same family content) before clustering. |
 | `--basename` | str | `rgp_cluster` | basename for the output file |
 | `-o, --output` | Path | `rgp_clustering` | Output directory |
-| `--graph_formats` | list | ['gexf', 'graphml'] | Format of the output graph. <br>Choices: `gexf`, `graphml` |
-| `--add_metadata` | 0 | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
-| `--metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--graph_formats` | str | `['gexf', 'graphml']` | Format of the output graph. <br>Choices: `gexf`, `graphml` |
+| `--add_metadata` | bool | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | str | — | Which source of metadata should be written. By default all metadata sources are included. |
 | `--metadata_sep` | str | `|` | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
 
 #### Common arguments for ppanggolin rgp_cluster
@@ -766,10 +766,10 @@ Cluster RGPs based on their gene families.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin spot`
@@ -786,22 +786,22 @@ Predicts spots in your pangenome.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `-o, --output` | Path | `ppanggolin_output<date>_<pid>` | Output directory |
-| `--spot_graph` | 0 | False | Writes a graph of pairs of blocks of single copy markers flanking RGPs, supposedly belonging to the same hotspot |
+| `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
+| `--spot_graph` | bool | False | Writes a graph of pairs of blocks of single copy markers flanking RGPs, supposedly belonging to the same hotspot |
 | `--overlapping_match` | int | 2 | The number of 'missing' persistent genes allowed when comparing flanking genes during hotspot computations |
 | `--set_size` | int | 3 | Number of single copy markers to use as flanking genes for a RGP during hotspot computation |
 | `--exact_match_size` | int | 1 | Number of perfectly matching flanking single copy markers required to associate RGPs during hotspot computation (Ex: If set to 1, two RGPs are in the same hotspot if both their 1st flanking genes are the same) |
-| `--graph_formats` | list | ['gexf'] | Format of the output graph. <br>Choices: `gexf`, `graphml` |
+| `--graph_formats` | str | `['gexf']` | Format of the output graph. <br>Choices: `gexf`, `graphml` |
 
 #### Common arguments for ppanggolin spot
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ## Analysis using reference pangenomes
@@ -822,27 +822,27 @@ Aligns a genome or a set of proteins to the pangenome gene families and predicts
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. (default: False) |
+| `--no_defrag` | bool | False | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. (default: False) |
 | `--identity` | float | 0.5 | min identity percentage threshold |
 | `--coverage` | float | 0.8 | min coverage percentage threshold |
-| `--fast` | 0 | False | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
+| `--fast` | bool | False | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `--getinfo` | 0 | False | Use this option to extract info related to the best hit of each query, such as the RGP it is in, or the spots. |
-| `--draw_related` | 0 | False | Draw figures and provide graphs in a gexf format of the eventual spots associated to the input sequences |
-| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `--getinfo` | bool | False | Use this option to extract info related to the best hit of each query, such as the RGP it is in, or the spots. |
+| `--draw_related` | bool | False | Draw figures and provide graphs in a gexf format of the eventual spots associated to the input sequences |
+| `--use_pseudo` | bool | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
-| `--tmpdir` | Path | /tmp | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
+| `--tmpdir` | Path | `/tmp` | directory for storing temporary files |
+| `--keep_tmp` | bool | False | Keeping temporary files (useful for debugging). |
 
 #### Common arguments for ppanggolin align
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin context`
@@ -854,7 +854,7 @@ Local genomic context analysis.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome.h5 file |
-| `-o, --output` | Path | `ppanggolin_context_DATE2026-08-13_HOUR16.22.03_PID909341` | Output directory where the file(s) will be written |
+| `-o, --output` | Path | `ppanggolin_context_<date>_<pid>` | Output directory where the file(s) will be written |
 
 #### Input file for ppanggolin context
 
@@ -869,20 +869,20 @@ Local genomic context analysis.
 |---|---|---|---|
 | `-t, --transitive` | int | 4 | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
 | `-w, --window_size` | int | 5 | Number of neighboring genes that are considered on each side of a gene of interest when searching for conserved genomic contexts. |
-| `-s, --jaccard` | restricted_float | 0.85 | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
+| `-s, --jaccard` | float | 0.85 | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
 | `--graph_format` | str | `graphml` | Format of the context graph. Can be gexf or graphml. <br>Choices: `gexf`, `graphml` |
 
 #### Alignment arguments for ppanggolin context
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. |
-| `--fast` | 0 | False | Use representative sequences of gene families for input gene alignment. This option is recommended for faster processing but may be less sensitive. By default, all pangenome genes are used for alignment. |
+| `--no_defrag` | bool | False | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. |
+| `--fast` | bool | False | Use representative sequences of gene families for input gene alignment. This option is recommended for faster processing but may be less sensitive. By default, all pangenome genes are used for alignment. |
 | `--identity` | float | 0.8 | min identity percentage threshold |
 | `--coverage` | float | 0.8 | min coverage percentage threshold |
 | `--translation_table` | int | 11 | The translation table to use when the input sequences are nucleotide sequences. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `--tmpdir` | str | /tmp | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
+| `--tmpdir` | str | `/tmp` | directory for storing temporary files |
+| `--keep_tmp` | bool | False | Keeping temporary files (useful for debugging). |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 
 #### Common arguments for ppanggolin context
@@ -890,10 +890,10 @@ Local genomic context analysis.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin msa`
@@ -911,26 +911,26 @@ Compute Multiple Sequence Alignments for pangenome gene families.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--soft_core` | restricted_float | 0.95 | Soft core threshold to use if 'softcore' partition is chosen |
-| `--dup_margin` | restricted_float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
-| `--single_copy` | 0 | False | Use report gene families that are considered 'single copy', for details see option --dup_margin |
+| `--soft_core` | float | 0.95 | Soft core threshold to use if 'softcore' partition is chosen |
+| `--dup_margin` | float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--single_copy` | bool | False | Use report gene families that are considered 'single copy', for details see option --dup_margin |
 | `--partition` | str | `core` | compute Multiple Sequence Alignment of the gene families in the given partition <br>Choices: `all`, `persistent`, `shell`, `cloud`, `core`, `accessory`, `softcore` |
 | `--source` | str | `protein` | indicates whether to use protein or dna sequences to compute the msa <br>Choices: `dna`, `protein` |
-| `--phylo` | 0 | False | Writes a whole genome msa file for additional phylogenetic analysis |
-| `--use_gene_id` | 0 | False | Use gene identifiers rather than genome names for sequences in the family MSA (genome names are used by default) |
+| `--phylo` | bool | False | Writes a whole genome msa file for additional phylogenetic analysis |
+| `--use_gene_id` | bool | False | Use gene identifiers rather than genome names for sequences in the family MSA (genome names are used by default) |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
 | `-c, --cpu` | int | 1 | Number of available cpus |
-| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--tmpdir` | str | `/tmp` | directory for storing temporary files |
 
 #### Common arguments for ppanggolin msa
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin projection`
@@ -950,33 +950,33 @@ Annotates external genomes with an existing pangenome.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-n, --genome_name` | str | `input_genome` | Specify the name of the genome whose genome you want to annotate when providing a single FASTA or annotation file. |
-| `--circular_contigs` | list | — | Specify the contigs of the input genome that should be treated as circular when providing a single FASTA or annotation file. |
+| `--circular_contigs` | tuple | — | Specify the contigs of the input genome that should be treated as circular when providing a single FASTA or annotation file. |
 
 #### Optional arguments for ppanggolin projection
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `-o, --output` | Path | `ppanggolin_projection_DATE2026-08-13_HOUR16.22.03_PID909341` | Output directory |
+| `-o, --output` | Path | `ppanggolin_projection_<date>_<pid>` | Output directory |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. (default: False) |
-| `--fast` | 0 | False | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
-| `--identity` | restricted_float | 0.8 | min identity percentage threshold |
-| `--coverage` | restricted_float | 0.8 | min coverage percentage threshold |
-| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `--dup_margin` | restricted_float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated'. This metric is used to compute completeness and duplication of the input genomes |
-| `--soft_core` | restricted_float | 0.95 | Soft core threshold used when generating general statistics on the projected genome. This threshold does not influence PPanGGOLiN's partitioning. The value determines the minimum fraction of genomes that must possess a gene family for it to be considered part of the soft core. |
-| `--spot_graph` | 0 | False | Write the spot graph to a file, with pairs of blocks of single copy markers flanking RGPs as nodes. This graph can be used to visualize nodes that have RGPs from the input genome. |
-| `--graph_formats` | list | ['gexf'] | Format of the output graph. <br>Choices: `gexf`, `graphml` |
-| `--gff` | 0 | False | Generate GFF files with projected pangenome annotations for each input genome. |
-| `--proksee` | 0 | False | Generate JSON map files for PROKSEE with projected pangenome annotations for each input genome. |
-| `--table` | 0 | False | Generate a tsv file for each input genome with pangenome annotations. |
-| `--compress` | 0 | False | Compress the files in .gz |
-| `--add_sequences` | 0 | False | Include input genome DNA sequences in GFF and Proksee output. |
+| `--no_defrag` | bool | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. (default: False) |
+| `--fast` | bool | False | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
+| `--identity` | float | 0.8 | min identity percentage threshold |
+| `--coverage` | float | 0.8 | min coverage percentage threshold |
+| `--use_pseudo` | bool | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `--dup_margin` | float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated'. This metric is used to compute completeness and duplication of the input genomes |
+| `--soft_core` | float | 0.95 | Soft core threshold used when generating general statistics on the projected genome. This threshold does not influence PPanGGOLiN's partitioning. The value determines the minimum fraction of genomes that must possess a gene family for it to be considered part of the soft core. |
+| `--spot_graph` | bool | False | Write the spot graph to a file, with pairs of blocks of single copy markers flanking RGPs as nodes. This graph can be used to visualize nodes that have RGPs from the input genome. |
+| `--graph_formats` | str | `['gexf']` | Format of the output graph. <br>Choices: `gexf`, `graphml` |
+| `--gff` | bool | False | Generate GFF files with projected pangenome annotations for each input genome. |
+| `--proksee` | bool | False | Generate JSON map files for PROKSEE with projected pangenome annotations for each input genome. |
+| `--table` | bool | False | Generate a tsv file for each input genome with pangenome annotations. |
+| `--compress` | bool | False | Compress the files in .gz |
+| `--add_sequences` | bool | False | Include input genome DNA sequences in GFF and Proksee output. |
 | `-c, --cpu` | int | 1 | Number of available cpus |
-| `--tmpdir` | Path | /tmp | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
-| `--add_metadata` | 0 | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
-| `--metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--tmpdir` | Path | `/tmp` | directory for storing temporary files |
+| `--keep_tmp` | bool | False | Keeping temporary files (useful for debugging). |
+| `--add_metadata` | bool | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | str | — | Which source of metadata should be written. By default all metadata sources are included. |
 | `--metadata_sep` | str | `|` | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
 
 #### Common arguments for ppanggolin projection
@@ -984,10 +984,10 @@ Annotates external genomes with an existing pangenome.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |
 
 
 ## Utility command
@@ -1013,7 +1013,7 @@ Helper side commands.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
-| `--log` | check_log | `stdout` | log output file |
-| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
-| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+| `--log` | str | `stdout` | log output file |
+| `-d, --disable_prog_bar` | bool | False | disables the progress bars |
+| `-f, --force` | bool | False | Force writing in output directory and in pangenome output file. |
+| `--config` | Path | — | Specify command arguments through a YAML configuration file. |

--- a/docs/user/command_reference.md
+++ b/docs/user/command_reference.md
@@ -10,132 +10,132 @@ This page is automatically generated from the PPanGGOLiN command-line parser.
 
 Easy workflow to run all possible analysis
 
-#### Parameters
+#### Optional parameters for ppanggolin all
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
-| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
-| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
-| `--basename` | str | `pangenome` | No | — | basename for the output file |
-| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
-| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
-| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
+| `--basename` | str | `pangenome` | basename for the output file |
+| `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. Choices: `bacteria`, `archaea` |
+| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) Choices: `0`, `1`, `2`, `3` |
+| `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin panmodule`
 
 Easy workflow to run a pangenome analysis with module prediction
 
-#### Parameters
+#### Optional parameters for ppanggolin panmodule
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
-| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
-| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
-| `--basename` | str | `pangenome` | No | — | basename for the output file |
-| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
-| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
-| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
+| `--basename` | str | `pangenome` | basename for the output file |
+| `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. Choices: `bacteria`, `archaea` |
+| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) Choices: `0`, `1`, `2`, `3` |
+| `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin panrgp`
 
 Easy workflow to run a pangenome analysis with genomic islands and spots of insertion detection
 
-#### Parameters
+#### Optional parameters for ppanggolin panrgp
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
-| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
-| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
-| `--basename` | str | `pangenome` | No | — | basename for the output file |
-| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
-| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
-| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
+| `--basename` | str | `pangenome` | basename for the output file |
+| `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. Choices: `bacteria`, `archaea` |
+| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) Choices: `0`, `1`, `2`, `3` |
+| `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin workflow`
 
 Easy workflow to run a pangenome analysis in one go
 
-#### Parameters
+#### Optional parameters for ppanggolin workflow
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
-| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
-| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
-| `--basename` | str | `pangenome` | No | — | basename for the output file |
-| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
-| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
-| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
-| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
-| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
+| `--basename` | str | `pangenome` | basename for the output file |
+| `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. Choices: `bacteria`, `archaea` |
+| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) Choices: `0`, `1`, `2`, `3` |
+| `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ## Expert
@@ -144,150 +144,150 @@ Easy workflow to run a pangenome analysis in one go
 
 Annotate genomes
 
-#### Parameters
+#### Optional parameters for ppanggolin annotate
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
-| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
-| `--allow_overlap` | 0 | False | No | — | Use to not remove genes overlapping with RNA features. |
-| `--norna` | 0 | False | No | — | Use to avoid annotating RNA features. |
-| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--basename` | str | `pangenome` | No | — | basename for the output file |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-p, --prodigal_procedure` | lower | — | No | single, meta | Allow to force the prodigal procedure. If nothing given, PPanGGOLiN will decide in function of contig length |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
+| `--anno` | Path | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
+| `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
+| `--allow_overlap` | 0 | False | Use to not remove genes overlapping with RNA features. |
+| `--norna` | 0 | False | Use to avoid annotating RNA features. |
+| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. Choices: `bacteria`, `archaea` |
+| `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--basename` | str | `pangenome` | basename for the output file |
+| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-p, --prodigal_procedure` | lower | — | Allow to force the prodigal procedure. If nothing given, PPanGGOLiN will decide in function of contig length Choices: `single`, `meta` |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin cluster`
 
 Cluster genes into gene families
 
-#### Parameters
+#### Optional parameters for ppanggolin cluster
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
-| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
-| `--no_defrag` | 0 | False | No | — | DO NOT Use the defragmentation strategy to link potential fragments with their original gene family. |
-| `--clusters` | Path | — | No | — | A tab-separated list containing the result of a clustering. One line per gene. First column is cluster ID, and second is gene ID |
-| `--infer_singletons` | 0 | False | No | — | When reading a clustering result with --clusters, if a gene is not in the provided file it will be placed in a cluster where the gene is the only member. |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
+| `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) Choices: `0`, `1`, `2`, `3` |
+| `--no_defrag` | 0 | False | DO NOT Use the defragmentation strategy to link potential fragments with their original gene family. |
+| `--clusters` | Path | — | A tab-separated list containing the result of a clustering. One line per gene. First column is cluster ID, and second is gene ID |
+| `--infer_singletons` | 0 | False | When reading a clustering result with --clusters, if a gene is not in the provided file it will be placed in a cluster where the gene is the only member. |
+| `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--tmpdir` | Path | /tmp | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin graph`
 
 Create the pangenome graph
 
-#### Parameters
+#### Optional parameters for ppanggolin graph
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-r, --remove_high_copy_number` | int | 0 | No | — | Positive Number: Remove families having a number of copy of gene in a single genome above or equal to this threshold in at least one genome (0 or negative values are ignored). |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `-r, --remove_high_copy_number` | int | 0 | Positive Number: Remove families having a number of copy of gene in a single genome above or equal to this threshold in at least one genome (0 or negative values are ignored). |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin metadata`
 
 Add metadata to elements in yout pangenome
 
-#### Parameters
+#### Optional parameters for ppanggolin metadata
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-m, --metadata` | Path | — | No | — | Metadata in TSV file. See our github for more detail about format |
-| `-s, --source` | str | — | No | — | Name of the metadata source |
-| `-a, --assign` | str | — | No | families, genomes, contigs, genes, RGPs, spots, modules | Select to which pangenome element metadata will be assigned |
-| `--omit` | 0 | False | No | — | Allow to pass if a key in metadata is not find in pangenome |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `-m, --metadata` | Path | — | Metadata in TSV file. See our github for more detail about format |
+| `-s, --source` | str | — | Name of the metadata source |
+| `-a, --assign` | str | — | Select to which pangenome element metadata will be assigned Choices: `families`, `genomes`, `contigs`, `genes`, `RGPs`, `spots`, `modules` |
+| `--omit` | 0 | False | Allow to pass if a key in metadata is not find in pangenome |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin partition`
 
 Partition the pangenome graph
 
-#### Parameters
+#### Optional parameters for ppanggolin partition
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
-| `-b, --beta` | float | 2.5 | No | — | beta is the strength of the smoothing using the graph topology during partitioning. 0 will deactivate spatial smoothing. |
-| `-ms, --max_degree_smoothing` | float | 10 | No | — | max. degree of the nodes to be included in the smoothing process. |
-| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
-| `-fd, --free_dispersion` | 0 | False | No | — | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
-| `-ck, --chunk_size` | int | 500 | No | — | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
-| `-Kmm, --krange` | 2 | [3, 20] | No | — | Range of K values to test when detecting K automatically. |
-| `-im, --ICL_margin` | float | 0.05 | No | — | K is detected automatically by maximizing ICL. However at some point the ICL reaches a plateau. Therefore we are looking for the minimal value of K without significant gain from the larger values of K measured by ICL. For that we take the lowest K that is found within a given 'margin' of the maximal ICL value. Basically, change this option only if you truly understand it, otherwise just leave it be. |
-| `--draw_ICL` | 0 | False | No | — | Use if you want to draw the ICL curve for all the tested K values. Will not be done if K is given. |
-| `--keep_tmp_files` | 0 | False | No | — | Use if you want to keep the temporary NEM files |
-| `-se, --seed` | int | 42 | No | — | seed used to generate random numbers |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome.h5 file |
+| `-b, --beta` | float | 2.5 | beta is the strength of the smoothing using the graph topology during partitioning. 0 will deactivate spatial smoothing. |
+| `-ms, --max_degree_smoothing` | float | 10 | max. degree of the nodes to be included in the smoothing process. |
+| `-o, --output` | Path | `ppanggolin_output<date>_<pid>` | Output directory |
+| `-fd, --free_dispersion` | 0 | False | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
+| `-ck, --chunk_size` | int | 500 | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
+| `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `-Kmm, --krange` | 2 | [3, 20] | Range of K values to test when detecting K automatically. |
+| `-im, --ICL_margin` | float | 0.05 | K is detected automatically by maximizing ICL. However at some point the ICL reaches a plateau. Therefore we are looking for the minimal value of K without significant gain from the larger values of K measured by ICL. For that we take the lowest K that is found within a given 'margin' of the maximal ICL value. Basically, change this option only if you truly understand it, otherwise just leave it be. |
+| `--draw_ICL` | 0 | False | Use if you want to draw the ICL curve for all the tested K values. Will not be done if K is given. |
+| `--keep_tmp_files` | 0 | False | Use if you want to keep the temporary NEM files |
+| `-se, --seed` | int | 42 | seed used to generate random numbers |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin rarefaction`
 
 Compute the rarefaction curve of the pangenome
 
-#### Parameters
+#### Optional parameters for ppanggolin rarefaction
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-b, --beta` | float | 2.5 | No | — | beta is the strength of the smoothing using the graph topology during  partitioning. 0 will deactivate spatial smoothing. |
-| `--depth` | int | 30 | No | — | Number of samplings at each sampling point |
-| `--min` | int | 1 | No | — | Minimum number of genomes in a sample |
-| `--max` | float | 100 | No | — | Maximum number of genomes in a sample (if above the number of provided genomes, the provided genomes will be the maximum) |
-| `-ms, --max_degree_smoothing` | float | 10 | No | — | max. degree of the nodes to be included in the smoothing process. |
-| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
-| `-fd, --free_dispersion` | 0 | False | No | — | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
-| `-ck, --chunk_size` | int | 500 | No | — | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
-| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. By default reuse K if it exists else compute it. |
-| `--reestimate_K` | 0 | False | No | — | Will recompute the number of partitions for each sample (between the values provided by --krange) (VERY intensive. Can take a long time.) |
-| `-Kmm, --krange` | 2 | [3, -1] | No | — | Range of K values to test when detecting K automatically. Default between 3 and the K previously computed if there is one, or 20 if there are none. |
-| `--soft_core` | float | 0.95 | No | — | Soft core threshold |
-| `-se, --seed` | int | 42 | No | — | seed used to generate random numbers |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `-b, --beta` | float | 2.5 | beta is the strength of the smoothing using the graph topology during  partitioning. 0 will deactivate spatial smoothing. |
+| `--depth` | int | 30 | Number of samplings at each sampling point |
+| `--min` | int | 1 | Minimum number of genomes in a sample |
+| `--max` | float | 100 | Maximum number of genomes in a sample (if above the number of provided genomes, the provided genomes will be the maximum) |
+| `-ms, --max_degree_smoothing` | float | 10 | max. degree of the nodes to be included in the smoothing process. |
+| `-o, --output` | Path | `ppanggolin_output<date>_<pid>` | Output directory |
+| `-fd, --free_dispersion` | 0 | False | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
+| `-ck, --chunk_size` | int | 500 | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
+| `-K, --nb_of_partitions` | int | -1 | Number of partitions to use. Must be at least 2. By default reuse K if it exists else compute it. |
+| `--reestimate_K` | 0 | False | Will recompute the number of partitions for each sample (between the values provided by --krange) (VERY intensive. Can take a long time.) |
+| `-Kmm, --krange` | 2 | [3, -1] | Range of K values to test when detecting K automatically. Default between 3 and the K previously computed if there is one, or 20 if there are none. |
+| `--soft_core` | float | 0.95 | Soft core threshold |
+| `-se, --seed` | int | 42 | seed used to generate random numbers |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ## Output
@@ -296,159 +296,204 @@ Compute the rarefaction curve of the pangenome
 
 Draw figures representing the pangenome through different aspects
 
-#### Parameters
+#### Optional parameters for ppanggolin draw
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
-| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
-| `--tile_plot` | 0 | False | No | — | draw the tile plot of the pangenome |
-| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use |
-| `--ucurve` | 0 | False | No | — | draw the U-curve of the pangenome |
-| `--draw_spots` | 0 | False | No | — | draw plots for spots of the pangenome |
-| `--spots` | list | `all` | No | — | a comma-separated list of spots to draw (or 'all' to draw all spots, or 'synteny' to draw spots with different RGP syntenies). |
-| `--nocloud` | 0 | False | No | — | Do not draw the cloud genes in the tile plot |
-| `--add_dendrogram` | 0 | False | No | — | Include a dendrogram for genomes in the tile plot based on the presence/absence of gene families. |
-| `--add_metadata` | 0 | False | No | — | Display gene metadata as hover text for each cell in the tile plot. |
-| `--metadata_sources` | list | — | No | — | Which source of metadata should be written in the tile plot. By default all metadata sources are included. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome.h5 file |
+| `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
+| `--tile_plot` | 0 | False | draw the tile plot of the pangenome |
+| `--soft_core` | restricted_float | 0.95 | Soft core threshold to use |
+| `--ucurve` | 0 | False | draw the U-curve of the pangenome |
+| `--draw_spots` | 0 | False | draw plots for spots of the pangenome |
+| `--spots` | list | `all` | a comma-separated list of spots to draw (or 'all' to draw all spots, or 'synteny' to draw spots with different RGP syntenies). |
+| `--nocloud` | 0 | False | Do not draw the cloud genes in the tile plot |
+| `--add_dendrogram` | 0 | False | Include a dendrogram for genomes in the tile plot based on the presence/absence of gene families. |
+| `--add_metadata` | 0 | False | Display gene metadata as hover text for each cell in the tile plot. |
+| `--metadata_sources` | list | — | Which source of metadata should be written in the tile plot. By default all metadata sources are included. |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin fasta`
 
 Writes fasta files for different elements of the pangenome.
 
-#### Parameters
+#### Required parameters for ppanggolin fasta
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
-| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
-| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
-| `--genes` | filter_values | — | No | — | Write all nucleotide CDS sequences. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
-| `--proteins` | filter_values | — | No | — | Write representative amino acid sequences of genes. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
-| `--prot_families` | filter_values | — | No | — | Write representative amino acid sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
-| `--gene_families` | filter_values | — | No | — | Write representative nucleotide sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
-| `--regions` | str | — | No | all, complete | Write the RGP nucleotide sequences (requires --anno or --fasta used to compute the pangenome to be given) |
-| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use if 'softcore' partition is chosen |
-| `--compress` | 0 | False | No | — | Compress the files in .gz |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `--cpu` | int | 1 | No | — | Number of available threads |
-| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional parameters for ppanggolin fasta
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
+| `--anno` | Path | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
+| `--genes` | filter_values | — | Write all nucleotide CDS sequences. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--proteins` | filter_values | — | Write representative amino acid sequences of genes. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--prot_families` | filter_values | — | Write representative amino acid sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--gene_families` | filter_values | — | Write representative nucleotide sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--regions` | str | — | Write the RGP nucleotide sequences (requires --anno or --fasta used to compute the pangenome to be given) Choices: `all`, `complete` |
+| `--soft_core` | restricted_float | 0.95 | Soft core threshold to use if 'softcore' partition is chosen |
+| `--compress` | 0 | False | Compress the files in .gz |
+| `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--cpu` | int | 1 | Number of available threads |
+| `--tmpdir` | Path | /tmp | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+
+
+### `ppanggolin info`
+
+Prints information about a given pangenome graph file.
+
+#### Required parameters for ppanggolin info
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | Path to the pangenome .h5 file Required: Yes |
+
+#### Optional parameters for ppanggolin info
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-a, --parameters` | 0 | False | Display the parameters used or computed for each step of pangenome generation |
+| `-c, --content` | 0 | False | Display detailed information about the pangenome's content |
+| `-s, --status` | 0 | False | Display information about the statuses of different elements in the pangenome, indicating what has been computed or not |
+| `-m, --metadata` | 0 | False | Display a summary of the metadata saved in the pangenome |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin metrics`
 
 Compute several metrics on a given pangenome.
 
-#### Parameters
+#### Optional parameters for ppanggolin metrics
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | Path to the pangenome .h5 file |
-| `--genome_fluidity` | 0 | False | No | — | Compute the pangenome genomic fluidity. |
-| `--no_print_info` | 0 | False | No | — | Suppress printing the metrics result. Metrics are saved in the pangenome and viewable using 'ppanggolin info'. |
-| `--recompute_metrics` | 0 | False | No | — | Force re-computation of metrics if already computed. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | Path to the pangenome .h5 file |
+| `--genome_fluidity` | 0 | False | Compute the pangenome genomic fluidity. |
+| `--no_print_info` | 0 | False | Suppress printing the metrics result. Metrics are saved in the pangenome and viewable using 'ppanggolin info'. |
+| `--recompute_metrics` | 0 | False | Force re-computation of metrics if already computed. |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin write_genomes`
 
 Writes 'flat' files that represent the genomes along with their associated pangenome elements.
 
-#### Parameters
+#### Required parameters for ppanggolin write_genomes
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
-| `--table` | 0 | False | No | — | Generate a tsv file for each genome with pangenome annotations. |
-| `--gff` | 0 | False | No | — | Generate a gff file for each genome containing pangenome annotations. |
-| `--proksee` | 0 | False | No | — | Generate JSON map files for PROKSEE for each genome containing pangenome annotations to be used in proksee. |
-| `--compress` | 0 | False | No | — | Compress the files in .gz |
-| `--genomes` | str | `all` | No | — | Specify the genomes for which to generate output. You can provide a list of genome names either directly in the command line separated by commas, or by referencing a file containing the list of genome names, with one name per line. |
-| `--add_metadata` | 0 | False | No | — | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
-| `--metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
-| `--metadata_sep` | str | `|` | No | — | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
-| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional parameters for ppanggolin write_genomes
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `--table` | 0 | False | Generate a tsv file for each genome with pangenome annotations. |
+| `--gff` | 0 | False | Generate a gff file for each genome containing pangenome annotations. |
+| `--proksee` | 0 | False | Generate JSON map files for PROKSEE for each genome containing pangenome annotations to be used in proksee. |
+| `--compress` | 0 | False | Compress the files in .gz |
+| `--genomes` | str | `all` | Specify the genomes for which to generate output. You can provide a list of genome names either directly in the command line separated by commas, or by referencing a file containing the list of genome names, with one name per line. |
+| `--add_metadata` | 0 | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--metadata_sep` | str | `|` | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
+| `--anno` | Path | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin write_metadata`
 
 Writes 'TSV' files that represent the metadata associated with elements of the pangenome.
 
-#### Parameters
+#### Required parameters for ppanggolin write_metadata
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
-| `--compress` | 0 | False | No | — | Compress the files in .gz |
-| `-e, --pangenome_elements` | list | ['families', 'genes', 'spots', 'genomes', 'RGPs', 'modules', 'contigs'] | No | families, genes, spots, genomes, RGPs, modules, contigs | Specify pangenome elements for which to write metadata. default is all element with metadata. |
-| `-s, --metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional parameters for ppanggolin write_metadata
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `--compress` | 0 | False | Compress the files in .gz |
+| `-e, --pangenome_elements` | list | ['spots', 'modules', 'contigs', 'genomes', 'genes', 'families', 'RGPs'] | Specify pangenome elements for which to write metadata. default is all element with metadata. Choices: `spots`, `modules`, `contigs`, `genomes`, `genes`, `families`, `RGPs` |
+| `-s, --metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin write_pangenome`
 
 Writes 'flat' files that represent the pangenome and its elements for use with other software.
 
-#### Parameters
+#### Required parameters for ppanggolin write_pangenome
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
-| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use |
-| `--dup_margin` | restricted_float | 0.05 | No | — | Minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
-| `--gexf` | 0 | False | No | — | Generate a detailed GEXF file with all genes and annotations for each family |
-| `--light_gexf` | 0 | False | No | — | Generate a simplified GEXF file with basic gene family information |
-| `--gt` | 0 | False | No | — | Generate a simplified graph-tool GT file with basic gene family and pangenome organism strains information |
-| `--json` | 0 | False | No | — | Export the graph in JSON file format |
-| `--csv` | 0 | False | No | — | Export gene presence/absence in CSV format (compatible with Roary). Uses partitions as alternative gene IDs if available. |
-| `--Rtab` | 0 | False | No | — | Export gene presence/absence as a tabular binary matrix |
-| `--stats` | 0 | False | No | — | Generate genome statistics ('genome_statistics.tsv') and duplication summary of persistent families ('mean_persistent_duplication.tsv') |
-| `--partitions` | 0 | False | No | — | Generate one file per partition listing the gene families it contains |
-| `--families_tsv` | 0 | False | No | — | Write a TSV file mapping genes to their corresponding gene families |
-| `--regions` | 0 | False | No | — | Write predicted RGPs (Regions of Genomic Plasticity) and metrics to 'plastic_regions.tsv' |
-| `--regions_families` | 0 | False | No | — | Write a TSV file mapping each RGP to its gene family content in 'rgp_families.tsv' |
-| `--spots` | 0 | False | No | — | Write spot summary and list all RGPs (Regions of Genomic Plasticity) per spot |
-| `--borders` | 0 | False | No | — | List all borders of each spot |
-| `--modules` | 0 | False | No | — | Write a TSV file listing functional modules and their associated gene families |
-| `--spot_modules` | 0 | False | No | — | Generate two files comparing module presence across spots |
-| `--compress` | 0 | False | No | — | Compress output files using gzip (.gz) |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional parameters for ppanggolin write_pangenome
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `--soft_core` | restricted_float | 0.95 | Soft core threshold to use |
+| `--dup_margin` | restricted_float | 0.05 | Minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--gexf` | 0 | False | Generate a detailed GEXF file with all genes and annotations for each family |
+| `--light_gexf` | 0 | False | Generate a simplified GEXF file with basic gene family information |
+| `--gt` | 0 | False | Generate a simplified graph-tool GT file with basic gene family and pangenome organism strains information |
+| `--json` | 0 | False | Export the graph in JSON file format |
+| `--csv` | 0 | False | Export gene presence/absence in CSV format (compatible with Roary). Uses partitions as alternative gene IDs if available. |
+| `--Rtab` | 0 | False | Export gene presence/absence as a tabular binary matrix |
+| `--stats` | 0 | False | Generate genome statistics ('genome_statistics.tsv') and duplication summary of persistent families ('mean_persistent_duplication.tsv') |
+| `--partitions` | 0 | False | Generate one file per partition listing the gene families it contains |
+| `--families_tsv` | 0 | False | Write a TSV file mapping genes to their corresponding gene families |
+| `--regions` | 0 | False | Write predicted RGPs (Regions of Genomic Plasticity) and metrics to 'plastic_regions.tsv' |
+| `--regions_families` | 0 | False | Write a TSV file mapping each RGP to its gene family content in 'rgp_families.tsv' |
+| `--spots` | 0 | False | Write spot summary and list all RGPs (Regions of Genomic Plasticity) per spot |
+| `--borders` | 0 | False | List all borders of each spot |
+| `--modules` | 0 | False | Write a TSV file listing functional modules and their associated gene families |
+| `--spot_modules` | 0 | False | Generate two files comparing module presence across spots |
+| `--compress` | 0 | False | Compress output files using gzip (.gz) |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ## Regions of Genomic Plasticity
@@ -457,91 +502,96 @@ Writes 'flat' files that represent the pangenome and its elements for use with o
 
 Predicts functional modules in your pangenome.
 
-#### Parameters
+#### Optional parameters for ppanggolin module
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `--size` | int | 3 | No | — | Minimal number of gene family in a module |
-| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
-| `-m, --min_presence` | int | 2 | No | — | Minimum number of times the module needs to be present in the pangenome to be reported. Increasing it will improve precision but lower sensitivity. |
-| `-t, --transitive` | int | 4 | No | — | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
-| `-s, --jaccard` | restricted_float | 0.85 | No | — | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `--size` | int | 3 | Minimal number of gene family in a module |
+| `--dup_margin` | restricted_float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `-m, --min_presence` | int | 2 | Minimum number of times the module needs to be present in the pangenome to be reported. Increasing it will improve precision but lower sensitivity. |
+| `-t, --transitive` | int | 4 | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
+| `-s, --jaccard` | restricted_float | 0.85 | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin rgp`
 
 Predicts Regions of Genomic Plasticity in the genomes of your pangenome.
 
-#### Parameters
+#### Optional parameters for ppanggolin rgp
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `--persistent_penalty` | int | 3 | No | — | Penalty score to apply to persistent genes |
-| `--variable_gain` | int | 1 | No | — | Gain score to apply to variable genes |
-| `--min_score` | int | 4 | No | — | Minimal score wanted for considering a region as being a RGP |
-| `--min_length` | int | 3000 | No | — | Minimum length (bp) of a region to be considered a RGP |
-| `--dup_margin` | restricted_float | 0.05 | No | — | Minimum ratio of genomes where the family is present in which the family must have multiple genes for it to be considered 'duplicated' |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `--persistent_penalty` | int | 3 | Penalty score to apply to persistent genes |
+| `--variable_gain` | int | 1 | Gain score to apply to variable genes |
+| `--min_score` | int | 4 | Minimal score wanted for considering a region as being a RGP |
+| `--min_length` | int | 3000 | Minimum length (bp) of a region to be considered a RGP |
+| `--dup_margin` | restricted_float | 0.05 | Minimum ratio of genomes where the family is present in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin rgp_cluster`
 
 Cluster RGPs based on their gene families.
 
-#### Parameters
+#### Required parameters for ppanggolin rgp_cluster
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | Yes | — | The pangenome .h5 file |
-| `--grr_cutoff` | restricted_float | 0.8 | No | — | Min gene repertoire relatedness metric used in the rgp clustering |
-| `--grr_metric` | str | `incomplete_aware_grr` | No | incomplete_aware_grr, min_grr, max_grr | The grr (Gene Repertoire Relatedness) is used to assess the similarity between two RGPs based on their gene families.There are three different modes for calculating the grr value: 'min_grr', 'max_grr' or  'incomplete_aware_grr'.'min_grr': Computes the number of gene families shared between the two RGPs and divides it by the smaller number of gene families among the two RGPs.'max_grr': Calculates the number of gene families shared between the two RGPs and divides it by the larger number of gene families among the two RGPs.'incomplete_aware_grr' (default): If at least one RGP is considered incomplete, which occurs when it is located at the border of a contig,the 'min_grr' mode is used. Otherwise, the 'max_grr' mode is applied. |
-| `--ignore_incomplete_rgp` | 0 | False | No | — | Do not cluster RGPs located on a contig border which are likely incomplete. |
-| `--no_identical_rgp_merging` | 0 | False | No | — | Do not merge in one node identical RGP (i.e. having the same family content) before clustering. |
-| `--basename` | str | `rgp_cluster` | No | — | basename for the output file |
-| `-o, --output` | Path | `rgp_clustering` | No | — | Output directory |
-| `--graph_formats` | list | ['gexf', 'graphml'] | No | gexf, graphml | Format of the output graph. |
-| `--add_metadata` | 0 | False | No | — | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
-| `--metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
-| `--metadata_sep` | str | `|` | No | — | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file Required: Yes |
+
+#### Optional parameters for ppanggolin rgp_cluster
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--grr_cutoff` | restricted_float | 0.8 | Min gene repertoire relatedness metric used in the rgp clustering |
+| `--grr_metric` | str | `incomplete_aware_grr` | The grr (Gene Repertoire Relatedness) is used to assess the similarity between two RGPs based on their gene families.There are three different modes for calculating the grr value: 'min_grr', 'max_grr' or  'incomplete_aware_grr'.'min_grr': Computes the number of gene families shared between the two RGPs and divides it by the smaller number of gene families among the two RGPs.'max_grr': Calculates the number of gene families shared between the two RGPs and divides it by the larger number of gene families among the two RGPs.'incomplete_aware_grr' (default): If at least one RGP is considered incomplete, which occurs when it is located at the border of a contig,the 'min_grr' mode is used. Otherwise, the 'max_grr' mode is applied. Choices: `incomplete_aware_grr`, `min_grr`, `max_grr` |
+| `--ignore_incomplete_rgp` | 0 | False | Do not cluster RGPs located on a contig border which are likely incomplete. |
+| `--no_identical_rgp_merging` | 0 | False | Do not merge in one node identical RGP (i.e. having the same family content) before clustering. |
+| `--basename` | str | `rgp_cluster` | basename for the output file |
+| `-o, --output` | Path | `rgp_clustering` | Output directory |
+| `--graph_formats` | list | ['gexf', 'graphml'] | Format of the output graph. Choices: `gexf`, `graphml` |
+| `--add_metadata` | 0 | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--metadata_sep` | str | `|` | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin spot`
 
 Predicts spots in your pangenome.
 
-#### Parameters
+#### Optional parameters for ppanggolin spot
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR12.55.19_PID729243 | No | — | Output directory |
-| `--spot_graph` | 0 | False | No | — | Writes a graph of pairs of blocks of single copy markers flanking RGPs, supposedly belonging to the same hotspot |
-| `--overlapping_match` | int | 2 | No | — | The number of 'missing' persistent genes allowed when comparing flanking genes during hotspot computations |
-| `--set_size` | int | 3 | No | — | Number of single copy markers to use as flanking genes for a RGP during hotspot computation |
-| `--exact_match_size` | int | 1 | No | — | Number of perfectly matching flanking single copy markers required to associate RGPs during hotspot computation (Ex: If set to 1, two RGPs are in the same hotspot if both their 1st flanking genes are the same) |
-| `--graph_formats` | list | ['gexf'] | No | gexf, graphml | Format of the output graph. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `-o, --output` | Path | `ppanggolin_output<date>_<pid>` | Output directory |
+| `--spot_graph` | 0 | False | Writes a graph of pairs of blocks of single copy markers flanking RGPs, supposedly belonging to the same hotspot |
+| `--overlapping_match` | int | 2 | The number of 'missing' persistent genes allowed when comparing flanking genes during hotspot computations |
+| `--set_size` | int | 3 | Number of single copy markers to use as flanking genes for a RGP during hotspot computation |
+| `--exact_match_size` | int | 1 | Number of perfectly matching flanking single copy markers required to associate RGPs during hotspot computation (Ex: If set to 1, two RGPs are in the same hotspot if both their 1st flanking genes are the same) |
+| `--graph_formats` | list | ['gexf'] | Format of the output graph. Choices: `gexf`, `graphml` |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ## Analysis using reference pangenomes
@@ -550,126 +600,155 @@ Predicts spots in your pangenome.
 
 Aligns a genome or a set of proteins to the pangenome gene families and predicts information from it.
 
-#### Parameters
+#### Required parameters for ppanggolin align
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-S, --sequences` | Path | — | No | — | sequences (nucleotides or amino acids) to align on the pangenome gene families |
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. (default: False) |
-| `--identity` | float | 0.5 | No | — | min identity percentage threshold |
-| `--coverage` | float | 0.8 | No | — | min coverage percentage threshold |
-| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `--getinfo` | 0 | False | No | — | Use this option to extract info related to the best hit of each query, such as the RGP it is in, or the spots. |
-| `--draw_related` | 0 | False | No | — | Draw figures and provide graphs in a gexf format of the eventual spots associated to the input sequences |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional parameters for ppanggolin align
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-S, --sequences` | Path | — | sequences (nucleotides or amino acids) to align on the pangenome gene families |
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. (default: False) |
+| `--identity` | float | 0.5 | min identity percentage threshold |
+| `--coverage` | float | 0.8 | min coverage percentage threshold |
+| `--fast` | 0 | False | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
+| `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--getinfo` | 0 | False | Use this option to extract info related to the best hit of each query, such as the RGP it is in, or the spots. |
+| `--draw_related` | 0 | False | Draw figures and provide graphs in a gexf format of the eventual spots associated to the input sequences |
+| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--tmpdir` | Path | /tmp | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin context`
 
 Local genomic context analysis.
 
-#### Parameters
+#### Optional parameters for ppanggolin context
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
-| `-o, --output` | Path | `ppanggolin_context_DATE2026-08-13_HOUR12.55.19_PID729243` | No | — | Output directory where the file(s) will be written |
-| `-S, --sequences` | Path | — | No | — | Fasta file with the sequences of interest |
-| `-F, --family` | Path | — | No | — | List of family IDs of interest from the pangenome |
-| `-t, --transitive` | int | 4 | No | — | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
-| `-w, --window_size` | int | 5 | No | — | Number of neighboring genes that are considered on each side of a gene of interest when searching for conserved genomic contexts. |
-| `-s, --jaccard` | restricted_float | 0.85 | No | — | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
-| `--graph_format` | str | `graphml` | No | gexf, graphml | Format of the context graph. Can be gexf or graphml. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. |
-| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is recommended for faster processing but may be less sensitive. By default, all pangenome genes are used for alignment. |
-| `--identity` | float | 0.8 | No | — | min identity percentage threshold |
-| `--coverage` | float | 0.8 | No | — | min coverage percentage threshold |
-| `--translation_table` | int | 11 | No | — | The translation table to use when the input sequences are nucleotide sequences. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome.h5 file |
+| `-o, --output` | Path | `ppanggolin_context_DATE2026-08-13_HOUR15.51.08_PID880462` | Output directory where the file(s) will be written |
+| `-S, --sequences` | Path | — | Fasta file with the sequences of interest |
+| `-F, --family` | Path | — | List of family IDs of interest from the pangenome |
+| `-t, --transitive` | int | 4 | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
+| `-w, --window_size` | int | 5 | Number of neighboring genes that are considered on each side of a gene of interest when searching for conserved genomic contexts. |
+| `-s, --jaccard` | restricted_float | 0.85 | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
+| `--graph_format` | str | `graphml` | Format of the context graph. Can be gexf or graphml. Choices: `gexf`, `graphml` |
+| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. |
+| `--fast` | 0 | False | Use representative sequences of gene families for input gene alignment. This option is recommended for faster processing but may be less sensitive. By default, all pangenome genes are used for alignment. |
+| `--identity` | float | 0.8 | min identity percentage threshold |
+| `--coverage` | float | 0.8 | min coverage percentage threshold |
+| `--translation_table` | int | 11 | The translation table to use when the input sequences are nucleotide sequences. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin msa`
 
 Compute Multiple Sequence Alignments for pangenome gene families.
 
-#### Parameters
+#### Required parameters for ppanggolin msa
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
-| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
-| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use if 'softcore' partition is chosen |
-| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
-| `--single_copy` | 0 | False | No | — | Use report gene families that are considered 'single copy', for details see option --dup_margin |
-| `--partition` | str | `core` | No | all, persistent, shell, cloud, core, accessory, softcore | compute Multiple Sequence Alignment of the gene families in the given partition |
-| `--source` | str | `protein` | No | dna, protein | indicates whether to use protein or dna sequences to compute the msa |
-| `--phylo` | 0 | False | No | — | Writes a whole genome msa file for additional phylogenetic analysis |
-| `--use_gene_id` | 0 | False | No | — | Use gene identifiers rather than genome names for sequences in the family MSA (genome names are used by default) |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional parameters for ppanggolin msa
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `--soft_core` | restricted_float | 0.95 | Soft core threshold to use if 'softcore' partition is chosen |
+| `--dup_margin` | restricted_float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--single_copy` | 0 | False | Use report gene families that are considered 'single copy', for details see option --dup_margin |
+| `--partition` | str | `core` | compute Multiple Sequence Alignment of the gene families in the given partition Choices: `all`, `persistent`, `shell`, `cloud`, `core`, `accessory`, `softcore` |
+| `--source` | str | `protein` | indicates whether to use protein or dna sequences to compute the msa Choices: `dna`, `protein` |
+| `--phylo` | 0 | False | Writes a whole genome msa file for additional phylogenetic analysis |
+| `--use_gene_id` | 0 | False | Use gene identifiers rather than genome names for sequences in the family MSA (genome names are used by default) |
+| `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--tmpdir` | str | /tmp | directory for storing temporary files |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
 
 
 ### `ppanggolin projection`
 
 Annotates external genomes with an existing pangenome.
 
-#### Parameters
+#### Optional parameters for ppanggolin projection
 
-| Parameter | Type | Default | Required | Choices | Description |
-|---|---|---|---|---|---|
-| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
-| `--fasta` | Path | — | No | — | Specify a FASTA file containing the genomic sequences of the genome(s) you wish to annotate, or provide a tab-separated file listing genome names alongside their respective FASTA filepaths, with one line per genome. |
-| `--anno` | Path | — | No | — | Specify an annotation file in GFF/GBFF format for the genome you wish to annotate. Alternatively, you can provide a tab-separated file listing genome names alongside their respective annotation filepaths, with one line per genome. If both an annotation file and a FASTA file are provided, the annotation file will take precedence. |
-| `-n, --genome_name` | str | `input_genome` | No | — | Specify the name of the genome whose genome you want to annotate when providing a single FASTA or annotation file. |
-| `--circular_contigs` | list | — | No | — | Specify the contigs of the input genome that should be treated as circular when providing a single FASTA or annotation file. |
-| `-o, --output` | Path | `ppanggolin_projection_DATE2026-08-13_HOUR12.55.19_PID729243` | No | — | Output directory |
-| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
-| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. (default: False) |
-| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
-| `--identity` | restricted_float | 0.8 | No | — | min identity percentage threshold |
-| `--coverage` | restricted_float | 0.8 | No | — | min coverage percentage threshold |
-| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated'. This metric is used to compute completeness and duplication of the input genomes |
-| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold used when generating general statistics on the projected genome. This threshold does not influence PPanGGOLiN's partitioning. The value determines the minimum fraction of genomes that must possess a gene family for it to be considered part of the soft core. |
-| `--spot_graph` | 0 | False | No | — | Write the spot graph to a file, with pairs of blocks of single copy markers flanking RGPs as nodes. This graph can be used to visualize nodes that have RGPs from the input genome. |
-| `--graph_formats` | list | ['gexf'] | No | gexf, graphml | Format of the output graph. |
-| `--gff` | 0 | False | No | — | Generate GFF files with projected pangenome annotations for each input genome. |
-| `--proksee` | 0 | False | No | — | Generate JSON map files for PROKSEE with projected pangenome annotations for each input genome. |
-| `--table` | 0 | False | No | — | Generate a tsv file for each input genome with pangenome annotations. |
-| `--compress` | 0 | False | No | — | Compress the files in .gz |
-| `--add_sequences` | 0 | False | No | — | Include input genome DNA sequences in GFF and Proksee output. |
-| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
-| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
-| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
-| `--add_metadata` | 0 | False | No | — | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
-| `--metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
-| `--metadata_sep` | str | `|` | No | — | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
-| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
-| `--log` | check_log | `stdout` | No | — | log output file |
-| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
-| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
-| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-p, --pangenome` | Path | — | The pangenome.h5 file |
+| `--fasta` | Path | — | Specify a FASTA file containing the genomic sequences of the genome(s) you wish to annotate, or provide a tab-separated file listing genome names alongside their respective FASTA filepaths, with one line per genome. |
+| `--anno` | Path | — | Specify an annotation file in GFF/GBFF format for the genome you wish to annotate. Alternatively, you can provide a tab-separated file listing genome names alongside their respective annotation filepaths, with one line per genome. If both an annotation file and a FASTA file are provided, the annotation file will take precedence. |
+| `-n, --genome_name` | str | `input_genome` | Specify the name of the genome whose genome you want to annotate when providing a single FASTA or annotation file. |
+| `--circular_contigs` | list | — | Specify the contigs of the input genome that should be treated as circular when providing a single FASTA or annotation file. |
+| `-o, --output` | Path | `ppanggolin_projection_DATE2026-08-13_HOUR15.51.08_PID880462` | Output directory |
+| `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. (default: False) |
+| `--fast` | 0 | False | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
+| `--identity` | restricted_float | 0.8 | min identity percentage threshold |
+| `--coverage` | restricted_float | 0.8 | min coverage percentage threshold |
+| `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `--dup_margin` | restricted_float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated'. This metric is used to compute completeness and duplication of the input genomes |
+| `--soft_core` | restricted_float | 0.95 | Soft core threshold used when generating general statistics on the projected genome. This threshold does not influence PPanGGOLiN's partitioning. The value determines the minimum fraction of genomes that must possess a gene family for it to be considered part of the soft core. |
+| `--spot_graph` | 0 | False | Write the spot graph to a file, with pairs of blocks of single copy markers flanking RGPs as nodes. This graph can be used to visualize nodes that have RGPs from the input genome. |
+| `--graph_formats` | list | ['gexf'] | Format of the output graph. Choices: `gexf`, `graphml` |
+| `--gff` | 0 | False | Generate GFF files with projected pangenome annotations for each input genome. |
+| `--proksee` | 0 | False | Generate JSON map files for PROKSEE with projected pangenome annotations for each input genome. |
+| `--table` | 0 | False | Generate a tsv file for each input genome with pangenome annotations. |
+| `--compress` | 0 | False | Compress the files in .gz |
+| `--add_sequences` | 0 | False | Include input genome DNA sequences in GFF and Proksee output. |
+| `-c, --cpu` | int | 1 | Number of available cpus |
+| `--tmpdir` | Path | /tmp | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
+| `--add_metadata` | 0 | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--metadata_sep` | str | `|` | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |
+
+
+## Utility command
+
+### `ppanggolin utils`
+
+Helper side commands.
+
+#### Optional parameters for ppanggolin utils
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--default_config` | str | — | Generate a config file with default values for the given subcommand. Choices: `annotate`, `cluster`, `graph`, `partition`, `rarefaction`, `workflow`, `panrgp`, `panmodule`, `all`, `draw`, `write_pangenome`, `write_genomes`, `write_metadata`, `fasta`, `msa`, `metrics`, `align`, `info`, `rgp`, `spot`, `module`, `context`, `projection`, `rgp_cluster`, `metadata`, `utils` |
+| `-o, --output` | Path | `default_config.yaml` | name and path of the config file with default parameters written in yaml. |
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--log` | check_log | `stdout` | log output file |
+| `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
+| `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | Specify command arguments through a YAML configuration file. |

--- a/docs/user/command_reference.md
+++ b/docs/user/command_reference.md
@@ -10,20 +10,25 @@ This page is automatically generated from the PPanGGOLiN command-line parser.
 
 Easy workflow to run all possible analysis
 
-#### Optional parameters for ppanggolin all
+#### Input arguments for ppanggolin all
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
 | `--anno` | Path | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
 | `--clusters` | Path | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+
+#### Optional arguments for ppanggolin all
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
 | `--basename` | str | `pangenome` | basename for the output file |
 | `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. Choices: `bacteria`, `archaea` |
-| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) Choices: `0`, `1`, `2`, `3` |
+| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. <br>Choices: `bacteria`, `archaea` |
+| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) <br>Choices: `0`, `1`, `2`, `3` |
 | `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
 | `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
 | `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
@@ -32,7 +37,12 @@ Easy workflow to run all possible analysis
 | `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
 | `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
 | `--tmpdir` | str | /tmp | directory for storing temporary files |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin all
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -43,20 +53,25 @@ Easy workflow to run all possible analysis
 
 Easy workflow to run a pangenome analysis with module prediction
 
-#### Optional parameters for ppanggolin panmodule
+#### Input arguments for ppanggolin panmodule
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
 | `--anno` | Path | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
 | `--clusters` | Path | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+
+#### Optional arguments for ppanggolin panmodule
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
 | `--basename` | str | `pangenome` | basename for the output file |
 | `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. Choices: `bacteria`, `archaea` |
-| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) Choices: `0`, `1`, `2`, `3` |
+| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. <br>Choices: `bacteria`, `archaea` |
+| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) <br>Choices: `0`, `1`, `2`, `3` |
 | `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
 | `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
 | `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
@@ -65,7 +80,12 @@ Easy workflow to run a pangenome analysis with module prediction
 | `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
 | `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
 | `--tmpdir` | str | /tmp | directory for storing temporary files |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin panmodule
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -76,20 +96,25 @@ Easy workflow to run a pangenome analysis with module prediction
 
 Easy workflow to run a pangenome analysis with genomic islands and spots of insertion detection
 
-#### Optional parameters for ppanggolin panrgp
+#### Input arguments for ppanggolin panrgp
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
 | `--anno` | Path | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
 | `--clusters` | Path | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+
+#### Optional arguments for ppanggolin panrgp
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
 | `--basename` | str | `pangenome` | basename for the output file |
 | `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. Choices: `bacteria`, `archaea` |
-| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) Choices: `0`, `1`, `2`, `3` |
+| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. <br>Choices: `bacteria`, `archaea` |
+| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) <br>Choices: `0`, `1`, `2`, `3` |
 | `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
 | `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
 | `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
@@ -98,7 +123,12 @@ Easy workflow to run a pangenome analysis with genomic islands and spots of inse
 | `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
 | `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
 | `--tmpdir` | str | /tmp | directory for storing temporary files |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin panrgp
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -109,20 +139,25 @@ Easy workflow to run a pangenome analysis with genomic islands and spots of inse
 
 Easy workflow to run a pangenome analysis in one go
 
-#### Optional parameters for ppanggolin workflow
+#### Input arguments for ppanggolin workflow
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
 | `--anno` | Path | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
 | `--clusters` | Path | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+
+#### Optional arguments for ppanggolin workflow
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
 | `--basename` | str | `pangenome` | basename for the output file |
 | `--rarefaction` | 0 | False | Use to compute the rarefaction curves (WARNING: can be time consuming) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
-| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. Choices: `bacteria`, `archaea` |
-| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) Choices: `0`, `1`, `2`, `3` |
+| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. <br>Choices: `bacteria`, `archaea` |
+| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) <br>Choices: `0`, `1`, `2`, `3` |
 | `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
 | `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
 | `--infer_singletons` | 0 | False | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
@@ -131,7 +166,12 @@ Easy workflow to run a pangenome analysis in one go
 | `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
 | `--no_flat_files` | 0 | False | Generate only the HDF5 pangenome file. |
 | `--tmpdir` | str | /tmp | directory for storing temporary files |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin workflow
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -144,23 +184,33 @@ Easy workflow to run a pangenome analysis in one go
 
 Annotate genomes
 
-#### Optional parameters for ppanggolin annotate
+#### Required arguments for ppanggolin annotate
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
 | `--anno` | Path | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
+
+#### Optional arguments for ppanggolin annotate
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
 | `--allow_overlap` | 0 | False | Use to not remove genes overlapping with RNA features. |
 | `--norna` | 0 | False | Use to avoid annotating RNA features. |
-| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. Choices: `bacteria`, `archaea` |
+| `--kingdom` | lower | `bacteria` | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. <br>Choices: `bacteria`, `archaea` |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
 | `--basename` | str | `pangenome` | basename for the output file |
 | `--use_pseudo` | 0 | False | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
-| `-p, --prodigal_procedure` | lower | — | Allow to force the prodigal procedure. If nothing given, PPanGGOLiN will decide in function of contig length Choices: `single`, `meta` |
+| `-p, --prodigal_procedure` | lower | — | Allow to force the prodigal procedure. If nothing given, PPanGGOLiN will decide in function of contig length <br>Choices: `single`, `meta` |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--tmpdir` | str | /tmp | directory for storing temporary files |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin annotate
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -171,22 +221,42 @@ Annotate genomes
 
 Cluster genes into gene families
 
-#### Optional parameters for ppanggolin cluster
+#### Required arguments for ppanggolin cluster
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+
+#### Clustering arguments for ppanggolin cluster
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--identity` | restricted_float | 0.8 | Minimal identity percent for two proteins to be in the same cluster |
 | `--coverage` | restricted_float | 0.8 | Minimal coverage of the alignment for two proteins to be in the same cluster |
-| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) Choices: `0`, `1`, `2`, `3` |
+| `--mode` | str | `1` | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) <br>Choices: `0`, `1`, `2`, `3` |
 | `--no_defrag` | 0 | False | DO NOT Use the defragmentation strategy to link potential fragments with their original gene family. |
+
+#### Read clustering arguments for ppanggolin cluster
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--clusters` | Path | — | A tab-separated list containing the result of a clustering. One line per gene. First column is cluster ID, and second is gene ID |
 | `--infer_singletons` | 0 | False | When reading a clustering result with --clusters, if a gene is not in the provided file it will be placed in a cluster where the gene is the only member. |
+
+#### Optional arguments for ppanggolin cluster
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--tmpdir` | Path | /tmp | directory for storing temporary files |
 | `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin cluster
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -197,13 +267,23 @@ Cluster genes into gene families
 
 Create the pangenome graph
 
-#### Optional parameters for ppanggolin graph
+#### Required arguments for ppanggolin graph
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+
+#### Optional arguments for ppanggolin graph
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-r, --remove_high_copy_number` | int | 0 | Positive Number: Remove families having a number of copy of gene in a single genome above or equal to this threshold in at least one genome (0 or negative values are ignored). |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin graph
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -214,16 +294,26 @@ Create the pangenome graph
 
 Add metadata to elements in yout pangenome
 
-#### Optional parameters for ppanggolin metadata
+#### Required arguments for ppanggolin metadata
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
 | `-m, --metadata` | Path | — | Metadata in TSV file. See our github for more detail about format |
 | `-s, --source` | str | — | Name of the metadata source |
-| `-a, --assign` | str | — | Select to which pangenome element metadata will be assigned Choices: `families`, `genomes`, `contigs`, `genes`, `RGPs`, `spots`, `modules` |
+| `-a, --assign` | str | — | Select to which pangenome element metadata will be assigned <br>Choices: `families`, `genomes`, `contigs`, `genes`, `RGPs`, `spots`, `modules` |
+
+#### Optional arguments for ppanggolin metadata
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--omit` | 0 | False | Allow to pass if a key in metadata is not find in pangenome |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin metadata
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -234,11 +324,16 @@ Add metadata to elements in yout pangenome
 
 Partition the pangenome graph
 
-#### Optional parameters for ppanggolin partition
+#### Required arguments for ppanggolin partition
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome.h5 file |
+
+#### Optional arguments for ppanggolin partition
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-b, --beta` | float | 2.5 | beta is the strength of the smoothing using the graph topology during partitioning. 0 will deactivate spatial smoothing. |
 | `-ms, --max_degree_smoothing` | float | 10 | max. degree of the nodes to be included in the smoothing process. |
 | `-o, --output` | Path | `ppanggolin_output<date>_<pid>` | Output directory |
@@ -252,7 +347,12 @@ Partition the pangenome graph
 | `-se, --seed` | int | 42 | seed used to generate random numbers |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--tmpdir` | str | /tmp | directory for storing temporary files |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin partition
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -263,11 +363,16 @@ Partition the pangenome graph
 
 Compute the rarefaction curve of the pangenome
 
-#### Optional parameters for ppanggolin rarefaction
+#### Required arguments for ppanggolin rarefaction
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+
+#### Optional arguments for ppanggolin rarefaction
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-b, --beta` | float | 2.5 | beta is the strength of the smoothing using the graph topology during  partitioning. 0 will deactivate spatial smoothing. |
 | `--depth` | int | 30 | Number of samplings at each sampling point |
 | `--min` | int | 1 | Minimum number of genomes in a sample |
@@ -283,7 +388,12 @@ Compute the rarefaction curve of the pangenome
 | `-se, --seed` | int | 42 | seed used to generate random numbers |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--tmpdir` | str | /tmp | directory for storing temporary files |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin rarefaction
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -296,11 +406,16 @@ Compute the rarefaction curve of the pangenome
 
 Draw figures representing the pangenome through different aspects
 
-#### Optional parameters for ppanggolin draw
+#### Required arguments for ppanggolin draw
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome.h5 file |
+
+#### Optional arguments for ppanggolin draw
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output_<date>_<pid>` | Output directory |
 | `--tile_plot` | 0 | False | draw the tile plot of the pangenome |
 | `--soft_core` | restricted_float | 0.95 | Soft core threshold to use |
@@ -311,7 +426,12 @@ Draw figures representing the pangenome through different aspects
 | `--add_dendrogram` | 0 | False | Include a dendrogram for genomes in the tile plot based on the presence/absence of gene families. |
 | `--add_metadata` | 0 | False | Display gene metadata as hover text for each cell in the tile plot. |
 | `--metadata_sources` | list | — | Which source of metadata should be written in the tile plot. By default all metadata sources are included. |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin draw
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -322,31 +442,46 @@ Draw figures representing the pangenome through different aspects
 
 Writes fasta files for different elements of the pangenome.
 
-#### Required parameters for ppanggolin fasta
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
-
-#### Optional parameters for ppanggolin fasta
+#### Required arguments for ppanggolin fasta
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Contextually required arguments for ppanggolin fasta
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
 | `--anno` | Path | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
+
+#### Output file for ppanggolin fasta
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--genes` | filter_values | — | Write all nucleotide CDS sequences. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
 | `--proteins` | filter_values | — | Write representative amino acid sequences of genes. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
 | `--prot_families` | filter_values | — | Write representative amino acid sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
 | `--gene_families` | filter_values | — | Write representative nucleotide sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
-| `--regions` | str | — | Write the RGP nucleotide sequences (requires --anno or --fasta used to compute the pangenome to be given) Choices: `all`, `complete` |
+
+#### Optional arguments for ppanggolin fasta
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--regions` | str | — | Write the RGP nucleotide sequences (requires --anno or --fasta used to compute the pangenome to be given) <br>Choices: `all`, `complete` |
 | `--soft_core` | restricted_float | 0.95 | Soft core threshold to use if 'softcore' partition is chosen |
 | `--compress` | 0 | False | Compress the files in .gz |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
 | `--cpu` | int | 1 | Number of available threads |
 | `--tmpdir` | Path | /tmp | directory for storing temporary files |
 | `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin fasta
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -357,13 +492,13 @@ Writes fasta files for different elements of the pangenome.
 
 Prints information about a given pangenome graph file.
 
-#### Required parameters for ppanggolin info
+#### Required arguments for ppanggolin info
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | Path to the pangenome .h5 file Required: Yes |
 
-#### Optional parameters for ppanggolin info
+#### Information Display Options (default: all) for ppanggolin info
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
@@ -371,7 +506,12 @@ Prints information about a given pangenome graph file.
 | `-c, --content` | 0 | False | Display detailed information about the pangenome's content |
 | `-s, --status` | 0 | False | Display information about the statuses of different elements in the pangenome, indicating what has been computed or not |
 | `-m, --metadata` | 0 | False | Display a summary of the metadata saved in the pangenome |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin info
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -382,15 +522,30 @@ Prints information about a given pangenome graph file.
 
 Compute several metrics on a given pangenome.
 
-#### Optional parameters for ppanggolin metrics
+#### Required arguments for ppanggolin metrics
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | Path to the pangenome .h5 file |
+
+#### Input file for ppanggolin metrics
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--genome_fluidity` | 0 | False | Compute the pangenome genomic fluidity. |
+
+#### Optional arguments for ppanggolin metrics
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--no_print_info` | 0 | False | Suppress printing the metrics result. Metrics are saved in the pangenome and viewable using 'ppanggolin info'. |
 | `--recompute_metrics` | 0 | False | Force re-computation of metrics if already computed. |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin metrics
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -401,17 +556,17 @@ Compute several metrics on a given pangenome.
 
 Writes 'flat' files that represent the genomes along with their associated pangenome elements.
 
-#### Required parameters for ppanggolin write_genomes
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
-
-#### Optional parameters for ppanggolin write_genomes
+#### Required arguments for ppanggolin write_genomes
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional arguments for ppanggolin write_genomes
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--table` | 0 | False | Generate a tsv file for each genome with pangenome annotations. |
 | `--gff` | 0 | False | Generate a gff file for each genome containing pangenome annotations. |
 | `--proksee` | 0 | False | Generate JSON map files for PROKSEE for each genome containing pangenome annotations to be used in proksee. |
@@ -421,9 +576,19 @@ Writes 'flat' files that represent the genomes along with their associated pange
 | `--metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
 | `--metadata_sep` | str | `|` | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
 | `-c, --cpu` | int | 1 | Number of available cpus |
+
+#### Contextually required arguments for ppanggolin write_genomes
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--fasta` | Path | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
 | `--anno` | Path | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin write_genomes
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -434,21 +599,26 @@ Writes 'flat' files that represent the genomes along with their associated pange
 
 Writes 'TSV' files that represent the metadata associated with elements of the pangenome.
 
-#### Required parameters for ppanggolin write_metadata
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
-
-#### Optional parameters for ppanggolin write_metadata
+#### Required arguments for ppanggolin write_metadata
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional arguments for ppanggolin write_metadata
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--compress` | 0 | False | Compress the files in .gz |
-| `-e, --pangenome_elements` | list | ['spots', 'modules', 'contigs', 'genomes', 'genes', 'families', 'RGPs'] | Specify pangenome elements for which to write metadata. default is all element with metadata. Choices: `spots`, `modules`, `contigs`, `genomes`, `genes`, `families`, `RGPs` |
+| `-e, --pangenome_elements` | list | ['modules', 'genomes', 'families', 'genes', 'contigs', 'spots', 'RGPs'] | Specify pangenome elements for which to write metadata. default is all element with metadata. <br>Choices: `modules`, `genomes`, `families`, `genes`, `contigs`, `spots`, `RGPs` |
 | `-s, --metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin write_metadata
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -459,17 +629,17 @@ Writes 'TSV' files that represent the metadata associated with elements of the p
 
 Writes 'flat' files that represent the pangenome and its elements for use with other software.
 
-#### Required parameters for ppanggolin write_pangenome
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
-
-#### Optional parameters for ppanggolin write_pangenome
+#### Required arguments for ppanggolin write_pangenome
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional arguments for ppanggolin write_pangenome
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--soft_core` | restricted_float | 0.95 | Soft core threshold to use |
 | `--dup_margin` | restricted_float | 0.05 | Minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
 | `--gexf` | 0 | False | Generate a detailed GEXF file with all genes and annotations for each family |
@@ -489,7 +659,12 @@ Writes 'flat' files that represent the pangenome and its elements for use with o
 | `--spot_modules` | 0 | False | Generate two files comparing module presence across spots |
 | `--compress` | 0 | False | Compress output files using gzip (.gz) |
 | `-c, --cpu` | int | 1 | Number of available cpus |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin write_pangenome
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -502,18 +677,28 @@ Writes 'flat' files that represent the pangenome and its elements for use with o
 
 Predicts functional modules in your pangenome.
 
-#### Optional parameters for ppanggolin module
+#### Required arguments for ppanggolin module
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+
+#### Optional arguments for ppanggolin module
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--size` | int | 3 | Minimal number of gene family in a module |
 | `--dup_margin` | restricted_float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
 | `-m, --min_presence` | int | 2 | Minimum number of times the module needs to be present in the pangenome to be reported. Increasing it will improve precision but lower sensitivity. |
 | `-t, --transitive` | int | 4 | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
 | `-s, --jaccard` | restricted_float | 0.85 | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
 | `-c, --cpu` | int | 1 | Number of available cpus |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin module
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -524,17 +709,27 @@ Predicts functional modules in your pangenome.
 
 Predicts Regions of Genomic Plasticity in the genomes of your pangenome.
 
-#### Optional parameters for ppanggolin rgp
+#### Required arguments for ppanggolin rgp
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+
+#### Optional arguments for ppanggolin rgp
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--persistent_penalty` | int | 3 | Penalty score to apply to persistent genes |
 | `--variable_gain` | int | 1 | Gain score to apply to variable genes |
 | `--min_score` | int | 4 | Minimal score wanted for considering a region as being a RGP |
 | `--min_length` | int | 3000 | Minimum length (bp) of a region to be considered a RGP |
 | `--dup_margin` | restricted_float | 0.05 | Minimum ratio of genomes where the family is present in which the family must have multiple genes for it to be considered 'duplicated' |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin rgp
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -545,27 +740,32 @@ Predicts Regions of Genomic Plasticity in the genomes of your pangenome.
 
 Cluster RGPs based on their gene families.
 
-#### Required parameters for ppanggolin rgp_cluster
+#### Required arguments for ppanggolin rgp_cluster
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file Required: Yes |
 
-#### Optional parameters for ppanggolin rgp_cluster
+#### Optional arguments for ppanggolin rgp_cluster
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `--grr_cutoff` | restricted_float | 0.8 | Min gene repertoire relatedness metric used in the rgp clustering |
-| `--grr_metric` | str | `incomplete_aware_grr` | The grr (Gene Repertoire Relatedness) is used to assess the similarity between two RGPs based on their gene families.There are three different modes for calculating the grr value: 'min_grr', 'max_grr' or  'incomplete_aware_grr'.'min_grr': Computes the number of gene families shared between the two RGPs and divides it by the smaller number of gene families among the two RGPs.'max_grr': Calculates the number of gene families shared between the two RGPs and divides it by the larger number of gene families among the two RGPs.'incomplete_aware_grr' (default): If at least one RGP is considered incomplete, which occurs when it is located at the border of a contig,the 'min_grr' mode is used. Otherwise, the 'max_grr' mode is applied. Choices: `incomplete_aware_grr`, `min_grr`, `max_grr` |
+| `--grr_metric` | str | `incomplete_aware_grr` | The grr (Gene Repertoire Relatedness) is used to assess the similarity between two RGPs based on their gene families.There are three different modes for calculating the grr value: 'min_grr', 'max_grr' or  'incomplete_aware_grr'.'min_grr': Computes the number of gene families shared between the two RGPs and divides it by the smaller number of gene families among the two RGPs.'max_grr': Calculates the number of gene families shared between the two RGPs and divides it by the larger number of gene families among the two RGPs.'incomplete_aware_grr' (default): If at least one RGP is considered incomplete, which occurs when it is located at the border of a contig,the 'min_grr' mode is used. Otherwise, the 'max_grr' mode is applied. <br>Choices: `incomplete_aware_grr`, `min_grr`, `max_grr` |
 | `--ignore_incomplete_rgp` | 0 | False | Do not cluster RGPs located on a contig border which are likely incomplete. |
 | `--no_identical_rgp_merging` | 0 | False | Do not merge in one node identical RGP (i.e. having the same family content) before clustering. |
 | `--basename` | str | `rgp_cluster` | basename for the output file |
 | `-o, --output` | Path | `rgp_clustering` | Output directory |
-| `--graph_formats` | list | ['gexf', 'graphml'] | Format of the output graph. Choices: `gexf`, `graphml` |
+| `--graph_formats` | list | ['gexf', 'graphml'] | Format of the output graph. <br>Choices: `gexf`, `graphml` |
 | `--add_metadata` | 0 | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
 | `--metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
 | `--metadata_sep` | str | `|` | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin rgp_cluster
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -576,18 +776,28 @@ Cluster RGPs based on their gene families.
 
 Predicts spots in your pangenome.
 
-#### Optional parameters for ppanggolin spot
+#### Required arguments for ppanggolin spot
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+
+#### Optional arguments for ppanggolin spot
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-o, --output` | Path | `ppanggolin_output<date>_<pid>` | Output directory |
 | `--spot_graph` | 0 | False | Writes a graph of pairs of blocks of single copy markers flanking RGPs, supposedly belonging to the same hotspot |
 | `--overlapping_match` | int | 2 | The number of 'missing' persistent genes allowed when comparing flanking genes during hotspot computations |
 | `--set_size` | int | 3 | Number of single copy markers to use as flanking genes for a RGP during hotspot computation |
 | `--exact_match_size` | int | 1 | Number of perfectly matching flanking single copy markers required to associate RGPs during hotspot computation (Ex: If set to 1, two RGPs are in the same hotspot if both their 1st flanking genes are the same) |
-| `--graph_formats` | list | ['gexf'] | Format of the output graph. Choices: `gexf`, `graphml` |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+| `--graph_formats` | list | ['gexf'] | Format of the output graph. <br>Choices: `gexf`, `graphml` |
+
+#### Common arguments for ppanggolin spot
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -600,18 +810,18 @@ Predicts spots in your pangenome.
 
 Aligns a genome or a set of proteins to the pangenome gene families and predicts information from it.
 
-#### Required parameters for ppanggolin align
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
-
-#### Optional parameters for ppanggolin align
+#### Required arguments for ppanggolin align
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-S, --sequences` | Path | — | sequences (nucleotides or amino acids) to align on the pangenome gene families |
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional arguments for ppanggolin align
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. (default: False) |
 | `--identity` | float | 0.5 | min identity percentage threshold |
 | `--coverage` | float | 0.8 | min coverage percentage threshold |
@@ -623,7 +833,12 @@ Aligns a genome or a set of proteins to the pangenome gene families and predicts
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--tmpdir` | Path | /tmp | directory for storing temporary files |
 | `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin align
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -634,18 +849,33 @@ Aligns a genome or a set of proteins to the pangenome gene families and predicts
 
 Local genomic context analysis.
 
-#### Optional parameters for ppanggolin context
+#### Required arguments for ppanggolin context
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome.h5 file |
-| `-o, --output` | Path | `ppanggolin_context_DATE2026-08-13_HOUR15.51.08_PID880462` | Output directory where the file(s) will be written |
+| `-o, --output` | Path | `ppanggolin_context_DATE2026-08-13_HOUR16.22.03_PID909341` | Output directory where the file(s) will be written |
+
+#### Input file for ppanggolin context
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-S, --sequences` | Path | — | Fasta file with the sequences of interest |
 | `-F, --family` | Path | — | List of family IDs of interest from the pangenome |
+
+#### Optional arguments for ppanggolin context
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-t, --transitive` | int | 4 | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
 | `-w, --window_size` | int | 5 | Number of neighboring genes that are considered on each side of a gene of interest when searching for conserved genomic contexts. |
 | `-s, --jaccard` | restricted_float | 0.85 | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
-| `--graph_format` | str | `graphml` | Format of the context graph. Can be gexf or graphml. Choices: `gexf`, `graphml` |
+| `--graph_format` | str | `graphml` | Format of the context graph. Can be gexf or graphml. <br>Choices: `gexf`, `graphml` |
+
+#### Alignment arguments for ppanggolin context
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. |
 | `--fast` | 0 | False | Use representative sequences of gene families for input gene alignment. This option is recommended for faster processing but may be less sensitive. By default, all pangenome genes are used for alignment. |
 | `--identity` | float | 0.8 | min identity percentage threshold |
@@ -654,7 +884,12 @@ Local genomic context analysis.
 | `--tmpdir` | str | /tmp | directory for storing temporary files |
 | `--keep_tmp` | 0 | False | Keeping temporary files (useful for debugging). |
 | `-c, --cpu` | int | 1 | Number of available cpus |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin context
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -665,28 +900,33 @@ Local genomic context analysis.
 
 Compute Multiple Sequence Alignments for pangenome gene families.
 
-#### Required parameters for ppanggolin msa
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
-
-#### Optional parameters for ppanggolin msa
+#### Required arguments for ppanggolin msa
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Output directory where the file(s) will be written Required: Yes |
+
+#### Optional arguments. Indicating 'all' writes all elements. Writing a partition ('persistent', 'shell', 'cloud', 'core' or 'accessory') write the elements associated to said partition. for ppanggolin msa
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `--soft_core` | restricted_float | 0.95 | Soft core threshold to use if 'softcore' partition is chosen |
 | `--dup_margin` | restricted_float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
 | `--single_copy` | 0 | False | Use report gene families that are considered 'single copy', for details see option --dup_margin |
-| `--partition` | str | `core` | compute Multiple Sequence Alignment of the gene families in the given partition Choices: `all`, `persistent`, `shell`, `cloud`, `core`, `accessory`, `softcore` |
-| `--source` | str | `protein` | indicates whether to use protein or dna sequences to compute the msa Choices: `dna`, `protein` |
+| `--partition` | str | `core` | compute Multiple Sequence Alignment of the gene families in the given partition <br>Choices: `all`, `persistent`, `shell`, `cloud`, `core`, `accessory`, `softcore` |
+| `--source` | str | `protein` | indicates whether to use protein or dna sequences to compute the msa <br>Choices: `dna`, `protein` |
 | `--phylo` | 0 | False | Writes a whole genome msa file for additional phylogenetic analysis |
 | `--use_gene_id` | 0 | False | Use gene identifiers rather than genome names for sequences in the family MSA (genome names are used by default) |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
 | `-c, --cpu` | int | 1 | Number of available cpus |
 | `--tmpdir` | str | /tmp | directory for storing temporary files |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin msa
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -697,16 +937,26 @@ Compute Multiple Sequence Alignments for pangenome gene families.
 
 Annotates external genomes with an existing pangenome.
 
-#### Optional parameters for ppanggolin projection
+#### Required arguments for ppanggolin projection
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `-p, --pangenome` | Path | — | The pangenome.h5 file |
 | `--fasta` | Path | — | Specify a FASTA file containing the genomic sequences of the genome(s) you wish to annotate, or provide a tab-separated file listing genome names alongside their respective FASTA filepaths, with one line per genome. |
 | `--anno` | Path | — | Specify an annotation file in GFF/GBFF format for the genome you wish to annotate. Alternatively, you can provide a tab-separated file listing genome names alongside their respective annotation filepaths, with one line per genome. If both an annotation file and a FASTA file are provided, the annotation file will take precedence. |
+
+#### Single Genome Arguments for ppanggolin projection
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-n, --genome_name` | str | `input_genome` | Specify the name of the genome whose genome you want to annotate when providing a single FASTA or annotation file. |
 | `--circular_contigs` | list | — | Specify the contigs of the input genome that should be treated as circular when providing a single FASTA or annotation file. |
-| `-o, --output` | Path | `ppanggolin_projection_DATE2026-08-13_HOUR15.51.08_PID880462` | Output directory |
+
+#### Optional arguments for ppanggolin projection
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `-o, --output` | Path | `ppanggolin_projection_DATE2026-08-13_HOUR16.22.03_PID909341` | Output directory |
 | `--translation_table` | int | 11 | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
 | `--no_defrag` | 0 | False | DO NOT Realign gene families to link fragments with their non-fragmented gene family. (default: False) |
 | `--fast` | 0 | False | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
@@ -716,7 +966,7 @@ Annotates external genomes with an existing pangenome.
 | `--dup_margin` | restricted_float | 0.05 | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated'. This metric is used to compute completeness and duplication of the input genomes |
 | `--soft_core` | restricted_float | 0.95 | Soft core threshold used when generating general statistics on the projected genome. This threshold does not influence PPanGGOLiN's partitioning. The value determines the minimum fraction of genomes that must possess a gene family for it to be considered part of the soft core. |
 | `--spot_graph` | 0 | False | Write the spot graph to a file, with pairs of blocks of single copy markers flanking RGPs as nodes. This graph can be used to visualize nodes that have RGPs from the input genome. |
-| `--graph_formats` | list | ['gexf'] | Format of the output graph. Choices: `gexf`, `graphml` |
+| `--graph_formats` | list | ['gexf'] | Format of the output graph. <br>Choices: `gexf`, `graphml` |
 | `--gff` | 0 | False | Generate GFF files with projected pangenome annotations for each input genome. |
 | `--proksee` | 0 | False | Generate JSON map files for PROKSEE with projected pangenome annotations for each input genome. |
 | `--table` | 0 | False | Generate a tsv file for each input genome with pangenome annotations. |
@@ -728,7 +978,12 @@ Annotates external genomes with an existing pangenome.
 | `--add_metadata` | 0 | False | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
 | `--metadata_sources` | list | — | Which source of metadata should be written. By default all metadata sources are included. |
 | `--metadata_sep` | str | `|` | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin projection
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |
@@ -741,13 +996,23 @@ Annotates external genomes with an existing pangenome.
 
 Helper side commands.
 
-#### Optional parameters for ppanggolin utils
+#### Required arguments for ppanggolin utils
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--default_config` | str | — | Generate a config file with default values for the given subcommand. Choices: `annotate`, `cluster`, `graph`, `partition`, `rarefaction`, `workflow`, `panrgp`, `panmodule`, `all`, `draw`, `write_pangenome`, `write_genomes`, `write_metadata`, `fasta`, `msa`, `metrics`, `align`, `info`, `rgp`, `spot`, `module`, `context`, `projection`, `rgp_cluster`, `metadata`, `utils` |
+| `--default_config` | str | — | Generate a config file with default values for the given subcommand. <br>Choices: `annotate`, `cluster`, `graph`, `partition`, `rarefaction`, `workflow`, `panrgp`, `panmodule`, `all`, `draw`, `write_pangenome`, `write_genomes`, `write_metadata`, `fasta`, `msa`, `metrics`, `align`, `info`, `rgp`, `spot`, `module`, `context`, `projection`, `rgp_cluster`, `metadata`, `utils` |
+
+#### Config arguments for ppanggolin utils
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
 | `-o, --output` | Path | `default_config.yaml` | name and path of the config file with default parameters written in yaml. |
-| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) Choices: `0`, `1`, `2` |
+
+#### Common arguments for ppanggolin utils
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--verbose` | int | 1 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) <br>Choices: `0`, `1`, `2` |
 | `--log` | check_log | `stdout` | log output file |
 | `-d, --disable_prog_bar` | 0 | False | disables the progress bars |
 | `-f, --force` | 0 | False | Force writing in output directory and in pangenome output file. |

--- a/docs/user/command_reference.md
+++ b/docs/user/command_reference.md
@@ -1,0 +1,695 @@
+# Command-line reference
+
+Complete reference of the PPanGGOLiN command-line interface.
+
+This page is automatically generated from the PPanGGOLiN command-line parser.
+
+## `ppanggolin align`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-S, --sequences` | Path | — | No | — | sequences (nucleotides or amino acids) to align on the pangenome gene families |
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. (default: False) |
+| `--identity` | float | 0.5 | No | — | min identity percentage threshold |
+| `--coverage` | float | 0.8 | No | — | min coverage percentage threshold |
+| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--getinfo` | 0 | False | No | — | Use this option to extract info related to the best hit of each query, such as the RGP it is in, or the spots. |
+| `--draw_related` | 0 | False | No | — | Draw figures and provide graphs in a gexf format of the eventual spots associated to the input sequences |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin all`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `--basename` | str | `pangenome` | No | — | basename for the output file |
+| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
+| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
+| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin annotate`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
+| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `--allow_overlap` | 0 | False | No | — | Use to not remove genes overlapping with RNA features. |
+| `--norna` | 0 | False | No | — | Use to avoid annotating RNA features. |
+| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--basename` | str | `pangenome` | No | — | basename for the output file |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-p, --prodigal_procedure` | lower | — | No | single, meta | Allow to force the prodigal procedure. If nothing given, PPanGGOLiN will decide in function of contig length |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin cluster`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
+| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
+| `--no_defrag` | 0 | False | No | — | DO NOT Use the defragmentation strategy to link potential fragments with their original gene family. |
+| `--clusters` | Path | — | No | — | A tab-separated list containing the result of a clustering. One line per gene. First column is cluster ID, and second is gene ID |
+| `--infer_singletons` | 0 | False | No | — | When reading a clustering result with --clusters, if a gene is not in the provided file it will be placed in a cluster where the gene is the only member. |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin context`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
+| `-o, --output` | Path | `ppanggolin_context_DATE2026-08-13_HOUR11.43.03_PID660761` | No | — | Output directory where the file(s) will be written |
+| `-S, --sequences` | Path | — | No | — | Fasta file with the sequences of interest |
+| `-F, --family` | Path | — | No | — | List of family IDs of interest from the pangenome |
+| `-t, --transitive` | int | 4 | No | — | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
+| `-w, --window_size` | int | 5 | No | — | Number of neighboring genes that are considered on each side of a gene of interest when searching for conserved genomic contexts. |
+| `-s, --jaccard` | restricted_float | 0.85 | No | — | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
+| `--graph_format` | str | `graphml` | No | gexf, graphml | Format of the context graph. Can be gexf or graphml. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments withtheir non-fragmented gene family. |
+| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is recommended for faster processing but may be less sensitive. By default, all pangenome genes are used for alignment. |
+| `--identity` | float | 0.8 | No | — | min identity percentage threshold |
+| `--coverage` | float | 0.8 | No | — | min coverage percentage threshold |
+| `--translation_table` | int | 11 | No | — | The translation table to use when the input sequences are nucleotide sequences. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin draw`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `--tile_plot` | 0 | False | No | — | draw the tile plot of the pangenome |
+| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use |
+| `--ucurve` | 0 | False | No | — | draw the U-curve of the pangenome |
+| `--draw_spots` | 0 | False | No | — | draw plots for spots of the pangenome |
+| `--spots` | list | `all` | No | — | a comma-separated list of spots to draw (or 'all' to draw all spots, or 'synteny' to draw spots with different RGP syntenies). |
+| `--nocloud` | 0 | False | No | — | Do not draw the cloud genes in the tile plot |
+| `--add_dendrogram` | 0 | False | No | — | Include a dendrogram for genomes in the tile plot based on the presence/absence of gene families. |
+| `--add_metadata` | 0 | False | No | — | Display gene metadata as hover text for each cell in the tile plot. |
+| `--metadata_sources` | list | — | No | — | Which source of metadata should be written in the tile plot. By default all metadata sources are included. |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin fasta`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
+| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
+| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
+| `--genes` | filter_values | — | No | — | Write all nucleotide CDS sequences. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--proteins` | filter_values | — | No | — | Write representative amino acid sequences of genes. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--prot_families` | filter_values | — | No | — | Write representative amino acid sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--gene_families` | filter_values | — | No | — | Write representative nucleotide sequences of gene families. Possible values are all, persistent, shell, cloud, rgp, softcore, core, module_X with X being a module id. |
+| `--regions` | str | — | No | all, complete | Write the RGP nucleotide sequences (requires --anno or --fasta used to compute the pangenome to be given) |
+| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use if 'softcore' partition is chosen |
+| `--compress` | 0 | False | No | — | Compress the files in .gz |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--cpu` | int | 1 | No | — | Number of available threads |
+| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin graph`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-r, --remove_high_copy_number` | int | 0 | No | — | Positive Number: Remove families having a number of copy of gene in a single genome above or equal to this threshold in at least one genome (0 or negative values are ignored). |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin info`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | Yes | — | Path to the pangenome .h5 file |
+| `-a, --parameters` | 0 | False | No | — | Display the parameters used or computed for each step of pangenome generation |
+| `-c, --content` | 0 | False | No | — | Display detailed information about the pangenome's content |
+| `-s, --status` | 0 | False | No | — | Display information about the statuses of different elements in the pangenome, indicating what has been computed or not |
+| `-m, --metadata` | 0 | False | No | — | Display a summary of the metadata saved in the pangenome |
+
+
+## `ppanggolin metadata`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-m, --metadata` | Path | — | No | — | Metadata in TSV file. See our github for more detail about format |
+| `-s, --source` | str | — | No | — | Name of the metadata source |
+| `-a, --assign` | str | — | No | families, genomes, contigs, genes, RGPs, spots, modules | Select to which pangenome element metadata will be assigned |
+| `--omit` | 0 | False | No | — | Allow to pass if a key in metadata is not find in pangenome |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin metrics`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | Path to the pangenome .h5 file |
+| `--genome_fluidity` | 0 | False | No | — | Compute the pangenome genomic fluidity. |
+| `--no_print_info` | 0 | False | No | — | Suppress printing the metrics result. Metrics are saved in the pangenome and viewable using 'ppanggolin info'. |
+| `--recompute_metrics` | 0 | False | No | — | Force re-computation of metrics if already computed. |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin module`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `--size` | int | 3 | No | — | Minimal number of gene family in a module |
+| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `-m, --min_presence` | int | 2 | No | — | Minimum number of times the module needs to be present in the pangenome to be reported. Increasing it will improve precision but lower sensitivity. |
+| `-t, --transitive` | int | 4 | No | — | Size of the transitive closure used to build the graph. This indicates the number of non related genes allowed in-between two related genes. Increasing it will improve precision but lower sensitivity a little. |
+| `-s, --jaccard` | restricted_float | 0.85 | No | — | minimum jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity a lot. |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin msa`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
+| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use if 'softcore' partition is chosen |
+| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--single_copy` | 0 | False | No | — | Use report gene families that are considered 'single copy', for details see option --dup_margin |
+| `--partition` | str | `core` | No | all, persistent, shell, cloud, core, accessory, softcore | compute Multiple Sequence Alignment of the gene families in the given partition |
+| `--source` | str | `protein` | No | dna, protein | indicates whether to use protein or dna sequences to compute the msa |
+| `--phylo` | 0 | False | No | — | Writes a whole genome msa file for additional phylogenetic analysis |
+| `--use_gene_id` | 0 | False | No | — | Use gene identifiers rather than genome names for sequences in the family MSA (genome names are used by default) |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin panmodule`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `--basename` | str | `pangenome` | No | — | basename for the output file |
+| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
+| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
+| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin panrgp`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `--basename` | str | `pangenome` | No | — | basename for the output file |
+| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
+| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
+| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin partition`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
+| `-b, --beta` | float | 2.5 | No | — | beta is the strength of the smoothing using the graph topology during partitioning. 0 will deactivate spatial smoothing. |
+| `-ms, --max_degree_smoothing` | float | 10 | No | — | max. degree of the nodes to be included in the smoothing process. |
+| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `-fd, --free_dispersion` | 0 | False | No | — | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
+| `-ck, --chunk_size` | int | 500 | No | — | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `-Kmm, --krange` | 2 | [3, 20] | No | — | Range of K values to test when detecting K automatically. |
+| `-im, --ICL_margin` | float | 0.05 | No | — | K is detected automatically by maximizing ICL. However at some point the ICL reaches a plateau. Therefore we are looking for the minimal value of K without significant gain from the larger values of K measured by ICL. For that we take the lowest K that is found within a given 'margin' of the maximal ICL value. Basically, change this option only if you truly understand it, otherwise just leave it be. |
+| `--draw_ICL` | 0 | False | No | — | Use if you want to draw the ICL curve for all the tested K values. Will not be done if K is given. |
+| `--keep_tmp_files` | 0 | False | No | — | Use if you want to keep the temporary NEM files |
+| `-se, --seed` | int | 42 | No | — | seed used to generate random numbers |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin projection`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome.h5 file |
+| `--fasta` | Path | — | No | — | Specify a FASTA file containing the genomic sequences of the genome(s) you wish to annotate, or provide a tab-separated file listing genome names alongside their respective FASTA filepaths, with one line per genome. |
+| `--anno` | Path | — | No | — | Specify an annotation file in GFF/GBFF format for the genome you wish to annotate. Alternatively, you can provide a tab-separated file listing genome names alongside their respective annotation filepaths, with one line per genome. If both an annotation file and a FASTA file are provided, the annotation file will take precedence. |
+| `-n, --genome_name` | str | `input_genome` | No | — | Specify the name of the genome whose genome you want to annotate when providing a single FASTA or annotation file. |
+| `--circular_contigs` | list | — | No | — | Specify the contigs of the input genome that should be treated as circular when providing a single FASTA or annotation file. |
+| `-o, --output` | Path | `ppanggolin_projection_DATE2026-08-13_HOUR11.43.03_PID660761` | No | — | Output directory |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified, the translation table used when building the pangenome will be used. This can be accessed using 'ppanggolin info'. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. (default: False) |
+| `--fast` | 0 | False | No | — | Use representative sequences of gene families for input gene alignment. This option is faster but may be less sensitive. By default, all pangenome genes are used. |
+| `--identity` | restricted_float | 0.8 | No | — | min identity percentage threshold |
+| `--coverage` | restricted_float | 0.8 | No | — | min coverage percentage threshold |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `--dup_margin` | restricted_float | 0.05 | No | — | minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated'. This metric is used to compute completeness and duplication of the input genomes |
+| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold used when generating general statistics on the projected genome. This threshold does not influence PPanGGOLiN's partitioning. The value determines the minimum fraction of genomes that must possess a gene family for it to be considered part of the soft core. |
+| `--spot_graph` | 0 | False | No | — | Write the spot graph to a file, with pairs of blocks of single copy markers flanking RGPs as nodes. This graph can be used to visualize nodes that have RGPs from the input genome. |
+| `--graph_formats` | list | ['gexf'] | No | gexf, graphml | Format of the output graph. |
+| `--gff` | 0 | False | No | — | Generate GFF files with projected pangenome annotations for each input genome. |
+| `--proksee` | 0 | False | No | — | Generate JSON map files for PROKSEE with projected pangenome annotations for each input genome. |
+| `--table` | 0 | False | No | — | Generate a tsv file for each input genome with pangenome annotations. |
+| `--compress` | 0 | False | No | — | Compress the files in .gz |
+| `--add_sequences` | 0 | False | No | — | Include input genome DNA sequences in GFF and Proksee output. |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | Path | /tmp | No | — | directory for storing temporary files |
+| `--keep_tmp` | 0 | False | No | — | Keeping temporary files (useful for debugging). |
+| `--add_metadata` | 0 | False | No | — | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--metadata_sep` | str | `|` | No | — | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin rarefaction`
+
+Compute the rarefaction curve of the pangenome
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-b, --beta` | float | 2.5 | No | — | beta is the strength of the smoothing using the graph topology during  partitioning. 0 will deactivate spatial smoothing. |
+| `--depth` | int | 30 | No | — | Number of samplings at each sampling point |
+| `--min` | int | 1 | No | — | Minimum number of genomes in a sample |
+| `--max` | float | 100 | No | — | Maximum number of genomes in a sample (if above the number of provided genomes, the provided genomes will be the maximum) |
+| `-ms, --max_degree_smoothing` | float | 10 | No | — | max. degree of the nodes to be included in the smoothing process. |
+| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `-fd, --free_dispersion` | 0 | False | No | — | use if the dispersion around the centroid vector of each partition during must be free. It will be the same for all genomes by default. |
+| `-ck, --chunk_size` | int | 500 | No | — | Size of the chunks when performing partitioning using chunks of genomes. Chunk partitioning will be used automatically if the number of genomes is above this number. |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. By default reuse K if it exists else compute it. |
+| `--reestimate_K` | 0 | False | No | — | Will recompute the number of partitions for each sample (between the values provided by --krange) (VERY intensive. Can take a long time.) |
+| `-Kmm, --krange` | 2 | [3, -1] | No | — | Range of K values to test when detecting K automatically. Default between 3 and the K previously computed if there is one, or 20 if there are none. |
+| `--soft_core` | float | 0.95 | No | — | Soft core threshold |
+| `-se, --seed` | int | 42 | No | — | seed used to generate random numbers |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin rgp`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `--persistent_penalty` | int | 3 | No | — | Penalty score to apply to persistent genes |
+| `--variable_gain` | int | 1 | No | — | Gain score to apply to variable genes |
+| `--min_score` | int | 4 | No | — | Minimal score wanted for considering a region as being a RGP |
+| `--min_length` | int | 3000 | No | — | Minimum length (bp) of a region to be considered a RGP |
+| `--dup_margin` | restricted_float | 0.05 | No | — | Minimum ratio of genomes where the family is present in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin rgp_cluster`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | Yes | — | The pangenome .h5 file |
+| `--grr_cutoff` | restricted_float | 0.8 | No | — | Min gene repertoire relatedness metric used in the rgp clustering |
+| `--grr_metric` | str | `incomplete_aware_grr` | No | incomplete_aware_grr, min_grr, max_grr | The grr (Gene Repertoire Relatedness) is used to assess the similarity between two RGPs based on their gene families.There are three different modes for calculating the grr value: 'min_grr', 'max_grr' or  'incomplete_aware_grr'.'min_grr': Computes the number of gene families shared between the two RGPs and divides it by the smaller number of gene families among the two RGPs.'max_grr': Calculates the number of gene families shared between the two RGPs and divides it by the larger number of gene families among the two RGPs.'incomplete_aware_grr' (default): If at least one RGP is considered incomplete, which occurs when it is located at the border of a contig,the 'min_grr' mode is used. Otherwise, the 'max_grr' mode is applied. |
+| `--ignore_incomplete_rgp` | 0 | False | No | — | Do not cluster RGPs located on a contig border which are likely incomplete. |
+| `--no_identical_rgp_merging` | 0 | False | No | — | Do not merge in one node identical RGP (i.e. having the same family content) before clustering. |
+| `--basename` | str | `rgp_cluster` | No | — | basename for the output file |
+| `-o, --output` | Path | `rgp_clustering` | No | — | Output directory |
+| `--graph_formats` | list | ['gexf', 'graphml'] | No | gexf, graphml | Format of the output graph. |
+| `--add_metadata` | 0 | False | No | — | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--metadata_sep` | str | `|` | No | — | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin spot`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-o, --output` | Path | ppanggolin_outputDATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `--spot_graph` | 0 | False | No | — | Writes a graph of pairs of blocks of single copy markers flanking RGPs, supposedly belonging to the same hotspot |
+| `--overlapping_match` | int | 2 | No | — | The number of 'missing' persistent genes allowed when comparing flanking genes during hotspot computations |
+| `--set_size` | int | 3 | No | — | Number of single copy markers to use as flanking genes for a RGP during hotspot computation |
+| `--exact_match_size` | int | 1 | No | — | Number of perfectly matching flanking single copy markers required to associate RGPs during hotspot computation (Ex: If set to 1, two RGPs are in the same hotspot if both their 1st flanking genes are the same) |
+| `--graph_formats` | list | ['gexf'] | No | gexf, graphml | Format of the output graph. |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin utils`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `--default_config` | str | — | No | annotate, cluster, graph, partition, rarefaction, workflow, panrgp, panmodule, all, draw, write_pangenome, write_genomes, write_metadata, fasta, msa, metrics, align, rgp, spot, module, context, projection, rgp_cluster, metadata | Generate a config file with default values for the given subcommand. |
+| `-o, --output` | Path | `default_config.yaml` | No | — | name and path of the config file with default parameters written in yaml. |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-f, --force` | 0 | False | No | — | Overwrite the given output file if it exists. |
+
+
+## `ppanggolin workflow`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). One line per genome. This option can be used alone. |
+| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff filepath of its annotations (the gffs can be compressed). One line per genome. This option can be used alone IF the fasta sequences are in the gff files, otherwise --fasta needs to be used. |
+| `--clusters` | Path | — | No | — | a tab-separated file listing the cluster names, the gene IDs, and optionally whether they are a fragment or not. |
+| `-o, --output` | Path | ppanggolin_output_DATE2026-08-13_HOUR11.43.03_PID660761 | No | — | Output directory |
+| `--basename` | str | `pangenome` | No | — | basename for the output file |
+| `--rarefaction` | 0 | False | No | — | Use to compute the rarefaction curves (WARNING: can be time consuming) |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--translation_table` | int | 11 | No | — | Translation table (genetic code) to use. If not specified and using annotation files (--anno), the translation table information found in the annotation files will be used. Otherwise, the default genetic code 11 will be used. |
+| `--kingdom` | lower | `bacteria` | No | bacteria, archaea | Kingdom to which the prokaryota belongs to, to know which models to use for rRNA annotation. |
+| `--mode` | str | `1` | No | 0, 1, 2, 3 | the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component), 2: CD-HIT-like, 3: CD-HIT-like (lowmem) |
+| `--coverage` | restricted_float | 0.8 | No | — | Minimal coverage of the alignment for two proteins to be in the same cluster |
+| `--identity` | restricted_float | 0.8 | No | — | Minimal identity percent for two proteins to be in the same cluster |
+| `--infer_singletons` | 0 | False | No | — | Use this option together with --clusters. If a gene is not present in the provided clustering result file, it will be assigned to its own unique cluster as a singleton. |
+| `--use_pseudo` | 0 | False | No | — | In the context of provided annotation, use this option to read pseudogenes. (Default behavior is to ignore them) |
+| `-K, --nb_of_partitions` | int | -1 | No | — | Number of partitions to use. Must be at least 2. If under 2, it will be detected automatically. |
+| `--no_defrag` | 0 | False | No | — | DO NOT Realign gene families to link fragments with their non-fragmented gene family. |
+| `--no_flat_files` | 0 | False | No | — | Generate only the HDF5 pangenome file. |
+| `--tmpdir` | str | /tmp | No | — | directory for storing temporary files |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin write_genomes`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
+| `--table` | 0 | False | No | — | Generate a tsv file for each genome with pangenome annotations. |
+| `--gff` | 0 | False | No | — | Generate a gff file for each genome containing pangenome annotations. |
+| `--proksee` | 0 | False | No | — | Generate JSON map files for PROKSEE for each genome containing pangenome annotations to be used in proksee. |
+| `--compress` | 0 | False | No | — | Compress the files in .gz |
+| `--genomes` | str | `all` | No | — | Specify the genomes for which to generate output. You can provide a list of genome names either directly in the command line separated by commas, or by referencing a file containing the list of genome names, with one name per line. |
+| `--add_metadata` | 0 | False | No | — | Include metadata information in the output files if any have been added to pangenome elements (see ppanggolin metadata command). |
+| `--metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--metadata_sep` | str | `|` | No | — | The separator used to join multiple metadata values for elements with multiple metadata values from the same source. This character should not appear in metadata values. |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--fasta` | Path | — | No | — | A tab-separated file listing the genome names, and the fasta filepath of its genomic sequence(s) (the fastas can be compressed with gzip). One line per genome. |
+| `--anno` | Path | — | No | — | A tab-separated file listing the genome names, and the gff/gbff filepath of its annotations (the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used. |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin write_metadata`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
+| `--compress` | 0 | False | No | — | Compress the files in .gz |
+| `-e, --pangenome_elements` | list | ['contigs', 'families', 'modules', 'genomes', 'RGPs', 'spots', 'genes'] | No | contigs, families, modules, genomes, RGPs, spots, genes | Specify pangenome elements for which to write metadata. default is all element with metadata. |
+| `-s, --metadata_sources` | list | — | No | — | Which source of metadata should be written. By default all metadata sources are included. |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |
+
+
+## `ppanggolin write_pangenome`
+
+Command description is not explicitly set in this parser.
+
+### Parameters
+
+| Parameter | Type | Default | Required | Choices | Description |
+|---|---|---|---|---|---|
+| `-p, --pangenome` | Path | — | No | — | The pangenome .h5 file |
+| `-o, --output` | Path | — | Yes | — | Output directory where the file(s) will be written |
+| `--soft_core` | restricted_float | 0.95 | No | — | Soft core threshold to use |
+| `--dup_margin` | restricted_float | 0.05 | No | — | Minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated' |
+| `--gexf` | 0 | False | No | — | Generate a detailed GEXF file with all genes and annotations for each family |
+| `--light_gexf` | 0 | False | No | — | Generate a simplified GEXF file with basic gene family information |
+| `--gt` | 0 | False | No | — | Generate a simplified graph-tool GT file with basic gene family and pangenome organism strains information |
+| `--json` | 0 | False | No | — | Export the graph in JSON file format |
+| `--csv` | 0 | False | No | — | Export gene presence/absence in CSV format (compatible with Roary). Uses partitions as alternative gene IDs if available. |
+| `--Rtab` | 0 | False | No | — | Export gene presence/absence as a tabular binary matrix |
+| `--stats` | 0 | False | No | — | Generate genome statistics ('genome_statistics.tsv') and duplication summary of persistent families ('mean_persistent_duplication.tsv') |
+| `--partitions` | 0 | False | No | — | Generate one file per partition listing the gene families it contains |
+| `--families_tsv` | 0 | False | No | — | Write a TSV file mapping genes to their corresponding gene families |
+| `--regions` | 0 | False | No | — | Write predicted RGPs (Regions of Genomic Plasticity) and metrics to 'plastic_regions.tsv' |
+| `--regions_families` | 0 | False | No | — | Write a TSV file mapping each RGP to its gene family content in 'rgp_families.tsv' |
+| `--spots` | 0 | False | No | — | Write spot summary and list all RGPs (Regions of Genomic Plasticity) per spot |
+| `--borders` | 0 | False | No | — | List all borders of each spot |
+| `--modules` | 0 | False | No | — | Write a TSV file listing functional modules and their associated gene families |
+| `--spot_modules` | 0 | False | No | — | Generate two files comparing module presence across spots |
+| `--compress` | 0 | False | No | — | Compress output files using gzip (.gz) |
+| `-c, --cpu` | int | 1 | No | — | Number of available cpus |
+| `--verbose` | int | 1 | No | 0, 1, 2 | Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug) |
+| `--log` | check_log | `stdout` | No | — | log output file |
+| `-d, --disable_prog_bar` | 0 | False | No | — | disables the progress bars |
+| `-f, --force` | 0 | False | No | — | Force writing in output directory and in pangenome output file. |
+| `--config` | FileType('r') | — | No | — | Specify command arguments through a YAML configuration file. |

--- a/docs/user/projection.md
+++ b/docs/user/projection.md
@@ -2,7 +2,7 @@
 
 The ppanggolin projection command allows you to annotate external genomes using an existing pangenome. This process eliminates the need to recompute all components, streamlining the annotation process. Input genomes are expected to belong to the same species.
 
-Genes within the input genome are aligned with genes in the pangenome to determine their gene families and partitions. Genes that do not align with any existing gene in the pangenome are considered specific to the input genome and are assigned to the "Cloud" partition. The number of this specific cloud families are detailed in the summary table.
+Genes within the input genome are aligned with genes in the pangenome to determine their gene families and partitions. Genes that do not align with any existing gene in the pangenome are considered specific to the input genome and are assigned to the "Cloud" partition. The numbers of these specific cloud families are detailed in the summary table.
 
 Based on the alignment and partition assignment, Regions of Plasticity (RGPs) within the input genome are predicted. Each RGP that is not located on a contig border is assigned to a spot of insertion. Finally, conserved modules of the pangenome found in the input genome are reported in the output files.
 
@@ -44,11 +44,11 @@ ppanggolin projection -p pangenome.h5 --anno genome_A.gbff --genome_name genome_
 
 Within the Output directory, the `summary_projection.tsv` file provides an overview of the projection, featuring one line per genome. This file includes all the columns described in the [genome-statistics table](./PangenomeAnalyses/pangenomeStat.md#genome-statistics-table) section, along with specific projection-related columns detailed below:
 
-| Column                      | Description                                                                                   |
-|-----------------------------|-----------------------------------------------------------------------------------------------|
-| Cloud_specific_families     | Number of cloud-specific families. These gene families do not match any existing families within the pangenome. |
-| Pangenome_file              | The file path of the pangenome used in the projection.                                           |
-| New_spots                   | Number of newly identified spots in the input genome.                                            |
+| Column                  | Description                                                                                                     |
+|-------------------------|-----------------------------------------------------------------------------------------------------------------|
+| Cloud_specific_families | Number of cloud-specific families. These gene families do not match any existing families within the pangenome. |
+| Pangenome_file          | The file path of the pangenome used in the projection.                                                          |
+| New_spots               | Number of newly identified spots in the input genome.                                                           |
 
 
 
@@ -60,7 +60,7 @@ For Gene Family and Partition of Input Genes:
 - `cds_sequences.fasta`: This file contains the sequences of coding regions (CDS) from the input genome.
 - `gene_to_gene_family.tsv`: It provides the mapping of genes to gene families of the pangenome. Its format follows [this output](PangenomeAnalyses/pangenomeAnalyses.md#gene-families-to-genes-associations)
 - `sequences_partition_projection.tsv`: This file maps the input genes to its partition (Persistent, Shell or Cloud).
-- `specific_genes.tsv`: This file lists the gene of the input genomes that do not align to any gene of the pangenome. These genes are assigned to Cloud parititon. 
+- `specific_genes.tsv`: This file lists the gene of the input genomes that do not align to any gene of the pangenome. These genes are assigned to Cloud partition. 
 
 For RGPs and Spots:
 

--- a/docs/user/projection.md
+++ b/docs/user/projection.md
@@ -58,7 +58,7 @@ Additionally, within the Output directory, there is a subdirectory for each inpu
 For Gene Family and Partition of Input Genes:
 
 - `cds_sequences.fasta`: This file contains the sequences of coding regions (CDS) from the input genome.
-- `gene_to_gene_family.tsv`: It provides the mapping of genes to gene families of the pangenome. Its format follows [this output](PangenomeAnalyses/pangenomeAnalyses.md#gene-families-to-genes-associations)
+- `gene_to_gene_family.tsv`: It provides the mapping of genes to gene families of the pangenome. Its format follows [this output](PangenomeAnalyses/pangenomeStat.md#gene-families-to-gene-associations).
 - `sequences_partition_projection.tsv`: This file maps the input genes to its partition (Persistent, Shell or Cloud).
 - `specific_genes.tsv`: This file lists the gene of the input genomes that do not align to any gene of the pangenome. These genes are assigned to Cloud partition. 
 

--- a/docs/user/projection.md
+++ b/docs/user/projection.md
@@ -10,6 +10,8 @@ Based on the alignment and partition assignment, Regions of Plasticity (RGPs) wi
 
 This command supports two input modes depending on whether you want to project a single genome or multiple genomes at once:
 
+In both modes, each option accepts only one kind of input: `--fasta` expects genomic sequences in FASTA format, while `--anno` expects annotation files in GFF3 or GBFF format. At least one of the two is required, and they must not be mixed within a single option. These are the same input types as the `annotate` command, described in the [Annotate from fasta files](./PangenomeAnalyses/pangenomeAnnotation.md#annotate-from-fasta-files) and [Use annotation files for your pangenome](./PangenomeAnalyses/pangenomeAnnotation.md#use-annotation-files-for-your-pangenome) sections. Both options can be given together, in which case the annotation files take precedence and the FASTA files provide the genomic sequences when the annotation files do not contain any.
+
 Multiple Files in One TSV:
 - **Options**: `--fasta` or `--anno`
 - **Description**: You can provide a tab-separated file listing genome names alongside their respective FASTA genomic sequences or annotation filepaths, with one line per genome. This mode is suitable when you want to annotate multiple genomes in a single operation. The format of this file is identical to the format used in the annotate and workflow commands; for more details, refer [here](./PangenomeAnalyses/pangenomeAnnotation.md).
@@ -28,9 +30,14 @@ Single File:
 - **Description**: When annotating a single genome, you can directly provide a single FASTA genomic sequence file or an annotation file in GFF/GBFF format. Additionally, specify the name of the genome using the `--genome_name` option. You can also indicate circular contigs using the `--circular_contigs` option when necessary.
 
 **Example Usage:**
-Suppose you have a single fasta file named `genome_A.fasta` of an external genome. To execute the projection, use the following command:
+Suppose you have a single FASTA file named `genome_A.fasta` of an external genome. To execute the projection, use the following command:
 ```bash
-ppanggolin projection -p pangenome.h5 --anno genome_A.fasta --genome_name genome_A
+ppanggolin projection -p pangenome.h5 --fasta genome_A.fasta --genome_name genome_A
+```
+
+If instead you have an annotation file `genome_A.gbff` for that genome, use `--anno`:
+```bash
+ppanggolin projection -p pangenome.h5 --anno genome_A.gbff --genome_name genome_A
 ```
 
 ## Output Files

--- a/docs/user/whatsNewInV2.md
+++ b/docs/user/whatsNewInV2.md
@@ -1,0 +1,55 @@
+# What's new in PPanGGOLiN v2
+
+This page summarises the changes between PPanGGOLiN v1 (last release `1.2.105`, February 2023) and v2 (first release `2.0.0`, January 2024). It is intended for users coming from v1 who want to know what is new and what has moved. The rationale behind these changes is described in the PPanGGOLiN v2 publication.
+
+## New commands
+
+| Command          | Description                                                                                                                                                                                                                | Documentation                                    |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
+| `projection`     | Annotate external genomes using an already computed pangenome, without recomputing it. Genes are assigned to existing gene families and partitions, then RGPs, spots and modules are predicted for the projected genome.   | [Projection](projection.md)                      |
+| `rgp_cluster`    | Cluster RGPs across genomes based on their shared gene families, using a Gene Repertoire Relatedness (GRR) score.                                                                                                          | [RGP clustering](RGP/rgpClustering.md)           |
+| `metadata`       | Attach arbitrary metadata to any pangenome element (genes, contigs, genomes, gene families, edges, RGPs, spots and modules) from a tabulated file. Metadata is stored in the pangenome file and propagated to the outputs. | [Metadata](metadata.md)                          |
+| `write_metadata` | Export the metadata stored in a pangenome.                                                                                                                                                                                 | [Metadata](metadata.md)                          |
+| `utils`          | Generate a default YAML configuration file with `--default_config`.                                                                                                                                                        | [Practical information](practicalInformation.md) |
+
+## Reorganised commands
+
+The v1 `write` command has been split into three commands with clearer scopes:
+
+| v1                                                 | v2                                                                                                                           |
+|----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `ppanggolin write --regions --spots --modules ...` | `ppanggolin write_pangenome` — pangenome-level outputs (gene families, partitions, RGPs, spots, modules, graphs, statistics) |
+| `ppanggolin write --projection`                    | `ppanggolin write_genomes --table` — genome-level outputs, one file per genome                                               |
+| —                                                  | `ppanggolin write_metadata` — metadata outputs                                                                               |
+
+Scripts written for v1 that call `ppanggolin write` need to be updated accordingly.
+
+## New output formats
+
+- **Proksee** (`write_genomes --proksee`, and the `projection` outputs): JSON files that can be loaded in [Proksee](https://proksee.ca/) to explore circular genome maps annotated with pangenome information.
+- **GFF3** (`write_genomes --gff`): genome annotations enriched with pangenome information (gene family, partition, RGP, spot, module).
+- **graph-tool** (`write_pangenome --gt`): the pangenome graph in the compressed `gt` format, in addition to the GEXF and JSON formats already available in v1.
+- **RGP gene families** (`write_pangenome --regions_families`): the gene family composition of each RGP.
+
+## Usability
+
+- **Configuration files.** Every command accepts a `--config` option pointing to a YAML file, so that parameters no longer have to be passed on the command line. This is particularly useful for the workflow commands, which run several steps in a single call, and for integration into computational platforms. A template can be generated with `ppanggolin utils --default_config`.
+- **Parameter tracking.** Parameters are resolved consistently (command line, then configuration file, then defaults), checked for consistency across analysis steps, and stored inside the pangenome file, so that an analysis can be inspected and reproduced afterwards with `ppanggolin info --parameters`.
+- **Defragmentation is now enabled by default.** The v1 opt-in `--defrag` option of the `cluster` command has been replaced by the opt-out `--no_defrag` option.
+- **Documentation.** The documentation has been fully rewritten and is now hosted on [ReadTheDocs](https://ppanggolin.readthedocs.io), including a reference of all commands and their options and an API reference for programmatic use.
+- **Distribution.** PPanGGOLiN v2 is available on [Bioconda](https://anaconda.org/bioconda/ppanggolin) and [PyPI](https://pypi.org/project/PPanGGOLiN/).
+
+## Performance and file format
+
+- **Pyrodigal replaces Prodigal.** Gene prediction now uses [Pyrodigal](https://github.com/althonos/pyrodigal), which removes the input/output overhead of calling an external binary during annotation.
+- **Redesigned HDF5 structure.** The internal layout of the pangenome file was reworked, substantially reducing file size and giving faster and more convenient programmatic access.
+- **Faster pangenome loading.** Reading a pangenome file has been optimised, reducing loading times from minutes to seconds on large datasets.
+- **Lower memory usage when writing sequences.** Sequences are read directly from the HDF5 file instead of being loaded into memory beforehand.
+
+## Compatibility with v1 pangenome files
+
+The HDF5 structure changed between v1 and v2. Pangenome files produced with v1 cannot be read by v2: PPanGGOLiN checks the version stored in the file and raises an explicit error if it was created by a v1 release. Such pangenomes have to be recomputed with v2.
+
+## Citation
+
+If you use features introduced in v2, please cite the PPanGGOLiN v2 publication in addition to the original PPanGGOLiN, panRGP and panModule papers listed on the [home page](../index.md).

--- a/docs/user/whatsNewInV2.md
+++ b/docs/user/whatsNewInV2.md
@@ -1,26 +1,36 @@
 # What's new in PPanGGOLiN v2
 
-This page summarises the changes between PPanGGOLiN v1 (last release `1.2.105`, February 2023) and v2 (first release `2.0.0`, January 2024). It is intended for users coming from v1 who want to know what is new and what has moved. The rationale behind these changes is described in the PPanGGOLiN v2 publication.
+PPanGGOLiN v2 is the result of the work carried out since mid-2021, released under version numbers `2.0.0` and above from January 2024 onwards. This page summarises what changed with respect to PPanGGOLiN as originally published ([Gautreau et al. 2020](https://doi.org/10.1371/journal.pcbi.1007732)), taking release `1.1.136` (February 2021) as the reference point. It is intended for users coming from a v1 release who want to know what is new and what has moved.
 
-## New commands
+The features listed below were released progressively, and some of them are already available in the later `1.2.x` releases. The major version number was raised to `2.0.0` at the point where the redesigned pangenome file broke compatibility with the HDF5 files produced by v1, marking the boundary between the two versions. The rationale behind these changes is described in the PPanGGOLiN v2 publication.
 
-| Command          | Description                                                                                                                                                                                                                | Documentation                                    |
-|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
-| `projection`     | Annotate external genomes using an already computed pangenome, without recomputing it. Genes are assigned to existing gene families and partitions, then RGPs, spots and modules are predicted for the projected genome.   | [Projection](projection.md)                      |
-| `rgp_cluster`    | Cluster RGPs across genomes based on their shared gene families, using a Gene Repertoire Relatedness (GRR) score.                                                                                                          | [RGP clustering](RGP/rgpClustering.md)           |
-| `metadata`       | Attach arbitrary metadata to any pangenome element (genes, contigs, genomes, gene families, edges, RGPs, spots and modules) from a tabulated file. Metadata is stored in the pangenome file and propagated to the outputs. | [Metadata](metadata.md)                          |
-| `write_metadata` | Export the metadata stored in a pangenome.                                                                                                                                                                                 | [Metadata](metadata.md)                          |
-| `utils`          | Generate a default YAML configuration file with `--default_config`.                                                                                                                                                        | [Practical information](practicalInformation.md) |
+## New analyses
+
+| Command | Description | Documentation |
+|---|---|---|
+| `projection` | Annotate external genomes using an already computed pangenome, without recomputing it. Genes are assigned to existing gene families and partitions, then RGPs, spots and modules are predicted for the projected genome. | [Projection](projection.md) |
+| `context` | Extract conserved genomic neighborhoods around genes of interest, using the neighborhood relationships already encoded in the pangenome graph. | [Genomic context](genomicContext.md) |
+| `rgp_cluster` | Cluster RGPs across genomes based on their shared gene families, using a Gene Repertoire Relatedness (GRR) score. | [RGP clustering](RGP/rgpClustering.md) |
+| `metadata` | Attach arbitrary metadata to any pangenome element (genes, contigs, genomes, gene families, edges, RGPs, spots and modules) from a tabulated file. Metadata is stored in the pangenome file and propagated to the outputs. | [Metadata](metadata.md) |
+
+## New utility commands
+
+| Command | Description | Documentation |
+|---|---|---|
+| `all` | Run the complete pipeline, including RGPs, spots and modules, in a single command. | [Workflows](PangenomeAnalyses/pangenomeWorkflow.md) |
+| `metrics` | Compute pangenome metrics such as genomic fluidity. | [Pangenome metrics](PangenomeAnalyses/pangenomeMetric.md) |
+| `write_metadata` | Export the metadata stored in a pangenome. | [Metadata](metadata.md) |
+| `utils` | Generate a default YAML configuration file with `--default_config`. | [Configuration file](practicalInformation.md#configuration-file) |
 
 ## Reorganised commands
 
-The v1 `write` command has been split into three commands with clearer scopes:
+The `write` command has been split into three commands with clearer scopes:
 
-| v1                                                 | v2                                                                                                                           |
-|----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| `ppanggolin write --regions --spots --modules ...` | `ppanggolin write_pangenome` — pangenome-level outputs (gene families, partitions, RGPs, spots, modules, graphs, statistics) |
-| `ppanggolin write --projection`                    | `ppanggolin write_genomes --table` — genome-level outputs, one file per genome                                               |
-| —                                                  | `ppanggolin write_metadata` — metadata outputs                                                                               |
+| v1 | v2 |
+|---|---|
+| `ppanggolin write --regions --spots ...` | `ppanggolin write_pangenome` — pangenome-level outputs (gene families, partitions, RGPs, spots, modules, graphs, statistics) |
+| `ppanggolin write --projection` | `ppanggolin write_genomes --table` — genome-level outputs, one file per genome |
+| — | `ppanggolin write_metadata` — metadata outputs |
 
 Scripts written for v1 that call `ppanggolin write` need to be updated accordingly.
 
@@ -33,7 +43,7 @@ Scripts written for v1 that call `ppanggolin write` need to be updated according
 
 ## Usability
 
-- **Configuration files.** Every command accepts a `--config` option pointing to a YAML file, so that parameters no longer have to be passed on the command line. This is particularly useful for the workflow commands, which run several steps in a single call, and for integration into computational platforms. A template can be generated with `ppanggolin utils --default_config`.
+- **Configuration files.** Every command accepts a `--config` option pointing to a YAML file, so that parameters no longer have to be passed on the command line. This is particularly useful for the workflow commands, which run several steps in a single call, and for integration into computational platforms. A template can be generated with `ppanggolin utils --default_config`, and the format is described in the [Configuration file](practicalInformation.md#configuration-file) section.
 - **Parameter tracking.** Parameters are resolved consistently (command line, then configuration file, then defaults), checked for consistency across analysis steps, and stored inside the pangenome file, so that an analysis can be inspected and reproduced afterwards with `ppanggolin info --parameters`.
 - **Defragmentation is now enabled by default.** The v1 opt-in `--defrag` option of the `cluster` command has been replaced by the opt-out `--no_defrag` option.
 - **Documentation.** The documentation has been fully rewritten and is now hosted on [ReadTheDocs](https://ppanggolin.readthedocs.io), including a reference of all commands and their options and an API reference for programmatic use.
@@ -48,7 +58,7 @@ Scripts written for v1 that call `ppanggolin write` need to be updated according
 
 ## Compatibility with v1 pangenome files
 
-The HDF5 structure changed between v1 and v2. Pangenome files produced with v1 cannot be read by v2: PPanGGOLiN checks the version stored in the file and raises an explicit error if it was created by a v1 release. Such pangenomes have to be recomputed with v2.
+The redesign of the HDF5 structure is what defines the boundary between v1 and v2: the major version number was raised to `2.0.0` precisely because pangenome files became incompatible at that point. Pangenome files produced with v1 therefore cannot be read by v2. PPanGGOLiN checks the version stored in the file and raises an explicit error if it was created by a v1 release, so such pangenomes have to be recomputed with v2.
 
 ## Citation
 

--- a/ppanggolin/RGP/genomicIsland.py
+++ b/ppanggolin/RGP/genomicIsland.py
@@ -412,8 +412,10 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     :return : parser arguments for align command
     """
     parser = sub_parser.add_parser("rgp", formatter_class=argparse.RawTextHelpFormatter)
-    parser.description = 'Predicts Regions of Genomic Plasticity in the genomes of your pangenome.'
-    parser.category = 'Regions of Genomic Plasticity'
+    parser.description = (
+        "Predicts Regions of Genomic Plasticity in the genomes of your pangenome."
+    )
+    parser.category = "Regions of Genomic Plasticity"
     parser_rgp(parser)
     return parser
 

--- a/ppanggolin/RGP/genomicIsland.py
+++ b/ppanggolin/RGP/genomicIsland.py
@@ -412,6 +412,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     :return : parser arguments for align command
     """
     parser = sub_parser.add_parser("rgp", formatter_class=argparse.RawTextHelpFormatter)
+    parser.description = 'Predicts Regions of Genomic Plasticity in the genomes of your pangenome.'
+    parser.category = 'Regions of Genomic Plasticity'
     parser_rgp(parser)
     return parser
 

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -803,8 +803,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "rgp_cluster", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Cluster RGPs based on their gene families.'
-    parser.category = 'Regions of Genomic Plasticity'
+    parser.description = "Cluster RGPs based on their gene families."
+    parser.category = "Regions of Genomic Plasticity"
     parser_cluster_rgp(parser)
     return parser
 

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -803,6 +803,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "rgp_cluster", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Cluster RGPs based on their gene families.'
+    parser.category = 'Regions of Genomic Plasticity'
     parser_cluster_rgp(parser)
     return parser
 

--- a/ppanggolin/RGP/spot.py
+++ b/ppanggolin/RGP/spot.py
@@ -335,6 +335,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "spot", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Predicts spots in your pangenome.'
+    parser.category = 'Regions of Genomic Plasticity'
     parser_spot(parser)
     return parser
 

--- a/ppanggolin/RGP/spot.py
+++ b/ppanggolin/RGP/spot.py
@@ -335,8 +335,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "spot", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Predicts spots in your pangenome.'
-    parser.category = 'Regions of Genomic Plasticity'
+    parser.description = "Predicts spots in your pangenome."
+    parser.category = "Regions of Genomic Plasticity"
     parser_spot(parser)
     return parser
 

--- a/ppanggolin/__init__.py
+++ b/ppanggolin/__init__.py
@@ -14,6 +14,7 @@ import ppanggolin.context
 import ppanggolin.workflow
 import ppanggolin.projection
 import ppanggolin.meta
+import ppanggolin.info
 
 SUBCOMMAND_TO_SUBPARSER = {
     "annotate": ppanggolin.annotate.subparser,
@@ -33,6 +34,7 @@ SUBCOMMAND_TO_SUBPARSER = {
     "msa": ppanggolin.formats.writeMSA.subparser,
     "metrics": ppanggolin.metrics.metrics.subparser,
     "align": ppanggolin.align.subparser,
+    "info": ppanggolin.info.subparser,
     "rgp": ppanggolin.RGP.genomicIsland.subparser,
     "spot": ppanggolin.RGP.spot.subparser,
     "module": ppanggolin.mod.subparser,
@@ -41,6 +43,13 @@ SUBCOMMAND_TO_SUBPARSER = {
     "rgp_cluster": ppanggolin.RGP.rgp_cluster.subparser,
     "metadata": ppanggolin.meta.subparser,
 }
+
+# The utility command lives in its own module, so we import it only after the
+# package is initialized and register it here to keep the CLI subcommand registry
+# in one place. This is the canonical list consumed by build_parser().
+import ppanggolin.utility
+
+SUBCOMMAND_TO_SUBPARSER["utils"] = ppanggolin.utility.utils.subparser
 
 
 version = distribution("ppanggolin").version

--- a/ppanggolin/align/alignOnPang.py
+++ b/ppanggolin/align/alignOnPang.py
@@ -859,8 +859,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "align", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Aligns a genome or a set of proteins to the pangenome gene families and predicts information from it.'
-    parser.category = 'Analysis using reference pangenomes'
+    parser.description = "Aligns a genome or a set of proteins to the pangenome gene families and predicts information from it."
+    parser.category = "Analysis using reference pangenomes"
     parser_align(parser)
     return parser
 

--- a/ppanggolin/align/alignOnPang.py
+++ b/ppanggolin/align/alignOnPang.py
@@ -859,6 +859,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "align", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Aligns a genome or a set of proteins to the pangenome gene families and predicts information from it.'
+    parser.category = 'Analysis using reference pangenomes'
     parser_align(parser)
     return parser
 

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -1975,8 +1975,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "annotate", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Annotate genomes'
-    parser.category = 'Expert'
+    parser.description = "Annotate genomes"
+    parser.category = "Expert"
     parser_annot(parser)
     return parser
 

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -1975,6 +1975,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "annotate", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Annotate genomes'
+    parser.category = 'Expert'
     parser_annot(parser)
     return parser
 

--- a/ppanggolin/cluster/cluster.py
+++ b/ppanggolin/cluster/cluster.py
@@ -909,6 +909,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "cluster", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Cluster genes into gene families'
+    parser.category = 'Expert'
     parser_clust(parser)
     return parser
 

--- a/ppanggolin/cluster/cluster.py
+++ b/ppanggolin/cluster/cluster.py
@@ -909,8 +909,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "cluster", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Cluster genes into gene families'
-    parser.category = 'Expert'
+    parser.description = "Cluster genes into gene families"
+    parser.category = "Expert"
     parser_clust(parser)
     return parser
 

--- a/ppanggolin/context/searchGeneContext.py
+++ b/ppanggolin/context/searchGeneContext.py
@@ -809,8 +809,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "context", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Local genomic context analysis.'
-    parser.category = 'Analysis using reference pangenomes'
+    parser.description = "Local genomic context analysis."
+    parser.category = "Analysis using reference pangenomes"
     parser_context(parser)
     return parser
 

--- a/ppanggolin/context/searchGeneContext.py
+++ b/ppanggolin/context/searchGeneContext.py
@@ -809,6 +809,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "context", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Local genomic context analysis.'
+    parser.category = 'Analysis using reference pangenomes'
     parser_context(parser)
     return parser
 

--- a/ppanggolin/figures/drawing.py
+++ b/ppanggolin/figures/drawing.py
@@ -83,8 +83,10 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "draw", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Draw figures representing the pangenome through different aspects'
-    parser.category = 'Output'
+    parser.description = (
+        "Draw figures representing the pangenome through different aspects"
+    )
+    parser.category = "Output"
     parser_draw(parser)
     return parser
 

--- a/ppanggolin/figures/drawing.py
+++ b/ppanggolin/figures/drawing.py
@@ -83,6 +83,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "draw", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Draw figures representing the pangenome through different aspects'
+    parser.category = 'Output'
     parser_draw(parser)
     return parser
 

--- a/ppanggolin/formats/writeFlatGenomes.py
+++ b/ppanggolin/formats/writeFlatGenomes.py
@@ -859,6 +859,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "write_genomes", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = "Writes 'flat' files that represent the genomes along with their associated pangenome elements."
+    parser.category = 'Output'
     parser_flat(parser)
     return parser
 

--- a/ppanggolin/formats/writeFlatGenomes.py
+++ b/ppanggolin/formats/writeFlatGenomes.py
@@ -860,7 +860,7 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
         "write_genomes", formatter_class=argparse.RawTextHelpFormatter
     )
     parser.description = "Writes 'flat' files that represent the genomes along with their associated pangenome elements."
-    parser.category = 'Output'
+    parser.category = "Output"
     parser_flat(parser)
     return parser
 

--- a/ppanggolin/formats/writeFlatMetadata.py
+++ b/ppanggolin/formats/writeFlatMetadata.py
@@ -180,7 +180,7 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
         "write_metadata", formatter_class=argparse.RawTextHelpFormatter
     )
     parser.description = "Writes 'TSV' files that represent the metadata associated with elements of the pangenome."
-    parser.category = 'Output'
+    parser.category = "Output"
     parser_flat(parser)
     return parser
 

--- a/ppanggolin/formats/writeFlatMetadata.py
+++ b/ppanggolin/formats/writeFlatMetadata.py
@@ -179,6 +179,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "write_metadata", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = "Writes 'TSV' files that represent the metadata associated with elements of the pangenome."
+    parser.category = 'Output'
     parser_flat(parser)
     return parser
 

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -1686,6 +1686,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "write_pangenome", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = "Writes 'flat' files that represent the pangenome and its elements for use with other software."
+    parser.category = 'Output'
     parser_flat(parser)
     return parser
 

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -1687,7 +1687,7 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
         "write_pangenome", formatter_class=argparse.RawTextHelpFormatter
     )
     parser.description = "Writes 'flat' files that represent the pangenome and its elements for use with other software."
-    parser.category = 'Output'
+    parser.category = "Output"
     parser_flat(parser)
     return parser
 

--- a/ppanggolin/formats/writeMSA.py
+++ b/ppanggolin/formats/writeMSA.py
@@ -462,8 +462,10 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     :return : parser arguments for align command
     """
     parser = sub_parser.add_parser("msa", formatter_class=argparse.RawTextHelpFormatter)
-    parser.description = 'Compute Multiple Sequence Alignments for pangenome gene families.'
-    parser.category = 'Analysis using reference pangenomes'
+    parser.description = (
+        "Compute Multiple Sequence Alignments for pangenome gene families."
+    )
+    parser.category = "Analysis using reference pangenomes"
     parser_msa(parser)
     return parser
 

--- a/ppanggolin/formats/writeMSA.py
+++ b/ppanggolin/formats/writeMSA.py
@@ -462,6 +462,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     :return : parser arguments for align command
     """
     parser = sub_parser.add_parser("msa", formatter_class=argparse.RawTextHelpFormatter)
+    parser.description = 'Compute Multiple Sequence Alignments for pangenome gene families.'
+    parser.category = 'Analysis using reference pangenomes'
     parser_msa(parser)
     return parser
 

--- a/ppanggolin/formats/writeSequences.py
+++ b/ppanggolin/formats/writeSequences.py
@@ -599,6 +599,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "fasta", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Writes fasta files for different elements of the pangenome.'
+    parser.category = 'Output'
     parser_seq(parser)
     return parser
 

--- a/ppanggolin/formats/writeSequences.py
+++ b/ppanggolin/formats/writeSequences.py
@@ -599,8 +599,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "fasta", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Writes fasta files for different elements of the pangenome.'
-    parser.category = 'Output'
+    parser.description = "Writes fasta files for different elements of the pangenome."
+    parser.category = "Output"
     parser_seq(parser)
     return parser
 

--- a/ppanggolin/graph/makeGraph.py
+++ b/ppanggolin/graph/makeGraph.py
@@ -172,8 +172,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "graph", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Create the pangenome graph'
-    parser.category = 'Expert'
+    parser.description = "Create the pangenome graph"
+    parser.category = "Expert"
     parser_graph(parser)
     return parser
 

--- a/ppanggolin/graph/makeGraph.py
+++ b/ppanggolin/graph/makeGraph.py
@@ -172,6 +172,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "graph", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Create the pangenome graph'
+    parser.category = 'Expert'
     parser_graph(parser)
     return parser
 

--- a/ppanggolin/info/info.py
+++ b/ppanggolin/info/info.py
@@ -125,6 +125,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "info", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Prints information about a given pangenome graph file.'
+    parser.category = 'Output'
     parser_info(parser)
     return parser
 

--- a/ppanggolin/info/info.py
+++ b/ppanggolin/info/info.py
@@ -125,8 +125,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "info", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Prints information about a given pangenome graph file.'
-    parser.category = 'Output'
+    parser.description = "Prints information about a given pangenome graph file."
+    parser.category = "Output"
     parser_info(parser)
     return parser
 

--- a/ppanggolin/main.py
+++ b/ppanggolin/main.py
@@ -108,7 +108,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     subparsers = parser.add_subparsers(
-        metavar="", dest="subcommand", title="subcommands", description=None
+        dest="subcommand", title="subcommands", metavar=""
     )
     subparsers.required = True  # because python3 sent subcommands to hell apparently
 

--- a/ppanggolin/main.py
+++ b/ppanggolin/main.py
@@ -45,12 +45,8 @@ from ppanggolin import (
 )
 
 
-def cmd_line() -> argparse.Namespace:
-    """Manage the command line argument given by user
-
-    :return: arguments given and readable by PPanGGOLiN
-    """
-    # need to manually write the description so that it's displayed into groups of subcommands ....
+def build_parser() -> argparse.ArgumentParser:
+    """Build the PPanGGOLiN command-line parser without parsing user input."""
     desc = "\n"
     desc += (
         "All of the following subcommands have their own set of options. To see them for a given subcommand,"
@@ -105,6 +101,7 @@ def cmd_line() -> argparse.Namespace:
     desc += "    utils      Helper side commands."
 
     parser = argparse.ArgumentParser(
+        prog="ppanggolin",
         description="Depicting microbial species diversity via a Partitioned PanGenome Graph Of Linked Neighbors",
         formatter_class=argparse.RawTextHelpFormatter,
         epilog=epilog + pan_epilog + rgp_epilog + mod_epilog,
@@ -119,16 +116,8 @@ def cmd_line() -> argparse.Namespace:
     )
     subparsers.required = True  # because python3 sent subcommands to hell apparently
 
-    # print help if no subcommand is specified
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(0)
-
-    # manage command parser to use command arguments
-    subs = []
     for sub_cmd, sub_fct in SUBCOMMAND_TO_SUBPARSER.items():
         sub = sub_fct(subparsers)
-        # add options common to all subcommands
         add_common_arguments(sub)
         sub.epilog = epilog
         if sub_cmd not in ["rgp", "spot", "module", "rgp_cluster"]:
@@ -145,16 +134,29 @@ def cmd_line() -> argparse.Namespace:
                 sub.epilog += rgp_epilog
             if sub_cmd not in ["rgp", "spot", "rgp_cluster", "panrgp"]:
                 sub.epilog += mod_epilog
-        subs.append(sub)
 
-    # manage command without common arguments
-    sub_info = ppanggolin.info.subparser(subparsers)
-    sub_utils = ppanggolin.utility.utils.subparser(subparsers)
-    subs += [sub_info, sub_utils]
+    ppanggolin.info.subparser(subparsers)
+    ppanggolin.utility.utils.subparser(subparsers)
+
+    return parser
+
+
+def cmd_line() -> argparse.Namespace:
+    """Manage the command line argument given by user
+
+    :return: arguments given and readable by PPanGGOLiN
+    """
+    parser = build_parser()
+
+    # print help if no subcommand is specified
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
 
     # print help if only the command is given
-    for sub in subs:
-        if len(sys.argv) == 2 and sub.prog.split()[1] == sys.argv[1]:
+    subcommands = parser._subparsers._group_actions[0].choices
+    for sub_name, sub in subcommands.items():
+        if len(sys.argv) == 2 and sub_name == sys.argv[1]:
             sub.print_help()
             exit(0)
 

--- a/ppanggolin/main.py
+++ b/ppanggolin/main.py
@@ -45,60 +45,56 @@ from ppanggolin import (
 )
 
 
+def _build_command_summary(parser: argparse.ArgumentParser) -> str:
+    """Build the human-readable command list from each subparser's own metadata."""
+    category_order = [
+        "Basic",
+        "Expert",
+        "Output",
+        "Regions of Genomic Plasticity",
+        "Analysis using reference pangenomes",
+        "Utility command",
+    ]
+
+    subparser_action = next(
+        (
+            action
+            for action in parser._actions
+            if isinstance(action, argparse._SubParsersAction)
+        ),
+        None,
+    )
+    if subparser_action is None:
+        return ""
+
+    grouped = {category: [] for category in category_order}
+    for command_name, command_parser in subparser_action.choices.items():
+        category = getattr(command_parser, "category", "General")
+        description = (getattr(command_parser, "description", "") or "").strip()
+        grouped.setdefault(category, []).append((command_name, description))
+
+    lines = [
+        "All of the following subcommands have their own set of options. To see them for a given subcommand,",
+        " use it with -h or --help, as such:",
+        "  ppanggolin <subcommand> -h",
+        "",
+    ]
+
+    for category in category_order:
+        if category not in grouped or not grouped[category]:
+            continue
+        lines.append(f"  {category}:")
+        for command_name, description in sorted(
+            grouped[category], key=lambda item: item[0]
+        ):
+            lines.append(f"    {command_name:<15} {description}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the PPanGGOLiN command-line parser without parsing user input."""
-    desc = "\n"
-    desc += (
-        "All of the following subcommands have their own set of options. To see them for a given subcommand,"
-        " use it with -h or --help, as such:\n"
-    )
-    desc += "  ppanggolin <subcommand> -h\n"
-    desc += "\n"
-    desc += "  Basic:\n"
-    desc += "    all           Easy workflow to run all possible analysis\n"
-    desc += "    workflow      Easy workflow to run a pangenome analysis in one go\n"
-    desc += (
-        "    panrgp        Easy workflow to run a pangenome analysis with genomic islands and spots of"
-        " insertion detection\n"
-    )
-    desc += "    panmodule     Easy workflow to run a pangenome analysis with module prediction\n"
-    desc += "  \n"
-    desc += "  Expert:\n"
-    desc += "    annotate      Annotate genomes\n"
-    desc += "    cluster       Cluster genes into gene families\n"
-    desc += "    graph         Create the pangenome graph\n"
-    desc += "    partition     Partition the pangenome graph\n"
-    desc += "    rarefaction   Compute the rarefaction curve of the pangenome\n"
-    desc += "    metadata      Add metadata to elements in yout pangenome\n"
-    desc += "  \n"
-    desc += "  Output:\n"
-    desc += "    draw              Draw figures representing the pangenome through different aspects\n"
-    desc += "    write_pangenome   Writes 'flat' files that represent the pangenome and its elements for use with other software.\n"
-    desc += "    write_genomes     Writes 'flat' files that represent the genomes along with their associated pangenome elements.\n"
-    desc += "    write_metadata    Writes 'TSV' files that represent the metadata associated with elements of the pangenome.\n"
-    desc += "    fasta             Writes fasta files for different elements of the pangenome.\n"
-    desc += (
-        "    info              Prints information about a given pangenome graph file.\n"
-    )
-    desc += "    metrics           Compute several metrics on a given pangenome.\n"
-    desc += "  \n"
-    desc += "  Regions of Genomic Plasticity:\n"
-    desc += "    rgp           Predicts Regions of Genomic Plasticity in the genomes of your pangenome.\n"
-    desc += "    spot          Predicts spots in your pangenome.\n"
-    desc += "    module        Predicts functional modules in your pangenome.\n"
-    desc += "    rgp_cluster   Cluster RGPs based on their gene families.\n"
-    desc += "  \n"
-    desc += "  Analysis using reference pangenomes:\n"
-    desc += "    msa          Compute Multiple Sequence Alignments for pangenome gene families.\n"
-    desc += (
-        "    align        Aligns a genome or a set of proteins to the pangenome gene families and "
-        "predicts information from it.\n"
-    )
-    desc += "    context      Local genomic context analysis.\n"
-    desc += "    projection   Annotates external genomes with an existing pangenome.\n"
-    desc += "  \n"
-    desc += "  Utility command:\n"
-    desc += "    utils      Helper side commands."
 
     parser = argparse.ArgumentParser(
         prog="ppanggolin",
@@ -112,7 +108,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     subparsers = parser.add_subparsers(
-        metavar="", dest="subcommand", title="subcommands", description=desc
+        metavar="", dest="subcommand", title="subcommands", description=None
     )
     subparsers.required = True  # because python3 sent subcommands to hell apparently
 
@@ -135,9 +131,10 @@ def build_parser() -> argparse.ArgumentParser:
             if sub_cmd not in ["rgp", "spot", "rgp_cluster", "panrgp"]:
                 sub.epilog += mod_epilog
 
-    ppanggolin.info.subparser(subparsers)
-    ppanggolin.utility.utils.subparser(subparsers)
+        # if getattr(sub, "description", None):
+        #     sub.help = sub.description
 
+    parser.epilog = _build_command_summary(parser) + parser.epilog
     return parser
 
 

--- a/ppanggolin/meta/meta.py
+++ b/ppanggolin/meta/meta.py
@@ -262,8 +262,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "metadata", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Add metadata to elements in yout pangenome'
-    parser.category = 'Expert'
+    parser.description = "Add metadata to elements in yout pangenome"
+    parser.category = "Expert"
     parser_meta(parser)
     return parser
 
@@ -317,7 +317,7 @@ def parser_meta(parser: argparse.ArgumentParser):
 
 if __name__ == "__main__":
     """To test local change and allow using debugger"""
-    from ppanggolin.utils import check_log, set_verbosity_level
+    from ppanggolin.utils import add_common_arguments, set_verbosity_level
 
     main_parser = argparse.ArgumentParser(
         description="Depicting microbial species diversity via a Partitioned PanGenome Graph Of Linked Neighbors",
@@ -325,30 +325,7 @@ if __name__ == "__main__":
     )
 
     parser_meta(main_parser)
-    common = main_parser.add_argument_group(title="Common argument")
-    common.add_argument(
-        "--verbose",
-        required=False,
-        type=int,
-        default=1,
-        choices=[0, 1, 2],
-        help="Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug)",
-    )
-    common.add_argument(
-        "--log",
-        required=False,
-        type=check_log,
-        default="stdout",
-        help="log output file",
-    )
-    common.add_argument(
-        "-d",
-        "--disable_prog_bar",
-        required=False,
-        action="store_true",
-        help="disables the progress bars",
-    )
-    common.add_argument(
+    main_parser.add_argument(
         "-c",
         "--cpu",
         required=False,
@@ -356,11 +333,6 @@ if __name__ == "__main__":
         type=int,
         help="Number of available cpus",
     )
-    common.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        help="Force writing in output directory and in pangenome output file.",
-    )
+    add_common_arguments(main_parser)
     set_verbosity_level(main_parser.parse_args())
     launch(main_parser.parse_args())

--- a/ppanggolin/meta/meta.py
+++ b/ppanggolin/meta/meta.py
@@ -262,6 +262,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "metadata", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Add metadata to elements in yout pangenome'
+    parser.category = 'Expert'
     parser_meta(parser)
     return parser
 

--- a/ppanggolin/metrics/metrics.py
+++ b/ppanggolin/metrics/metrics.py
@@ -154,6 +154,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "metrics", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Compute several metrics on a given pangenome.'
+    parser.category = 'Output'
     parser_metrics(parser)
     return parser
 

--- a/ppanggolin/metrics/metrics.py
+++ b/ppanggolin/metrics/metrics.py
@@ -154,8 +154,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "metrics", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Compute several metrics on a given pangenome.'
-    parser.category = 'Output'
+    parser.description = "Compute several metrics on a given pangenome."
+    parser.category = "Output"
     parser_metrics(parser)
     return parser
 

--- a/ppanggolin/mod/module.py
+++ b/ppanggolin/mod/module.py
@@ -206,8 +206,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "module", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Predicts functional modules in your pangenome.'
-    parser.category = 'Regions of Genomic Plasticity'
+    parser.description = "Predicts functional modules in your pangenome."
+    parser.category = "Regions of Genomic Plasticity"
     parser_module(parser)
     return parser
 

--- a/ppanggolin/mod/module.py
+++ b/ppanggolin/mod/module.py
@@ -206,6 +206,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "module", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Predicts functional modules in your pangenome.'
+    parser.category = 'Regions of Genomic Plasticity'
     parser_module(parser)
     return parser
 

--- a/ppanggolin/nem/partition.py
+++ b/ppanggolin/nem/partition.py
@@ -943,8 +943,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "partition", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Partition the pangenome graph'
-    parser.category = 'Expert'
+    parser.description = "Partition the pangenome graph"
+    parser.category = "Expert"
     parser_partition(parser)
     return parser
 

--- a/ppanggolin/nem/partition.py
+++ b/ppanggolin/nem/partition.py
@@ -943,6 +943,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "partition", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Partition the pangenome graph'
+    parser.category = 'Expert'
     parser_partition(parser)
     return parser
 

--- a/ppanggolin/nem/rarefaction.py
+++ b/ppanggolin/nem/rarefaction.py
@@ -767,6 +767,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
         description="Compute the rarefaction curve of the pangenome",
         formatter_class=argparse.RawTextHelpFormatter,
     )
+    parser.description = "Compute the rarefaction curve of the pangenome"
+    parser.category = "Expert"
     parser_rarefaction(parser)
     return parser
 

--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -1711,6 +1711,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "projection", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Annotates external genomes with an existing pangenome.'
+    parser.category = 'Analysis using reference pangenomes'
     parser_projection(parser)
     return parser
 

--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -1711,8 +1711,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "projection", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Annotates external genomes with an existing pangenome.'
-    parser.category = 'Analysis using reference pangenomes'
+    parser.description = "Annotates external genomes with an existing pangenome."
+    parser.category = "Analysis using reference pangenomes"
     parser_projection(parser)
     return parser
 

--- a/ppanggolin/utility/utils.py
+++ b/ppanggolin/utility/utils.py
@@ -283,6 +283,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "utils", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Helper side commands.'
+    parser.category = 'Utility command'
     parser_default_config(parser)
     return parser
 

--- a/ppanggolin/utility/utils.py
+++ b/ppanggolin/utility/utils.py
@@ -283,8 +283,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "utils", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Helper side commands.'
-    parser.category = 'Utility command'
+    parser.description = "Helper side commands."
+    parser.category = "Utility command"
     parser_default_config(parser)
     return parser
 
@@ -322,38 +322,20 @@ def parser_default_config(parser: argparse.ArgumentParser):
         help="name and path of the config file with default parameters written in yaml.",
     )
 
-    optional.add_argument(
-        "--verbose",
-        required=False,
-        type=int,
-        default=1,
-        choices=[0, 1, 2],
-        help="Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug)",
-    )
-
-    optional.add_argument(
-        "--log",
-        required=False,
-        type=check_log,
-        default="stdout",
-        help="log output file",
-    )
-
-    optional.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        help="Overwrite the given output file if it exists.",
-    )
+    # Common CLI options are added centrally in add_common_arguments() to keep
+    # a single source of truth and avoid argparse conflicts.
 
 
 if __name__ == "__main__":
     """To test local change and allow using debugger"""
+    from ppanggolin.utils import add_common_arguments
+
     main_parser = argparse.ArgumentParser(
         description="Depicting microbial species diversity via a Partitioned PanGenome Graph Of Linked Neighbors",
         formatter_class=argparse.RawTextHelpFormatter,
     )
 
     parser_default_config(main_parser)
+    add_common_arguments(main_parser)
 
     launch(main_parser.parse_args())

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -623,44 +623,82 @@ def add_common_arguments(subparser: argparse.ArgumentParser):
     :param subparser: A subparser object from any subcommand.
     """
 
+    existing_options = {
+        option for action in subparser._actions for option in action.option_strings
+    }
+
     common = subparser._action_groups.pop(
         1
     )  # get the 'optional arguments' action group.
     common.title = "Common arguments"
-    common.add_argument(
-        "--verbose",
-        required=False,
-        type=int,
-        default=1,
-        choices=[0, 1, 2],
-        help="Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug)",
-    )
-    common.add_argument(
-        "--log",
-        required=False,
-        type=check_log,
-        default="stdout",
-        help="log output file",
-    )
-    common.add_argument(
-        "-d",
-        "--disable_prog_bar",
-        required=False,
-        action="store_true",
-        help="disables the progress bars",
-    )
-    common.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        help="Force writing in output directory and in pangenome output file.",
-    )
-    common.add_argument(
-        "--config",
-        required=False,
-        type=argparse.FileType(),
-        help="Specify command arguments through a YAML configuration file.",
-    )
+
+    if "--verbose" not in existing_options:
+        common.add_argument(
+            "--verbose",
+            required=False,
+            type=int,
+            default=1,
+            choices=[0, 1, 2],
+            help="Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug)",
+        )
+    else:
+        logging.getLogger("PPanGGOLiN").warning(
+            "The --verbose argument is already defined in the subcommand. "
+            "Please remove it from the subcommand to avoid conflicts."
+        )
+
+    if "--log" not in existing_options:
+        common.add_argument(
+            "--log",
+            required=False,
+            type=check_log,
+            default="stdout",
+            help="log output file",
+        )
+    else:
+        logging.getLogger("PPanGGOLiN").warning(
+            "The --log argument is already defined in the subcommand. "
+            "Please remove it from the subcommand to avoid conflicts."
+        )
+
+    if "-d" not in existing_options and "--disable_prog_bar" not in existing_options:
+        common.add_argument(
+            "-d",
+            "--disable_prog_bar",
+            required=False,
+            action="store_true",
+            help="disables the progress bars",
+        )
+    else:
+        logging.getLogger("PPanGGOLiN").warning(
+            "The --disable_prog_bar argument is already defined in the subcommand. "
+            "Please remove it from the subcommand to avoid conflicts."
+        )
+
+    if "-f" not in existing_options and "--force" not in existing_options:
+        common.add_argument(
+            "-f",
+            "--force",
+            action="store_true",
+            help="Force writing in output directory and in pangenome output file.",
+        )
+    else:
+        logging.getLogger("PPanGGOLiN").warning(
+            "The --force argument is already defined in the subcommand. "
+            "Please remove it from the subcommand to avoid conflicts."
+        )
+    if "--config" not in existing_options:
+        common.add_argument(
+            "--config",
+            required=False,
+            type=argparse.FileType(),
+            help="Specify command arguments through a YAML configuration file.",
+        )
+    else:
+        logging.getLogger("PPanGGOLiN").warning(
+            "The --config argument is already defined in the subcommand. "
+            "Please remove it from the subcommand to avoid conflicts."
+        )
     subparser._action_groups.append(common)
 
 

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -587,7 +587,7 @@ def check_option_workflow(args):
         )
 
 
-def parse_config_file(yaml_config_file: str) -> dict:
+def parse_config_file(yaml_config_file: Path) -> dict:
     """
     Parse yaml config file.
 
@@ -596,7 +596,7 @@ def parse_config_file(yaml_config_file: str) -> dict:
     :return: dict of config with key the command and as value another dict with param as key and value as value.
     """
 
-    with yaml_config_file as yaml_fh:
+    with open(yaml_config_file) as yaml_fh:
         config = yaml.safe_load(yaml_fh)
 
     if config is None:
@@ -846,7 +846,7 @@ def get_args_differing_from_default(
 
 
 def manage_cli_and_config_args(
-    subcommand: str, config_file: str, subcommand_to_subparser: dict
+    subcommand: str, config_file: Optional[Path], subcommand_to_subparser: dict
 ) -> argparse.Namespace:
     """
     Manage command line and config arguments for the given subcommand.

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -691,7 +691,7 @@ def add_common_arguments(subparser: argparse.ArgumentParser):
         common.add_argument(
             "--config",
             required=False,
-            type=argparse.FileType(),
+            type=Path,
             help="Specify command arguments through a YAML configuration file.",
         )
     else:

--- a/ppanggolin/workflow/all.py
+++ b/ppanggolin/workflow/all.py
@@ -485,6 +485,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     :return : parser arguments for all command
     """
     parser = sub_parser.add_parser("all", formatter_class=argparse.RawTextHelpFormatter)
+    parser.description = 'Easy workflow to run all possible analysis'
+    parser.category = 'Basic'
 
     add_workflow_args(parser)
 

--- a/ppanggolin/workflow/all.py
+++ b/ppanggolin/workflow/all.py
@@ -485,8 +485,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     :return : parser arguments for all command
     """
     parser = sub_parser.add_parser("all", formatter_class=argparse.RawTextHelpFormatter)
-    parser.description = 'Easy workflow to run all possible analysis'
-    parser.category = 'Basic'
+    parser.description = "Easy workflow to run all possible analysis"
+    parser.category = "Basic"
 
     add_workflow_args(parser)
 

--- a/ppanggolin/workflow/panModule.py
+++ b/ppanggolin/workflow/panModule.py
@@ -28,8 +28,10 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "panmodule", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Easy workflow to run a pangenome analysis with module prediction'
-    parser.category = 'Basic'
+    parser.description = (
+        "Easy workflow to run a pangenome analysis with module prediction"
+    )
+    parser.category = "Basic"
 
     add_workflow_args(parser)
 

--- a/ppanggolin/workflow/panModule.py
+++ b/ppanggolin/workflow/panModule.py
@@ -28,6 +28,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "panmodule", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Easy workflow to run a pangenome analysis with module prediction'
+    parser.category = 'Basic'
 
     add_workflow_args(parser)
 

--- a/ppanggolin/workflow/panRGP.py
+++ b/ppanggolin/workflow/panRGP.py
@@ -29,8 +29,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "panrgp", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Easy workflow to run a pangenome analysis with genomic islands and spots of insertion detection'
-    parser.category = 'Basic'
+    parser.description = "Easy workflow to run a pangenome analysis with genomic islands and spots of insertion detection"
+    parser.category = "Basic"
 
     add_workflow_args(parser)
 

--- a/ppanggolin/workflow/panRGP.py
+++ b/ppanggolin/workflow/panRGP.py
@@ -29,6 +29,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "panrgp", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Easy workflow to run a pangenome analysis with genomic islands and spots of insertion detection'
+    parser.category = 'Basic'
 
     add_workflow_args(parser)
 

--- a/ppanggolin/workflow/workflow.py
+++ b/ppanggolin/workflow/workflow.py
@@ -28,8 +28,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "workflow", formatter_class=argparse.RawTextHelpFormatter
     )
-    parser.description = 'Easy workflow to run a pangenome analysis in one go'
-    parser.category = 'Basic'
+    parser.description = "Easy workflow to run a pangenome analysis in one go"
+    parser.category = "Basic"
 
     add_workflow_args(parser)
 

--- a/ppanggolin/workflow/workflow.py
+++ b/ppanggolin/workflow/workflow.py
@@ -28,6 +28,8 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     parser = sub_parser.add_parser(
         "workflow", formatter_class=argparse.RawTextHelpFormatter
     )
+    parser.description = 'Easy workflow to run a pangenome analysis in one go'
+    parser.category = 'Basic'
 
     add_workflow_args(parser)
 

--- a/ppanggolin_env.yaml
+++ b/ppanggolin_env.yaml
@@ -13,7 +13,7 @@ dependencies:
   - gmpy2>=2.0.0,<3.0.0
   - pandas>=2.0.0,<3.0.0
   - numpy>1.24.0,<2.0.0
-  - bokeh>=3.0.0,<4.0.0
+  - bokeh>=3.0.0,<3.4.0
   - graph-tool>=2
   # Tools that are not in Python 
   - infernal=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "scipy>=1.0.0,<2.0.0",
     "plotly>=5.0.0,<6.0.0",
     "gmpy2>=2.0.0,<3.0.0",
-    "bokeh>=3.0.0,<4.0.0"
+    "bokeh>=3.0.0,<3.4.0"
 ]
 
 license = {file="LICENSE.txt"}

--- a/tests/unit_tests/test_cli_reference.py
+++ b/tests/unit_tests/test_cli_reference.py
@@ -1,6 +1,8 @@
+import argparse
 import importlib.util
 from pathlib import Path
 
+from ppanggolin import SUBCOMMAND_TO_SUBPARSER
 from ppanggolin.main import build_parser
 
 
@@ -28,6 +30,34 @@ def test_build_parser_does_not_execute_analysis(monkeypatch):
     assert parser is not None
 
 
+def test_subparsers_own_command_metadata():
+    parser = argparse.ArgumentParser(prog="ppanggolin")
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    all_parser = SUBCOMMAND_TO_SUBPARSER["all"](subparsers)
+    info_parser = SUBCOMMAND_TO_SUBPARSER["info"](subparsers)
+
+    assert all_parser.category == "Basic"
+    assert all_parser.description == "Easy workflow to run all possible analysis"
+    assert info_parser.category == "Output"
+    assert (
+        info_parser.description
+        == "Prints information about a given pangenome graph file."
+    )
+
+
+def test_top_level_help_lists_subcommands():
+    parser = build_parser()
+    help_text = parser.format_help()
+
+    assert "subcommands:" in help_text
+    assert "all" in help_text
+    assert "info" in help_text
+    assert "utils" in help_text
+    assert "All of the following subcommands have their own set of options" in help_text
+    assert "Basic:" in help_text
+
+
 def test_generated_reference_contains_cli_data(tmp_path):
     script_path = (
         Path(__file__).resolve().parents[2]
@@ -48,6 +78,10 @@ def test_generated_reference_contains_cli_data(tmp_path):
     assert "## `ppanggolin all`" in rendered
     assert "## `ppanggolin info`" in rendered
     assert "## `ppanggolin utils`" in rendered
+    assert "## Basic" in rendered
+    assert "Easy workflow to run all possible analysis" in rendered
+    assert "## Utility command" in rendered
+    assert "Helper side commands" in rendered
     assert "--cpu" in rendered
     assert "--pangenome" in rendered
     assert "False" in rendered

--- a/tests/unit_tests/test_cli_reference.py
+++ b/tests/unit_tests/test_cli_reference.py
@@ -18,7 +18,9 @@ def test_build_parser_does_not_execute_analysis(monkeypatch):
     import ppanggolin.workflow.all as workflow_all
 
     def boom(*args, **kwargs):
-        raise AssertionError("analysis launch should not be called while building the parser")
+        raise AssertionError(
+            "analysis launch should not be called while building the parser"
+        )
 
     monkeypatch.setattr(workflow_all, "launch", boom)
 
@@ -27,8 +29,15 @@ def test_build_parser_does_not_execute_analysis(monkeypatch):
 
 
 def test_generated_reference_contains_cli_data(tmp_path):
-    script_path = Path(__file__).resolve().parents[2] / "docs" / "_scripts" / "generate_command_reference.py"
-    spec = importlib.util.spec_from_file_location("generate_command_reference", script_path)
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "_scripts"
+        / "generate_command_reference.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "generate_command_reference", script_path
+    )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 

--- a/tests/unit_tests/test_cli_reference.py
+++ b/tests/unit_tests/test_cli_reference.py
@@ -1,0 +1,45 @@
+import importlib.util
+from pathlib import Path
+
+from ppanggolin.main import build_parser
+
+
+def test_build_parser_is_available_without_sys_argv():
+    parser = build_parser()
+
+    assert parser is not None
+    assert parser.prog == "ppanggolin"
+    assert "all" in parser._subparsers._group_actions[0].choices
+    assert "info" in parser._subparsers._group_actions[0].choices
+    assert "utils" in parser._subparsers._group_actions[0].choices
+
+
+def test_build_parser_does_not_execute_analysis(monkeypatch):
+    import ppanggolin.workflow.all as workflow_all
+
+    def boom(*args, **kwargs):
+        raise AssertionError("analysis launch should not be called while building the parser")
+
+    monkeypatch.setattr(workflow_all, "launch", boom)
+
+    parser = build_parser()
+    assert parser is not None
+
+
+def test_generated_reference_contains_cli_data(tmp_path):
+    script_path = Path(__file__).resolve().parents[2] / "docs" / "_scripts" / "generate_command_reference.py"
+    spec = importlib.util.spec_from_file_location("generate_command_reference", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    output_path = tmp_path / "command_reference.md"
+    rendered = module.generate_reference(output_path)
+
+    assert "# Command-line reference" in rendered
+    assert "## `ppanggolin all`" in rendered
+    assert "## `ppanggolin info`" in rendered
+    assert "## `ppanggolin utils`" in rendered
+    assert "--cpu" in rendered
+    assert "--pangenome" in rendered
+    assert "False" in rendered
+    assert "Choices" in rendered

--- a/tests/unit_tests/test_cli_reference.py
+++ b/tests/unit_tests/test_cli_reference.py
@@ -86,6 +86,9 @@ def test_generated_reference_contains_cli_data(tmp_path):
     assert "--pangenome" in rendered
     assert "False" in rendered
     assert "Choices" in rendered
+    assert "bool" in rendered
+    assert "float" in rendered
     assert "Input arguments for ppanggolin all" in rendered
     assert "Optional arguments for ppanggolin all" in rendered
     assert "Common arguments for ppanggolin utils" in rendered
+    assert "ppanggolin_context_<date>_<pid>" in rendered

--- a/tests/unit_tests/test_cli_reference.py
+++ b/tests/unit_tests/test_cli_reference.py
@@ -86,3 +86,5 @@ def test_generated_reference_contains_cli_data(tmp_path):
     assert "--pangenome" in rendered
     assert "False" in rendered
     assert "Choices" in rendered
+    assert "Optional parameters for ppanggolin all" in rendered
+    assert "Optional parameters for ppanggolin utils" in rendered

--- a/tests/unit_tests/test_cli_reference.py
+++ b/tests/unit_tests/test_cli_reference.py
@@ -86,5 +86,6 @@ def test_generated_reference_contains_cli_data(tmp_path):
     assert "--pangenome" in rendered
     assert "False" in rendered
     assert "Choices" in rendered
-    assert "Optional parameters for ppanggolin all" in rendered
-    assert "Optional parameters for ppanggolin utils" in rendered
+    assert "Input arguments for ppanggolin all" in rendered
+    assert "Optional arguments for ppanggolin all" in rendered
+    assert "Common arguments for ppanggolin utils" in rendered


### PR DESCRIPTION
# Documentation improvements following the JOSS review

This PR addresses several documentation points raised during the JOSS review of the PPanGGOLiN v2 manuscript.

## 1. New page: "What's new in PPanGGOLiN v2"

A reviewer asked for a recap of what changed between v1 and v2.

`docs/user/whatsNewInV2.md` (linked from the User Guide toctree) takes release `1.1.136` (February 2021) as its reference point, matching the manuscript's definition of v2 as the work carried out since mid-2021. The page explains that some of these features shipped under later `1.2.x` version numbers, and that the major version was only raised to `2.0.0` at the point where the redesigned pangenome file broke compatibility with v1 HDF5 files, so that users coming from a recent v1 release are not misled.

It covers:
- new analyses: `projection`, `context`, `rgp_cluster` and `metadata`;
- new utility commands: `all`, `metrics`, `write_metadata` and `utils`;
- the `write` → `write_pangenome` / `write_genomes` / `write_metadata` split, with a  v1 → v2 mapping so existing scripts can be updated;
- new output formats (Proksee, GFF3, graph-tool `gt`, RGP gene families);
- usability changes (YAML configuration files, parameter tracking in the pangenome file,
  defragmentation now enabled by default via `--no_defrag`, ReadTheDocs, Bioconda/PyPI);
- performance and file-format changes (Pyrodigal, redesigned HDF5 layout, faster loading,  lower memory when writing sequences);
- the incompatibility of v1 pangenome files, which is what defines the v1/v2 boundary.

The command lists were established by diffing the CLI against the `1.1.136` tag rather than from the manuscript, so the page and the code cannot disagree.

## 2. `projection`: clarify `--fasta` vs `--anno`

A reviewer found it unclear that `--fasta` takes only FASTA files and `--anno` only annotation files. The single-genome example was in fact contradicting the text: it passed a `.fasta` file to `--anno`, which is very likely what caused the confusion.

- Added an explicit paragraph on what each option accepts, cross-referencing the  corresponding sections of the annotation documentation.
- Fixed the example to use `--fasta genome_A.fasta`, and added a second example using  `--anno genome_A.gbff`.
- Documented that both options may be given together, in which case annotations take  precedence and the FASTA supplies sequences for genomes whose annotation files contain  none.
- Fixed a broken cross-reference: the target section lives in `pangenomeStat.md`, not  `pangenomeAnalyses.md`, and the anchor is `#gene-families-to-gene-associations`.
- Minor typo and table formatting fixes.

## 3. `rgp_cluster`: document the output location

Added a note that the output files are written to a directory named `rgp_clustering` by default (changeable with `--output`), and that the file names follow `--basename` (`rgp_cluster` by default).
