### PR TITLE
Refactor and optimize RGP clustering

### DIFF
--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -4,6 +4,7 @@
 import logging
 import argparse
 import os
+import resource
 from itertools import combinations
 from collections.abc import Callable
 from collections import defaultdict
@@ -27,6 +28,7 @@ import typing as tp
 from dataclasses import dataclass, field
 from pyroaring import BitMap
 from ppanggolin.formats.h5reader import H5Reader, TableAttribute
+
 
 class RegionProxy:
 
@@ -505,9 +507,6 @@ class RGPClustering:
 
         with H5Reader(self.h5) as reader:
 
-            # self._contig_to_organism = self._get_contig_to_organism(reader)
-            # self._contig_id_to_is_circular = self._get_contig_to_is_circular(reader)
-
             rgp_to_genes = self._get_rgp_genes(reader)
 
             contigs_with_rgp = {rgp_name.split("_RGP_")[0] for rgp_name in rgp_to_genes}
@@ -526,9 +525,7 @@ class RGPClustering:
             for info in rgp_infos:
                 fams_key = tuple(sorted(fam_id for fam_id in info.families_ids))
                 fams_to_rgps[fams_key].append(info)
-            print(
-                f"{len(fams_to_rgps)} unique family combinations found for {len(rgp_infos)} RGPs"
-            )
+
             idx = 0
             for rgps in fams_to_rgps.values():
                 self._construct_and_add(idx, rgps)
@@ -679,28 +676,64 @@ class RGPClustering:
             graph_filename = output / f"{basename}.gexf"
             logging.info(f"Writing RGP graph in GEXF format to {graph_filename}")
             nx.write_gexf(self.graph, graph_filename)
+
+            rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+            logging.info(f"Memory after writing GEXF: RSS peak={rss_peak:.2f} MB")
+
         if "graphml" in graph_formats:
             graph_filename = output / f"{basename}.graphml"
             logging.info(f"Writing RGP graph in GraphML format to {graph_filename}")
             nx.write_graphml(self.graph, graph_filename)
 
+            rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+            logging.info(f"Memory after writing GraphML: RSS peak={rss_peak:.2f} MB")
+
     def _write_outputs(self, output: Path, basename: str, graph_formats: list[str]):
         self._write_graphs(output, basename, graph_formats)
 
     def run(self, options: RGPClusteringOptions):
+
+        # Get initial memory
+        rss_start = (
+            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        )  # Convert to MB (on Linux, ru_maxrss is in KB)
+        logging.info(f"Memory at start: RSS peak={rss_start:.2f} MB")
+
         with Timer("_construct_regions", logging):
             self._construct_regions()
+
+        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        logging.info(f"Memory after _construct_regions: RSS peak={rss_peak:.2f} MB")
+
         self._compute_all_metrics(options.grr_cutoff, options.metric)
+
+        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        logging.info(f"Memory after _compute_all_metrics: RSS peak={rss_peak:.2f} MB")
+
         self._louvain_clustering(options.metric)
+
+        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        logging.info(f"Memory after _louvain_clustering: RSS peak={rss_peak:.2f} MB")
 
         if options.unmerge_identical_rgps:
             self._add_edges_to_identical_rgps()
         else:
             self._add_info_to_identical_rgps()
 
+        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        logging.info(
+            f"Memory after identical_rgps processing: RSS peak={rss_peak:.2f} MB"
+        )
+
         self._add_info_to_rgps()
 
+        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        logging.info(f"Memory after _add_info_to_rgps: RSS peak={rss_peak:.2f} MB")
+
         self._write_outputs(options.output, options.basename, options.graph_formats)
+
+        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        logging.info(f"Memory after _write_outputs: RSS peak={rss_peak:.2f} MB")
 
     @property
     def rgp_count(self) -> int:

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -688,7 +688,8 @@ class RGPClustering:
         self._write_graphs(output, basename, graph_formats)
 
     def run(self, options: RGPClusteringOptions):
-        self._construct_regions()
+        with Timer("_construct_regions", logging):
+            self._construct_regions()
         self._compute_all_metrics(options.grr_cutoff, options.metric)
         self._louvain_clustering(options.metric)
 

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -163,7 +163,7 @@ class RGPGenes:
 class RGPInfo:
     name: str
     families: set[str]
-    families_ids: set[int]
+    families_ids: BitMap
     is_contig_border: bool
     is_whole_contig: bool
     contig: str
@@ -252,37 +252,44 @@ class RGPClustering:
             circular_contig_ids[table.idx] = table.is_circular
         return circular_contig_ids
 
-    def _get_contig_to_info(self, reader: H5Reader):
+    def _get_contig_to_info(
+        self, reader: H5Reader, contigs_to_keep: set[str] = None
+    ) -> dict[str, Contig]:
 
         contig_to_info: dict[str, Contig] = {}
         for table in reader.fetch(ContigTable):
-            contig_to_info[table.contig] = Contig(
-                organism=table.genome,
-                is_circular=table.is_circular,
-                idx=table.idx,
-                name=table.contig,
-            )
+            if contigs_to_keep is None or table.contig in contigs_to_keep:
+                contig_to_info[table.contig] = Contig(
+                    organism=table.genome,
+                    is_circular=table.is_circular,
+                    idx=table.idx,
+                    name=table.contig,
+                )
 
         return contig_to_info
 
     def _get_contig_border_genes(
-        self, reader: H5Reader, all_rgp_genes: set[str] = None
+        self, reader: H5Reader
     ) -> dict[str, ContigBorderPosition]:
         """
         Get contig information such as if it is circular, last gene position and last gene idx.
         """
 
+        contig_ids_with_rgp = {
+            contig_info.idx for contig_info in self._rgp_contig_to_info.values()
+        }
         genedata_to_contig_ids: dict[int, list[int]] = defaultdict(list)
 
-        contig_genedata_id_to_gene_name: dict[tuple[int, int], str] = {}
+        # contig_genedata_id_to_gene_name: dict[tuple[int, int], str] = {}
 
         # Map gene name with genetadata id
         # and contig id with genmetadata id in annotations/genes table
-        # TODO do not process contig that have no RGP
 
         for table in reader.fetch(GenesTable):
+            if table.contig not in contig_ids_with_rgp:
+                continue
             genedata_to_contig_ids[table.genedata].append(table.contig)
-            contig_genedata_id_to_gene_name[(table.contig, table.genedata)] = table.name
+            # contig_genedata_id_to_gene_name[(table.contig, table.genedata)] = table.name
 
         # Create a contig info dictionary to store contig information
         contig_to_info: dict[int, ContigBorderPosition] = {}
@@ -321,8 +328,26 @@ class RGPClustering:
 
         contig_id_to_name = {
             contig_info.idx: contig_info.name
-            for contig_info in self._contig_to_info.values()
+            for contig_info in self._rgp_contig_to_info.values()
         }
+
+        # compute mapping (contig_id, genedata_id) to gene_name info only for border genes
+        # need to go through GenesTable again to get gene names
+        contig_genedata_id_to_gene_name = {
+            (contig_id, info.first_gene_idx): None
+            for contig_id, info in contig_to_info.items()
+        }
+        contig_genedata_id_to_gene_name.update(
+            {
+                (contig_id, info.last_gene_idx): None
+                for contig_id, info in contig_to_info.items()
+            }
+        )
+        for table in reader.fetch(GenesTable):
+            if (table.contig, table.genedata) in contig_genedata_id_to_gene_name:
+                contig_genedata_id_to_gene_name[(table.contig, table.genedata)] = (
+                    table.name
+                )
 
         contig_name_to_border_genes = {
             contig_id_to_name[contig_id]: ContigBorderGenes(
@@ -336,15 +361,22 @@ class RGPClustering:
             )
             for contig_id, info in contig_to_info.items()
         }
+
         return contig_name_to_border_genes
 
-    def _get_rgp_info(self, reader: H5Reader) -> list[RGPInfo]:
-        rgp_with_genes: dict[str, set[str]] = defaultdict(set)
-        all_rgp_genes: set[str] = set()
+    def _get_rgp_genes(self, reader: H5Reader) -> dict[str, set[str]]:
+        rgp_genes: dict[str, set[str]] = defaultdict(set)
 
         for table in reader.fetch(RGPTable):
-            rgp_with_genes[table.rgp].add(table.gene)
-            all_rgp_genes.add(table.gene)
+            rgp_genes[table.rgp].add(table.gene)
+
+        return rgp_genes
+
+    def _get_rgp_info(
+        self,
+        reader: H5Reader,
+        rgp_with_genes: dict[str, set[str]],
+    ) -> list[RGPInfo]:
 
         contig_to_border_genes = self._get_contig_border_genes(reader)
 
@@ -363,7 +395,7 @@ class RGPClustering:
 
         for rgp_name, genes in rgp_with_genes.items():
 
-            rgp_families_ids: set[int] = set()  # TODO Use BitMap here directly??
+            rgp_families_ids: BitMap = BitMap()
             rgp_families: set[str] = set()
             contig_name = rgp_name.split("_RGP_")[0]
             for gene in genes:
@@ -374,7 +406,7 @@ class RGPClustering:
                 rgp_families_ids.add(fam_id)
 
             contig_border_info = contig_to_border_genes[contig_name]
-            is_contig_circular = self._contig_to_info[contig_name].is_circular
+            is_contig_circular = self._rgp_contig_to_info[contig_name].is_circular
 
             is_contig_border = False
             if not is_contig_circular and (
@@ -403,14 +435,14 @@ class RGPClustering:
         return RegionProxy(
             ID=idx,
             name=rgp.name,
-            families=BitMap(rgp.families_ids),
+            families=rgp.families_ids,
             modules=BitMap(
                 module_id
                 for fam in rgp.families
                 for module_id in self._fam_to_modules.get(fam, [])
             ),
             contig=rgp.contig,
-            organism=self._contig_to_info[rgp.contig].organism,
+            organism=self._rgp_contig_to_info[rgp.contig].organism,
             length=self._rgp_to_nb_genes[rgp.name],
             is_contig_border=rgp.is_contig_border,
             is_whole_contig=rgp.is_whole_contig,
@@ -424,7 +456,7 @@ class RGPClustering:
         return RegionProxy(
             ID=idx,
             name=f"identical_rgps_{self.identical_regions}",
-            families=BitMap(rgps[0].families_ids),
+            families=rgps[0].families_ids,
             children=set(
                 self._construct_single(i, rgp)
                 for i, rgp in enumerate(rgps, start=idx + 1)
@@ -475,9 +507,17 @@ class RGPClustering:
 
             # self._contig_to_organism = self._get_contig_to_organism(reader)
             # self._contig_id_to_is_circular = self._get_contig_to_is_circular(reader)
-            self._contig_to_info = self._get_contig_to_info(reader)
 
-            rgp_infos = self._get_rgp_info(reader)
+            rgp_to_genes = self._get_rgp_genes(reader)
+
+            contigs_with_rgp = {rgp_name.split("_RGP_")[0] for rgp_name in rgp_to_genes}
+
+            self._rgp_contig_to_info = self._get_contig_to_info(
+                reader, contigs_with_rgp
+            )
+
+            rgp_infos = self._get_rgp_info(reader, rgp_to_genes)
+
             self._rgp_to_spot = self._get_rgp_spot(reader)
             self._fam_to_modules = self._get_fam_to_modules(reader)
 

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -221,6 +221,7 @@ class RGPClusteringOptions:
     graph_formats: list[str] = ("gexf", "graphml")
     with_metadata: bool = False
     metadata_sources: list[str] = field(default_factory=list)
+    ignore_incomplete_rgp: bool = False
 
 class RGPClustering:
     def __init__(self, pangenome_h5: Path):
@@ -631,7 +632,7 @@ class RGPClustering:
         return m if getattr(m, metric) >= grr_cutoff else None
 
     def _construct_regions(
-        self, with_metadata: bool = False, metadata_sources: list[str] = None
+        self, with_metadata: bool = False, metadata_sources: list[str] = None, ignore_incomplete_rgp: bool = False
     ):
         logging.info("Loading RGPs from pangenome H5 file")
 
@@ -647,6 +648,16 @@ class RGPClustering:
             )
 
             rgp_infos = self._get_rgp_info(reader, rgp_to_genes)
+
+            if ignore_incomplete_rgp:
+                rgp_infos = [
+                    rgp_info
+                    for rgp_info in rgp_infos
+                    if not rgp_info.is_contig_border
+                ]
+                logging.info(
+                    f"{len(rgp_infos)} RGPs loaded from pangenome after filtering out incomplete RGPs"
+                )
 
             self._rgp_to_spot = self._get_rgp_spot(reader)
             self._fam_to_modules = self._get_fam_to_modules(reader)
@@ -1003,6 +1014,7 @@ class RGPClustering:
             self._construct_regions(
                 with_metadata=options.with_metadata,
                 metadata_sources=options.metadata_sources or None,
+                ignore_incomplete_rgp=options.ignore_incomplete_rgp
             )
 
         rss_peak_after_construct_regions = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
@@ -1858,6 +1870,7 @@ def launch(args: argparse.Namespace):
                     graph_formats=args.graph_formats,
                     with_metadata=args.add_metadata,
                     metadata_sources=args.metadata_sources,
+                    ignore_incomplete_rgp=args.ignore_incomplete_rgp
                 )
             )
     if A == 2:

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -1,32 +1,33 @@
 #!/usr/bin/env python3
 
 # default libraries
-import logging
 import argparse
 import json
-from itertools import combinations
-from collections.abc import Callable
+import logging
+import typing as tp
 from collections import defaultdict
-from typing import Dict, List, Set, Union
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from itertools import combinations
 from pathlib import Path
+from typing import Dict, List, Set, Union
+
+import networkx as nx
+import pandas as pd
+from pyroaring import BitMap
 
 # installed libraries
 from tqdm import tqdm
-import networkx as nx
-import pandas as pd
 
-# local libraries
-from ppanggolin.region import Region, Spot, Module
-from ppanggolin.utils import restricted_float, mk_outdir
+from ppanggolin.formats.h5reader import H5Reader, TableAttribute
 from ppanggolin.geneFamily import GeneFamily
 
-import typing as tp
-from dataclasses import dataclass, field
-from pyroaring import BitMap
-from ppanggolin.formats.h5reader import H5Reader, TableAttribute
+# local libraries
+from ppanggolin.utils import mk_outdir, restricted_float
 
 
 class RegionProxy:
+    """Represent a single RGP or a merged group of identical RGPs in the clustering graph."""
 
     def __init__(
         self,
@@ -41,6 +42,19 @@ class RegionProxy:
         organism=None,
         length=0,
     ):
+        """Initialize the proxy with the RGP identity and family content.
+
+        :param ID: Stable identifier used in the graph and output tables.
+        :param name: Name of the region or identical-group label.
+        :param families: BitMap of family identifiers present in the RGP.
+        :param is_contig_border: Whether the region touches a contig border.
+        :param is_whole_contig: Whether the region spans the whole contig.
+        :param children: Child RGP proxies for merged identical regions.
+        :param modules: Module identifiers associated with the RGP.
+        :param contig: Contig name associated with the region.
+        :param organism: Organism name associated with the region.
+        :param length: Number of genes in the region.
+        """
         self.ID: int = ID
         self.name: str = name
         self.families: BitMap = families
@@ -62,21 +76,42 @@ class RegionProxy:
 
     @property
     def is_identical_region(self) -> bool:
+        """Whether this region proxy represents a merged group of identical RGPs.
+
+        :return: True when the proxy stores multiple child regions.
+        """
         return self.children is not None and len(self.children) > 0
 
     def __repr__(self):
+        """Return a compact representation of the proxy for debugging.
+
+        :return: Debug-friendly representation of the region proxy.
+        """
         return f"RegionProxy2(ID={self.ID}, name='{self.name}')"
 
     def __str__(self):
+        """Return the region name.
+
+        :return: Human-readable name of the region.
+        """
         return self.name
 
     def __hash__(self) -> int:
+        """Hash the proxy using a stable region identifier.
+
+        :return: Hash value derived from the region ID.
+        """
         # Hash on the stable, deterministically-assigned ID rather than id(self):
         # object addresses vary between runs and make set/dict iteration order
         # (and therefore graph construction order) non-reproducible.
         return hash(self.ID)
 
     def __eq__(self, rhs: "RegionProxy") -> bool:
+        """Check whether two region proxies describe the same content.
+
+        :param rhs: Other region proxy to compare against.
+        :return: Whether the two proxies are equivalent.
+        """
         return (
             self.families == rhs.families
             and self.children == rhs.children
@@ -84,20 +119,42 @@ class RegionProxy:
         )
 
     def __lt__(self, obj):
+        """Compare regions by their stable identifier.
+
+        :param obj: Other region proxy.
+        :return: Whether this region comes before the other one.
+        """
         return self.ID < obj.ID
 
     def __gt__(self, obj):
+        """Compare regions by their stable identifier.
+
+        :param obj: Other region proxy.
+        :return: Whether this region comes after the other one.
+        """
         return self.ID > obj.ID
 
     def __le__(self, obj):
+        """Compare regions by their stable identifier.
+
+        :param obj: Other region proxy.
+        :return: Whether this region is less than or equal to the other one.
+        """
         return self.ID <= obj.ID
 
     def __ge__(self, obj):
+        """Compare regions by their stable identifier.
+
+        :param obj: Other region proxy.
+        :return: Whether this region is greater than or equal to the other one.
+        """
         return self.ID >= obj.ID
 
 
 @dataclass
 class RGPTable:
+    """Schema for the RGP membership table stored in the HDF5 file."""
+
     rgp: tp.Annotated[
         str, TableAttribute(name="RGP", transform=lambda x: x.decode("utf-8"))
     ]
@@ -109,6 +166,8 @@ class RGPTable:
 
 @dataclass
 class GeneFamTable:
+    """Schema for the gene-to-family table stored in the HDF5 file."""
+
     gene: tp.Annotated[
         str, TableAttribute(name="gene", transform=lambda x: x.decode("utf-8"))
     ]
@@ -120,6 +179,8 @@ class GeneFamTable:
 
 @dataclass
 class AnnotationsGeneTable:
+    """Schema for the annotations gene table used to map genes to contigs."""
+
     name: tp.Annotated[
         str, TableAttribute(name="ID", transform=lambda x: x.decode("utf-8"))
     ]
@@ -129,6 +190,8 @@ class AnnotationsGeneTable:
 
 @dataclass
 class RGPSpotTable:
+    """Schema for the RGP-to-spot assignment table."""
+
     rgp: tp.Annotated[
         str, TableAttribute(name="RGP", transform=lambda x: x.decode("utf-8"))
     ]
@@ -138,6 +201,8 @@ class RGPSpotTable:
 
 @dataclass
 class ModuleTable:
+    """Schema for the family-to-module membership table."""
+
     fam: tp.Annotated[
         str, TableAttribute(name="geneFam", transform=lambda x: x.decode("utf-8"))
     ]
@@ -147,6 +212,8 @@ class ModuleTable:
 
 @dataclass
 class ContigTable:
+    """Schema for contig metadata stored in the HDF5 pangenome."""
+
     genome: tp.Annotated[
         str, TableAttribute(name="genome", transform=lambda x: x.decode("utf-8"))
     ]
@@ -160,6 +227,8 @@ class ContigTable:
 
 @dataclass
 class GenesTable:
+    """Schema for the gene annotations table used to resolve contig membership."""
+
     name: tp.Annotated[
         str, TableAttribute(name="ID", transform=lambda x: x.decode("utf-8"))
     ]
@@ -170,6 +239,8 @@ class GenesTable:
 
 @dataclass
 class GeneDataTable:
+    """Schema for the per-gene coordinate table used in contig border logic."""
+
     # gene_type: tp.Annotated[str, TableAttribute(name="gene_type", transform=lambda x: x.decode('utf-8'))]
     idx: tp.Annotated[int, TableAttribute(name="genedata_id")]
     start: tp.Annotated[int, TableAttribute(name="start")]
@@ -180,6 +251,8 @@ class GeneDataTable:
 
 @dataclass
 class RGPGeneProxy:
+    """Store the coordinate information of a gene within an RGP."""
+
     start: int
     stop: int
     position: int
@@ -187,6 +260,8 @@ class RGPGeneProxy:
 
 @dataclass
 class RGPGenes:
+    """Bundle contig-level information for a set of genes belonging to an RGP."""
+
     contig: int
     is_circular_contig: bool
     genes: list[RGPGeneProxy]
@@ -194,6 +269,8 @@ class RGPGenes:
 
 @dataclass
 class RGPInfo:
+    """In-memory summary of an RGP before building graph nodes."""
+
     name: str
     families: set[str]
     families_ids: BitMap
@@ -204,6 +281,8 @@ class RGPInfo:
 
 @dataclass
 class ContigBorderPosition:
+    """Store the first and last gene coordinates on a contig."""
+
     last_gene_position: int
     last_gene_idx: int
     first_gene_idx: int
@@ -213,6 +292,8 @@ class ContigBorderPosition:
 
 @dataclass
 class ContigBorderGenes:
+    """Store the first and last gene names for a contig used in border checks."""
+
     first_gene: str
     last_gene: str
     gene_count: int
@@ -220,6 +301,8 @@ class ContigBorderGenes:
 
 @dataclass
 class RGPMetric:
+    """Store the computed similarity metric between two regions."""
+
     max_grr: float
     min_grr: float
     incomplete_aware_grr: float
@@ -228,6 +311,8 @@ class RGPMetric:
 
 @dataclass
 class Contig:
+    """Basic metadata describing a contig referenced by the clustering analysis."""
+
     organism: str
     is_circular: bool
     idx: int
@@ -239,6 +324,8 @@ RGPMetricType = tp.Literal["max_grr", "min_grr", "incomplete_aware_grr"]
 
 @dataclass
 class RGPClusteringOptions:
+    """Configuration values controlling the RGP clustering workflow."""
+
     grr_cutoff: float = 0.3
     metric: RGPMetricType = "incomplete_aware_grr"
     unmerge_identical_rgps: bool = True
@@ -252,7 +339,13 @@ class RGPClusteringOptions:
 
 
 class RGPClustering:
+    """Load RGP data from an HDF5 pangenome and cluster regions by family content."""
+
     def __init__(self, pangenome_h5: Path):
+        """Initialize an RGP clustering analysis for a pangenome file.
+
+        :param pangenome_h5: Path to the pangenome HDF5 file.
+        """
         self.h5 = Path(pangenome_h5)
         self.rgps: set[RegionProxy] = set()
         self.metrics: list[RGPMetric] = []
@@ -275,24 +368,44 @@ class RGPClustering:
         self._module_metadata_sources: Dict[int, set] = defaultdict(set)
 
     def _get_rgp_spot(self, reader: H5Reader) -> dict[str, int]:
+        """Load the mapping between each RGP and its associated spot.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :return: Dictionary mapping every RGP name to its spot identifier.
+        """
         rgp_to_spot: dict[str, int] = {}
         for table in reader.fetch(RGPSpotTable):
             rgp_to_spot[table.rgp] = table.spot
         return rgp_to_spot
 
     def _get_fam_to_modules(self, reader: H5Reader) -> dict[str, set[str]]:
+        """Load the mapping from each gene family to the modules containing it.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :return: Dictionary from family name to set of module identifiers.
+        """
         fam_to_modules: dict[str, set[str]] = defaultdict(set)
         for table in reader.fetch(ModuleTable):
             fam_to_modules[table.fam].add(table.module)
         return fam_to_modules
 
     def _get_contig_to_organism(self, reader: H5Reader) -> dict[str, str]:
+        """Map contig names to their associated genome names.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :return: Dictionary mapping each contig name to its organism name.
+        """
         contig_to_organism: dict[str, str] = {}
         for table in reader.fetch(ContigTable):
             contig_to_organism[table.contig] = table.genome
         return contig_to_organism
 
     def _get_contig_to_is_circular(self, reader: H5Reader) -> dict[str, bool]:
+        """Map contig identifiers to their circularity metadata.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :return: Dictionary mapping each contig identifier to whether it is circular.
+        """
         circular_contig_ids: dict[str, bool] = {}
         for table in reader.fetch(ContigTable):
             circular_contig_ids[table.idx] = table.is_circular
@@ -301,6 +414,12 @@ class RGPClustering:
     def _get_contig_to_info(
         self, reader: H5Reader, contigs_to_keep: set[str] = None
     ) -> dict[str, Contig]:
+        """Load contig metadata for the contigs involved in RGP analysis.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :param contigs_to_keep: Optional subset of contig names to keep.
+        :return: Mapping from contig name to Contig metadata records.
+        """
 
         contig_to_info: dict[str, Contig] = {}
         for table in reader.fetch(ContigTable):
@@ -315,6 +434,13 @@ class RGPClustering:
         return contig_to_info
 
     def _fetch_required_table(self, reader: H5Reader, table_type):
+        """Fetch a required table from the HDF5 file and convert missing-table errors.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :param table_type: Dataclass schema describing the table to read.
+        :raises ValueError: If the table does not exist in the file.
+        :return: Iterator over rows from the requested table.
+        """
         try:
             return reader.fetch(table_type)
         except KeyError as e:
@@ -326,8 +452,10 @@ class RGPClustering:
     def _get_contig_border_genes(
         self, reader: H5Reader
     ) -> dict[str, ContigBorderPosition]:
-        """
-        Get contig information such as if it is circular, last gene position and last gene idx.
+        """Identify the first and last genes of each contig carrying RGPs.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :return: Mapping from contig name to its border gene information.
         """
 
         contig_ids_with_rgp = {
@@ -418,6 +546,11 @@ class RGPClustering:
         return contig_name_to_border_genes
 
     def _get_rgp_genes(self, reader: H5Reader) -> dict[str, set[str]]:
+        """Load the gene membership of each RGP from the HDF5 file.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :return: Mapping from each RGP name to the set of genes it contains.
+        """
         rgp_genes: dict[str, set[str]] = defaultdict(set)
 
         for table in reader.fetch(RGPTable):
@@ -428,9 +561,11 @@ class RGPClustering:
     def _get_metadata_sources(
         self, reader: H5Reader, metadata_sources: list[str] = None
     ) -> dict[str, list[str]]:
-        """
-        Get, per metatype, the list of metadata sources present in the pangenome file,
-        restricted to the requested sources (if any).
+        """List metadata sources available for each element type in the pangenome.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :param metadata_sources: Optional subset of allowed metadata sources.
+        :return: Mapping of metatype names to the filtered source list.
         """
         status_attrs = reader.handle.root.status._v_attrs
         if not (hasattr(status_attrs, "metadata") and status_attrs.metadata):
@@ -470,11 +605,14 @@ class RGPClustering:
         value_target: Dict[str, Dict[str, list]] = None,
         source_target: Dict[Union[str, int], set] = None,
     ) -> None:
-        """
-        Read a single metadata source table directly from the H5 file (lightweight, no
-        pangenome object creation), and accumulate either the raw values (for RGPs metadata,
-        which are written as node attributes) and/or the set of sources providing metadata
-        for each identifier (used for family/gene/module/spot presence flags).
+        """Read one metadata source table and accumulate its values or source flags.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :param metatype: Metadata element type, such as RGPs, genes, or families.
+        :param source: Name of the metadata source to read.
+        :param value_target: Optional mapping of identifiers to metadata value lists.
+        :param source_target: Optional mapping of identifiers to metadata source sets.
+        :return: None. The data is stored in the instance dictionaries.
         """
         table = reader.handle.get_node(f"/metadata/{metatype}/{source}")
 
@@ -498,9 +636,11 @@ class RGPClustering:
     def _load_metadata(
         self, reader: H5Reader, metadata_sources: list[str] = None
     ) -> None:
-        """
-        Load metadata directly from the H5 file, in the same lightweight way RGP info is
-        loaded (reading tables directly instead of building full pangenome objects).
+        """Load metadata from the HDF5 file into the clustering graph metadata stores.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :param metadata_sources: Optional subset of metadata sources to include.
+        :return: None. The metadata caches are updated on the instance.
         """
         metatype_to_sources = self._get_metadata_sources(reader, metadata_sources)
 
@@ -546,6 +686,12 @@ class RGPClustering:
         reader: H5Reader,
         rgp_with_genes: dict[str, set[str]],
     ) -> list[RGPInfo]:
+        """Build a compact RGP summary from each gene collection.
+
+        :param reader: H5Reader opened on the pangenome file.
+        :param rgp_with_genes: Mapping of each RGP name to the genes it contains.
+        :return: List of RGPInfo objects describing family content and contig status.
+        """
 
         contig_to_border_genes = self._get_contig_border_genes(reader)
 
@@ -615,6 +761,12 @@ class RGPClustering:
         return rgp_infos
 
     def _construct_single(self, idx: int, rgp: RGPInfo):
+        """Create a RegionProxy for a single RGP.
+
+        :param idx: Stable graph node identifier.
+        :param rgp: Summary of the RGP to transform into a proxy.
+        :return: RegionProxy for the single RGP.
+        """
         return RegionProxy(
             ID=idx,
             name=rgp.name,
@@ -632,10 +784,22 @@ class RGPClustering:
         )
 
     def _construct_single_and_add(self, idx: int, rgp: RGPInfo):
+        """Create and register a single-region node in the graph.
+
+        :param idx: Stable graph node identifier.
+        :param rgp: Summary of the RGP to add.
+        :return: None. The graph and rgps set are updated.
+        """
         self.graph.add_node(idx)
         self.rgps.add(self._construct_single(idx, rgp))
 
     def _construct_multiple(self, idx: int, rgps: list[RGPInfo]):
+        """Create a merged RegionProxy for identical RGPs.
+
+        :param idx: Stable graph node identifier for the merged region.
+        :param rgps: RGP summaries that share the same family content.
+        :return: RegionProxy representing the identical-group node.
+        """
         return RegionProxy(
             ID=idx,
             name=f"identical_rgps_{self.identical_regions}",
@@ -657,22 +821,49 @@ class RGPClustering:
         )
 
     def _construct_multiple_and_add(self, idx: int, rgps: list[RGPInfo]):
+        """Create and register a merged identical-region node.
+
+        :param idx: Stable graph node identifier.
+        :param rgps: Identical RGP summaries to merge.
+        :return: None. The graph and rgps collection are updated.
+        """
         self.rgps.add(self._construct_multiple(idx, rgps))
         self.graph.add_node(idx)
         self.identical_regions += 1
 
     def _construct_and_add(self, idx: int, rgps: list[RGPInfo]):
+        """Register a region as either a single node or a merged identical-group node.
+
+        :param idx: Stable graph node identifier.
+        :param rgps: One or more RGP summaries to add.
+        :return: None.
+        """
         if len(rgps) == 1:
             self._construct_single_and_add(idx, rgps[0])
         else:
             self._construct_multiple_and_add(idx, rgps)
 
     def _grr(self, b1: BitMap, b2: BitMap, mode: Callable) -> float:
+        """Compute the gene repertoire relatedness between two family sets.
+
+        :param b1: BitMap of families in the first region.
+        :param b2: BitMap of families in the second region.
+        :param mode: Callable used to choose the denominator (min or max).
+        :return: Jaccard-style similarity value between the two family sets.
+        """
         return len(b1 & b2) / mode(len(b1), len(b2))
 
     def _rgp_metric(
         self, r1: RegionProxy, r2: RegionProxy, grr_cutoff: float, metric: RGPMetricType
     ) -> RGPMetric:
+        """Compute the similarity metric used to connect two RGPs in the graph.
+
+        :param r1: First region proxy.
+        :param r2: Second region proxy.
+        :param grr_cutoff: Minimum required metric value for an edge to be retained.
+        :param metric: Name of the metric to evaluate.
+        :return: RGPMetric if the similarity exceeds the cutoff, otherwise None.
+        """
         if r1.is_contig_border or r2.is_contig_border:
             agrr = self._grr(r1.families, r2.families, min)
             max_grr = self._grr(r1.families, r2.families, max)
@@ -691,6 +882,13 @@ class RGPClustering:
         metadata_sources: list[str] = None,
         ignore_incomplete_rgp: bool = False,
     ):
+        """Load all RGPs from disk and assemble graph nodes before clustering.
+
+        :param with_metadata: Whether metadata should be attached to the graph.
+        :param metadata_sources: Optional list of metadata sources to include.
+        :param ignore_incomplete_rgp: Whether edge-border RGPs should be filtered out.
+        :return: None. The graph content and RGP cache are populated.
+        """
         logging.getLogger("PPanGGOLiN").info("Loading RGPs from pangenome H5 file")
 
         with H5Reader(self.h5) as reader:
@@ -743,7 +941,13 @@ class RGPClustering:
     def _compute_all_metrics(
         self, grr_cutoff: float, metric: RGPMetricType, disable_bar: bool = False
     ):
-        """Compute metrics without materializing the set of candidate pairs."""
+        """Compute RGP-to-RGP similarity metrics and retain edges above the threshold.
+
+        :param grr_cutoff: Minimum similarity required to keep an edge.
+        :param metric: Metric name used to decide edge retention.
+        :param disable_bar: Whether to silence the progress bar.
+        :return: None. The graph edges are updated in place.
+        """
         logging.getLogger("PPanGGOLiN").info("Computing RGP metrics")
 
         family_to_rgps = defaultdict(list)
@@ -778,6 +982,11 @@ class RGPClustering:
         )
 
     def _louvain_clustering(self, metric: RGPMetricType):
+        """Cluster the RGP graph using the Louvain method.
+
+        :param metric: Similarity metric to use as the graph edge weight.
+        :return: None. Cluster labels are attached to graph nodes.
+        """
         logging.getLogger("PPanGGOLiN").info(
             f"Clustering RGPs using Louvain communities on '{metric}' metric"
         )
@@ -802,6 +1011,10 @@ class RGPClustering:
         )
 
     def _add_edges_to_identical_rgps(self):
+        """Expand merged identical-region nodes into their child RGP nodes and edges.
+
+        :return: None. The graph is updated to include both children and the original group.
+        """
         logging.getLogger("PPanGGOLiN").info("Unmerging identical RGPs in the graph")
 
         unmerged = 0
@@ -836,6 +1049,11 @@ class RGPClustering:
         logging.getLogger("PPanGGOLiN").info(f"Unmerged {unmerged} identical RGPs")
 
     def _spot_id(self, rgp: RegionProxy) -> str:
+        """Return the human-readable spot identifier for an RGP.
+
+        :param rgp: Region proxy to inspect.
+        :return: Spot label in the form 'spot_X' or 'No spot'.
+        """
         if rgp.name in self._rgp_to_spot:
             return f"spot_{self._rgp_to_spot[rgp.name]}"
         else:
@@ -848,10 +1066,13 @@ class RGPClustering:
         families_ids: BitMap,
         module_ids: Set[int],
     ) -> None:
-        """
-        Add metadata-derived attributes to a node info dict: booleans indicating whether
-        family/gene/module/spot metadata is present from a given source, and the RGP's own
-        metadata fields.
+        """Append metadata-derived attributes to an RGP node description.
+
+        :param info: Dictionary storing node attributes to enrich.
+        :param rgp_names: Names of the RGPs to inspect for metadata.
+        :param families_ids: Family identifiers contributing to the metadata summary.
+        :param module_ids: Module identifiers contributing to the metadata summary.
+        :return: None. The info dictionary is modified in place.
         """
         if not self._has_metadata:
             return
@@ -908,6 +1129,11 @@ class RGPClustering:
             info[key] = json.dumps(values)
 
     def _make_info_identical_rgp(self, rgp: RegionProxy) -> dict:
+        """Build the attribute dictionary for a merged identical-RGP group node.
+
+        :param rgp: Region proxy representing identical child RGPs.
+        :return: Dictionary of node attributes for output tables and graph exports.
+        """
 
         spots = {self._spot_id(child) for child in rgp.children}
 
@@ -916,7 +1142,9 @@ class RGPClustering:
             "name": rgp.name,
             "families_count": len(rgp.families),
             "identical_rgp_count": len(rgp.children),
-            "identical_rgp_names": ";".join(sorted(child.name for child in rgp.children)),
+            "identical_rgp_names": ";".join(
+                sorted(child.name for child in rgp.children)
+            ),
             "identical_rgp_genomes": ";".join(
                 ";".join(sorted({child.organism for child in rgp.children}))
             ),
@@ -941,6 +1169,11 @@ class RGPClustering:
         return info
 
     def _make_info_from_rgp(self, rgp: RegionProxy) -> dict:
+        """Build the attribute dictionary for a single RGP node.
+
+        :param rgp: Region proxy representing a single RGP.
+        :return: Dictionary of node attributes for output tables and graph exports.
+        """
 
         info = {
             "contig": rgp.contig,
@@ -959,6 +1192,10 @@ class RGPClustering:
         return info
 
     def _add_info_to_rgps(self):
+        """Attach metadata and summary attributes to each graph node.
+
+        :return: None. Each node in the graph is updated with annotation fields.
+        """
 
         logging.getLogger("PPanGGOLiN").info("Adding info to RGPs in graph")
 
@@ -985,6 +1222,13 @@ class RGPClustering:
         logging.getLogger("PPanGGOLiN").info(f"Added info to {annotated} RGPs")
 
     def _write_graphs(self, output: Path, basename: str, graph_formats: list[str]):
+        """Write the computed graph to the selected output formats.
+
+        :param output: Output directory for the graph files.
+        :param basename: Basename used for the exported files.
+        :param graph_formats: Graph output formats to generate.
+        :return: None. Files are written on disk.
+        """
         if "gexf" in graph_formats:
             graph_filename = output / f"{basename}.gexf"
             logging.getLogger("PPanGGOLiN").info(
@@ -1000,6 +1244,13 @@ class RGPClustering:
             nx.write_graphml(self.graph, graph_filename)
 
     def _write_cluster_table(self, output: Path, basename: str, metric: str):
+        """Write cluster assignments to a TSV table.
+
+        :param output: Output directory for the TSV file.
+        :param basename: Basename used for the output file.
+        :param metric: Metric name used in the cluster attribute labels.
+        :return: None. The cluster table is written to disk.
+        """
         outfile = output / f"{basename}.tsv"
         rows = []
 
@@ -1046,10 +1297,23 @@ class RGPClustering:
     def _write_outputs(
         self, output: Path, basename: str, graph_formats: list[str], metric: str
     ):
+        """Write all clustering outputs for the current analysis.
+
+        :param output: Output directory for the exported files.
+        :param basename: Basename used for all generated files.
+        :param graph_formats: Output graph formats to generate.
+        :param metric: Metric name used in cluster labels.
+        :return: None. Output tables and graphs are written on disk.
+        """
         self._write_graphs(output, basename, graph_formats)
         self._write_cluster_table(output, basename, metric)
 
     def run(self, options: RGPClusteringOptions):
+        """Run the full RGP clustering workflow from HDF5 loading to output writing.
+
+        :param options: Configuration parameters for the clustering process.
+        :return: None. The graph and output files are generated in place.
+        """
 
         self._construct_regions(
             with_metadata=options.with_metadata,
@@ -1074,14 +1338,18 @@ class RGPClustering:
 
     @property
     def rgp_count(self) -> int:
+        """Return the number of unique RGP proxies held in memory.
+
+        :return: Count of loaded RGP entries.
+        """
         return len(self.rgps)
 
 
 def launch(args: argparse.Namespace):
-    """
-    Command launcher
+    """Command launcher for the RGP clustering workflow.
 
-    :param args: All arguments provided by user
+    :param args: All arguments provided by the user on the command line.
+    :return: None. The clustering workflow is executed in place.
     """
 
     mk_outdir(args.output, args.force)
@@ -1109,12 +1377,10 @@ def launch(args: argparse.Namespace):
 
 
 def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
-    """
-    Subparser to launch PPanGGOLiN in Command line
+    """Create the command-line subparser for the RGP clustering command.
 
-    :param sub_parser : Sub_parser for cluster_rgp command
-
-    :return : Parser arguments for cluster_rgp command
+    :param sub_parser: Argument parser collection that receives the new subcommand.
+    :return: The configured argument parser for the RGP clustering command.
     """
     parser = sub_parser.add_parser(
         "rgp_cluster", formatter_class=argparse.RawTextHelpFormatter
@@ -1126,10 +1392,10 @@ def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser
 
 
 def parser_cluster_rgp(parser: argparse.ArgumentParser):
-    """
-    Parser for specific argument of rgp command
+    """Define all CLI arguments for the RGP clustering command.
 
-    :param parser: Parser for cluster_rgp argument
+    :param parser: Argument parser instance to enrich with clustering options.
+    :return: None. The passed parser is updated in place.
     """
     required = parser.add_argument_group(
         title="Required arguments",

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -248,6 +248,20 @@ class RGPClustering:
         self._spot_metadata_sources: Dict[int, set] = defaultdict(set)
         self._module_metadata_sources: Dict[int, set] = defaultdict(set)
 
+    def _check_required_status(
+        self,
+        status: dict,
+        required_statuses: dict[str, str],
+    ):
+        """Check that all required pangenome information is available in the H5 file."""
+
+        for status_name, description in required_statuses.items():
+            if status.get(status_name) != "inFile":
+                raise ValueError(
+                    f"Cannot compute RGP metrics: {description} is not available "
+                    "in the pangenome H5 file."
+                )
+            
     def _get_rgp_spot(self, reader: H5Reader) -> dict[str, int]:
         rgp_to_spot: dict[str, int] = {}
         for table in reader.fetch(RGPSpotTable):
@@ -287,7 +301,16 @@ class RGPClustering:
                 )
 
         return contig_to_info
-
+        
+    def _fetch_required_table(self, reader: H5Reader, table_type):
+        try:
+            return reader.fetch(table_type)
+        except KeyError as e:
+            raise ValueError(
+                f"Required table '{table_type.__name__}' is missing from the "
+                "pangenome H5 file."
+            ) from e
+        
     def _get_contig_border_genes(
         self, reader: H5Reader
     ) -> dict[str, ContigBorderPosition]:
@@ -1008,12 +1031,6 @@ class RGPClustering:
         self._write_cluster_table(output, basename, metric)
 
     def run(self, options: RGPClusteringOptions):
-
-        # Get initial memory
-        # rss_start = (
-        #     resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        # )  # Convert to MB (on Linux, ru_maxrss is in KB)
-        # logging.info(f"Memory at start: RSS peak={rss_start:.2f} MB")
 
         with Timer("_construct_regions", logging):
             self._construct_regions(

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -740,6 +740,8 @@ class RGPClustering:
         logging.getLogger("PPanGGOLiN").info(
             f"{len(rgp_infos)} RGPs loaded from pangenome ({len(self.rgps)} unique RGPs after dereplication)"
         )
+        if len(rgp_infos) == 0:
+            logging.getLogger("PPanGGOLiN").warning("Pangenome contains no RGPs. Output files will be empty.")
 
     def _compute_all_metrics(
         self, grr_cutoff: float, metric: RGPMetricType, disable_bar: bool = False
@@ -796,7 +798,7 @@ class RGPClustering:
                 name=f"{metric}_cluster",
             )
 
-        logging.getLogger("PPanGGOLiN").info(f"Graph has {len(ordered_partitions)} clusters using '{metric}'")
+        logging.getLogger("PPanGGOLiN").info(f"Graph has {len(ordered_partitions)} RGP clusters using '{metric}'")
 
     def _add_edges_to_identical_rgps(self):
         logging.getLogger("PPanGGOLiN").info("Unmerging identical RGPs in the graph")

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -49,7 +49,7 @@ class RegionProxy:
         self.name: str = name
         self.families: BitMap = families
         self.children: set[RegionProxy] = children
-        self.modules: set[int] = modules
+        self.modules: set[int] = set(modules) if modules is not None else set()
 
         if self.children:
             self.organism: str = next(iter(self.children)).organism
@@ -547,7 +547,9 @@ class RGPClustering:
             if m := self._rgp_metric(r1, r2, grr_cutoff, metric):
                 self.metrics.append(m)
                 self.graph.add_edge(r1.ID, r2.ID, **m.__dict__)
-        logging.info(f"RGP metrics computed for {nb_pairs:,} pairs of RGPs ({len(self.metrics)} selected after GRR cutoff)")
+        logging.info(
+            f"RGP metrics computed for {nb_pairs:,} pairs of RGPs ({len(self.metrics)} selected after GRR cutoff)"
+        )
 
     def _louvain_clustering(self, metric: RGPMetricType):
         logging.info(f"Clustering RGPs using Louvain communities on '{metric}' metric")
@@ -555,14 +557,19 @@ class RGPClustering:
         partitions = nx.algorithms.community.louvain_communities(
             self.graph, weight=metric
         )
-        for i, nodes in enumerate(partitions):
+        ordered_partitions = sorted(
+            partitions,
+            key=lambda nodes: (min(nodes), len(nodes)),
+        )
+
+        for i, nodes in enumerate(ordered_partitions):
             nx.set_node_attributes(
                 self.graph,
                 {node: f"cluster_{i}" for node in nodes},
                 name=f"{metric}_cluster",
             )
 
-        logging.info(f"Graph has {len(partitions)} clusters using '{metric}'")
+        logging.info(f"Graph has {len(ordered_partitions)} clusters using '{metric}'")
 
     def _add_edges_to_identical_rgps(self):
         logging.info("Unmerging identical RGPs in the graph")
@@ -582,20 +589,16 @@ class RGPClustering:
             unmerged += 1
             self.graph.add_nodes_from(
                 (child.ID for child in rgp.children),
-                identical_rcp_group=rgp.name,
+                identical_rgp_group=rgp.name,
             )
 
             edges = [
-                (r1.ID, r2.ID, edge_data)
-                for r1, r2 in combinations(rgp.children, 2)
+                (r1.ID, r2.ID, edge_data) for r1, r2 in combinations(rgp.children, 2)
             ]
 
             for connected in self.graph.neighbors(rgp.ID):
                 data = self.graph[rgp.ID][connected]
-                edges += [
-                    (child.ID, connected, data)
-                    for child in rgp.children
-                ]
+                edges += [(child.ID, connected, data) for child in rgp.children]
 
             self.graph.add_edges_from(edges)
             self.graph.remove_node(rgp.ID)
@@ -608,41 +611,34 @@ class RGPClustering:
         else:
             return "No spot"
 
-    def _add_info_to_identical_rgps(self):
-        logging.info("Adding info to identical RGPs in graph")
+    def _make_info_identical_rgp(self, rgp: RegionProxy) -> dict:
 
-        identical = 0
-        for rgp in self.rgps:
-            if not rgp.is_identical_region:
-                continue
+        spots = {self._spot_id(child) for child in rgp.children}
 
-            identical += 1
-            spots = {self._spot_id(child) for child in rgp.children}
-
-            self.graph.nodes[rgp.ID].update({
-                "identical_rgp_group": True,
-                "name": rgp.name,
-                "families_count": len(rgp.families),
-                "identical_rgp_count": len(rgp.children),
-                "identical_rgp_names": ";".join(child.name for child in rgp.children),
-                "identical_rgp_contig_border_count": len(
-                    [True for child in rgp.children if child.is_contig_border]
-                ),
-                "identical_rgp_whole_contig_count": len(
-                    [True for child in rgp.children if child.is_whole_contig]
-                ),
-                "identical_rgp_spots": ";".join(spots),
-                "spot_id": (
-                    spots.pop()
-                    if len(spots) == 1
-                    else "Multiple spots"
-                ),
-                "modules": ",".join(str(module) for module in rgp.modules),
-            })
-
-        logging.info(f"Added info to {identical} identical RGPs")
+        return {
+            "identical_rgp_group": True,
+            "name": rgp.name,
+            "families_count": len(rgp.families),
+            "identical_rgp_count": len(rgp.children),
+            "identical_rgp_names": ";".join(
+                child.name for child in rgp.children
+            ),
+            "identical_rgp_genomes": ";".join(
+                {child.organism for child in rgp.children}
+            ),
+            "identical_rgp_contig_border_count": len(
+                [True for child in rgp.children if child.is_contig_border]
+            ),
+            "identical_rgp_whole_contig_count": len(
+                [True for child in rgp.children if child.is_whole_contig]
+            ),
+            "identical_rgp_spots": ";".join(spots),
+            "spot_id": (spots.pop() if len(spots) == 1 else "Multiple spots"),
+            "modules": ";".join(f"module_{module}" for module in rgp.modules),
+            }
 
     def _make_info_from_rgp(self, rgp: RegionProxy) -> dict:
+
         return {
             "contig": rgp.contig,
             "genome": rgp.organism,
@@ -651,22 +647,32 @@ class RGPClustering:
             "is_contig_border": rgp.is_contig_border,
             "is_whole_contig": rgp.is_whole_contig,
             "spot_id": self._spot_id(rgp),
-            "modules": ";".join(str(module) for module in rgp.modules),
+            "modules": ";".join(f"module_{module}" for module in rgp.modules),
             "families_count": rgp.nb_families,
         }
 
     def _add_info_to_rgps(self):
+
         logging.info("Adding info to RGPs in graph")
+
         annotated = 0
         for rgp in self.rgps:
+
             if rgp.ID in self.graph:
-                self.graph.nodes[rgp.ID].update(self._make_info_from_rgp(rgp))
+                if rgp.is_identical_region:
+                    self.graph.nodes[rgp.ID].update(self._make_info_identical_rgp(rgp))
+
+                else:
+                    self.graph.nodes[rgp.ID].update(self._make_info_from_rgp(rgp))
+
                 annotated += 1
 
-            if rgp.children:
+            if rgp.children: # in case identical rgp are unmerged
                 for child in rgp.children:
                     if child.ID in self.graph:
-                        self.graph.nodes[child.ID].update(self._make_info_from_rgp(child))
+                        self.graph.nodes[child.ID].update(
+                            self._make_info_from_rgp(child)
+                        )
                         annotated += 1
 
         logging.info(f"Added info to {annotated} RGPs")
@@ -688,8 +694,53 @@ class RGPClustering:
             rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
             logging.info(f"Memory after writing GraphML: RSS peak={rss_peak:.2f} MB")
 
-    def _write_outputs(self, output: Path, basename: str, graph_formats: list[str]):
+    def _write_cluster_table(self, output: Path, basename: str, metric: str):
+        outfile = output / f"{basename}.tsv"
+        rows = []
+
+        for node, attrs in self.graph.nodes(data=True):
+            cluster = attrs.get(f"{metric}_cluster")
+            if cluster is None:
+                raise ValueError(
+                    f"Node {node} does not have a '{metric}_cluster' attribute"
+                )
+
+            name = attrs["name"]
+
+            if name.startswith("identical_rgps_"):
+                identical_rgp_names = attrs["identical_rgp_names"]
+
+                for child_name in identical_rgp_names.split(";"):
+                    rows.append(
+                        {
+                            "RGPs": child_name,
+                            "cluster": cluster,
+                            "spot_id": self._rgp_to_spot.get(child_name, "No spot"),
+                        }
+                    )
+            else:
+
+                rows.append(
+                    {
+                        "RGPs": attrs.get("name", str(node)),
+                        "cluster": cluster,
+                        "spot_id": attrs.get("spot_id", "No spot"),
+                    }
+                )
+
+        rows.sort(key=lambda row: (row["cluster"], row["RGPs"]))
+        pd.DataFrame(rows, columns=["RGPs", "cluster", "spot_id"]).to_csv(
+            outfile,
+            sep="\t",
+            index=False,
+        )
+        logging.info(f"Writing RGP clusters in TSV format to {outfile}")
+
+    def _write_outputs(
+        self, output: Path, basename: str, graph_formats: list[str], metric: str
+    ):
         self._write_graphs(output, basename, graph_formats)
+        self._write_cluster_table(output, basename, metric)
 
     def run(self, options: RGPClusteringOptions):
 
@@ -702,6 +753,12 @@ class RGPClustering:
         with Timer("_construct_regions", logging):
             self._construct_regions()
 
+        # print("NEW", ">" * 40)
+
+        # print(f"Constructed {len(self.rgps)} unique RGPs from pangenome")
+        # print(self.graph.number_of_nodes(), "nodes in graph")
+        # print(self.graph.number_of_edges(), "edges in graph")
+        # print("<" * 40)
         rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         logging.info(f"Memory after _construct_regions: RSS peak={rss_peak:.2f} MB")
 
@@ -717,8 +774,6 @@ class RGPClustering:
 
         if options.unmerge_identical_rgps:
             self._add_edges_to_identical_rgps()
-        else:
-            self._add_info_to_identical_rgps()
 
         rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         logging.info(
@@ -730,7 +785,9 @@ class RGPClustering:
         rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         logging.info(f"Memory after _add_info_to_rgps: RSS peak={rss_peak:.2f} MB")
 
-        self._write_outputs(options.output, options.basename, options.graph_formats)
+        self._write_outputs(
+            options.output, options.basename, options.graph_formats, options.metric
+        )
 
         rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         logging.info(f"Memory after _write_outputs: RSS peak={rss_peak:.2f} MB")
@@ -1068,7 +1125,9 @@ def add_info_to_identical_rgps(
                 if len(spots_of_identical_rgp_obj) == 1
                 else "Multiple spots"
             ),
-            modules=";".join({str(module) for module in identical_rgp_obj.modules}),
+            modules=";".join(
+                f"module_{module.ID}" for module in identical_rgp_obj.modules
+            ),
         )
 
 
@@ -1141,8 +1200,11 @@ def dereplicate_rgp(
     families_to_rgps = defaultdict(list)
 
     for rgp in tqdm(rgps, total=len(rgps), unit="RGP", disable=disable_bar):
-        families_to_rgps[tuple(sorted(f.ID for f in rgp.families))].append(rgp)
+        families_to_rgps[tuple(sorted(set(f.ID for f in rgp.families)))].append(rgp)
 
+    print(
+        f"{len(families_to_rgps)} unique family combinations found in {len(rgps)} RGPs"
+    )
     dereplicated_rgps = []
     identical_region_count = 0
     for rgps in families_to_rgps.values():
@@ -1218,12 +1280,15 @@ def cluster_rgp_on_grr(graph: nx.Graph, clustering_attribute: str = "grr"):
     partitions = nx.algorithms.community.louvain_communities(
         graph, weight=clustering_attribute
     )
+    ordered_partitions = sorted(
+        partitions,
+        key=lambda nodes: (min(nodes), len(nodes)),
+    )
 
-    # Add partition index in node attributes
-    for i, cluster_nodes in enumerate(partitions):
+    for i, nodes in enumerate(ordered_partitions):
         nx.set_node_attributes(
             graph,
-            {node: f"cluster_{i}" for node in cluster_nodes},
+            {node: f"cluster_{i}" for node in nodes},
             name=f"{clustering_attribute}_cluster",
         )
 
@@ -1390,6 +1455,11 @@ def cluster_rgp(
     grr_graph = nx.Graph()
     grr_graph.add_nodes_from(rgp.ID for rgp in dereplicated_rgps)
 
+    print("OLD", ">" * 40)
+    print(f"Constructed {len(dereplicated_rgps)} unique RGPs from pangenome")
+    print(grr_graph.number_of_nodes(), "nodes in graph")
+    print(grr_graph.number_of_edges(), "edges in graph")
+    print("<" * 40)
     # Get all pairs of RGP that share at least one family
 
     family2rgp = defaultdict(set)
@@ -1487,6 +1557,8 @@ def launch(args: argparse.Namespace):
     pangenome = Pangenome()
 
     mk_outdir(args.output, args.force)
+    mk_outdir(args.output / "old", args.force)
+    mk_outdir(args.output / "new", args.force)
 
     pangenome.add_file(args.pangenome)
 
@@ -1497,7 +1569,7 @@ def launch(args: argparse.Namespace):
             cluster_rgp(
                 pangenome,
                 grr_cutoff=args.grr_cutoff,
-                output=args.output,
+                output=args.output / "old",
                 basename=args.basename,
                 ignore_incomplete_rgp=args.ignore_incomplete_rgp,
                 unmerge_identical_rgps=args.no_identical_rgp_merging,
@@ -1516,7 +1588,7 @@ def launch(args: argparse.Namespace):
                     unmerge_identical_rgps=args.no_identical_rgp_merging,
                     grr_cutoff=args.grr_cutoff,
                     metric=args.grr_metric,
-                    output=args.output,
+                    output=args.output / "new",
                     basename=args.basename,
                     graph_formats=args.graph_formats,
                     with_metadata=args.add_metadata,

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -222,6 +222,8 @@ class RGPClusteringOptions:
     with_metadata: bool = False
     metadata_sources: list[str] = field(default_factory=list)
     ignore_incomplete_rgp: bool = False
+    disable_prog_bar: bool = False
+    
 
 class RGPClustering:
     def __init__(self, pangenome_h5: Path):
@@ -681,7 +683,7 @@ class RGPClustering:
         )
 
     def _compute_all_metrics(
-        self, grr_cutoff: float, metric: RGPMetricType
+        self, grr_cutoff: float, metric: RGPMetricType, disable_bar: bool = False
     ):
         """Compute metrics without materializing the set of candidate pairs."""
         logging.info("Computing RGP metrics")
@@ -694,16 +696,19 @@ class RGPClustering:
                 family_to_rgps[family].append(rgp)
 
         nb_pairs = 0
-        for family in sorted(family_to_rgps):
-            for r1, r2 in combinations(family_to_rgps[family], 2):
-                shared_families = r1.families & r2.families
-                if family != next(iter(shared_families)):
-                    continue
+        
+        with tqdm(total=len(family_to_rgps), desc="Computing metrics", disable=disable_bar, bar_format="{desc}: {percentage:3.0f}%|{bar}") as pbar:
+            for family in sorted(family_to_rgps):
+                for r1, r2 in combinations(family_to_rgps[family], 2):
+                    shared_families = r1.families & r2.families
+                    if family != next(iter(shared_families)):
+                        continue
 
-                nb_pairs += 1
-                if m := self._rgp_metric(r1, r2, grr_cutoff, metric):
-                    self.metrics.append(m)
-                    self.graph.add_edge(r1.ID, r2.ID, **m.__dict__)
+                    nb_pairs += 1
+                    if m := self._rgp_metric(r1, r2, grr_cutoff, metric):
+                        self.metrics.append(m)
+                        self.graph.add_edge(r1.ID, r2.ID, **m.__dict__)
+                pbar.update(1)
 
         logging.info(
             f"RGP metrics computed for {nb_pairs:,} pairs of RGPs "
@@ -772,7 +777,7 @@ class RGPClustering:
         for rgp in self.rgps:
             if not rgp.is_identical_region:
                 continue
-
+            
             unmerged += 1
             self.graph.add_nodes_from(
                 (child.ID for child in rgp.children),
@@ -1022,18 +1027,20 @@ class RGPClustering:
 
 
         with Timer('_compute_all_metrics', logging):
-            self._compute_all_metrics(options.grr_cutoff, options.metric)
+            self._compute_all_metrics(options.grr_cutoff, options.metric, disable_bar=options.disable_prog_bar)
         
         rss_peak_after_compute_all_metrics = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         logging.info(f"Memory after _compute_all_metrics: RSS peak={rss_peak_after_compute_all_metrics:.2f} MB")
+
+
+        if options.unmerge_identical_rgps:
+            self._add_edges_to_identical_rgps()
 
         self._louvain_clustering(options.metric)
 
         # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         # logging.info(f"Memory after _louvain_clustering: RSS peak={rss_peak:.2f} MB")
 
-        if options.unmerge_identical_rgps:
-            self._add_edges_to_identical_rgps()
 
         # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         # logging.info(
@@ -1870,52 +1877,11 @@ def launch(args: argparse.Namespace):
                     graph_formats=args.graph_formats,
                     with_metadata=args.add_metadata,
                     metadata_sources=args.metadata_sources,
-                    ignore_incomplete_rgp=args.ignore_incomplete_rgp
+                    ignore_incomplete_rgp=args.ignore_incomplete_rgp,
+                    disable_prog_bar=args.disable_prog_bar
                 )
             )
-    if A == 2:
-        # comparison of RGP between old and new implementation
-        rgp_name_to_rgp_proxy = {}
-        for rgp_proxy in clustering.rgps:
-            if rgp_proxy.children:
-                for child_rgp_proxy in rgp_proxy.children:
-                    rgp_name_to_rgp_proxy[child_rgp_proxy.name] = child_rgp_proxy
-            else:
-                rgp_name_to_rgp_proxy[rgp_proxy.name] = rgp_proxy
 
-        for region in pangenome.regions:
-            rgp_proxy = rgp_name_to_rgp_proxy[region.name]
-
-            # Log debug info when either region has is_contig_border=True or is_whole_contig=True
-            if region.is_contig_border or rgp_proxy.is_contig_border or region.is_whole_contig or rgp_proxy.is_whole_contig:
-                logging.debug(
-                    f"Comparing RGP: {region.name}\n"
-                    f"  Region object:\n"
-                    f"    - name: {region.name}\n"
-                    f"    - is_contig_border: {region.is_contig_border}\n"
-                    f"    - is_whole_contig: {region.is_whole_contig}\n"
-                    f"    - families count: {region.number_of_families}\n"
-                    f"    - genes count: {len(region)}\n"
-                    f"    - contig: {region.contig.name}\n"
-                    f"    - organism: {region.organism.name}\n"
-                    f"  RegionProxy object:\n"
-                    f"    - name: {rgp_proxy.name}\n"
-                    f"    - is_contig_border: {rgp_proxy.is_contig_border}\n"
-                    f"    - is_whole_contig: {rgp_proxy.is_whole_contig}\n"
-                    f"    - families count: {len(rgp_proxy.families)}\n"
-                    f"    - genes count: {rgp_proxy.length}\n"
-                    f"    - contig: {rgp_proxy.contig}\n"
-                    f"    - organism: {rgp_proxy.organism}"
-                )
-
-            if region.is_contig_border != rgp_proxy.is_contig_border:
-                logging.error(f"Mismatch in is_contig_border for RGP: {region.name}")
-
-            if region.is_whole_contig != rgp_proxy.is_whole_contig:
-                logging.error(f"Mismatch in is_whole_contig for RGP: {region.name}")
-
-            assert region.is_contig_border == rgp_proxy.is_contig_border, region.name
-            assert region.is_whole_contig == rgp_proxy.is_whole_contig, region.name
 
 
 def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser:

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -178,21 +178,21 @@ class GeneDataTable:
     _table: str = "/annotations/genedata"
 
 
-@dataclass
+@dataclass(slots=True)
 class RGPGeneProxy:
     start: int
     stop: int
     position: int
 
 
-@dataclass
+@dataclass(slots=True)
 class RGPGenes:
     contig: int
     is_circular_contig: bool
     genes: list[RGPGeneProxy]
 
 
-@dataclass
+@dataclass(slots=True)
 class RGPInfo:
     name: str
     families: set[str]
@@ -202,7 +202,7 @@ class RGPInfo:
     contig: str
 
 
-@dataclass
+@dataclass(slots=True)
 class ContigBorderPosition:
     last_gene_position: int
     last_gene_idx: int
@@ -211,14 +211,14 @@ class ContigBorderPosition:
     gene_count: int
 
 
-@dataclass
+@dataclass(slots=True)
 class ContigBorderGenes:
     first_gene: str
     last_gene: str
     gene_count: int
 
 
-@dataclass
+@dataclass(slots=False)
 class RGPMetric:
     max_grr: float
     min_grr: float
@@ -226,7 +226,7 @@ class RGPMetric:
     shared_family: int
 
 
-@dataclass
+@dataclass(slots=True)
 class Contig:
     organism: str
     is_circular: bool

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -555,8 +555,18 @@ class RGPClustering:
             rgp_name: len(genes) for rgp_name, genes in rgp_with_genes.items()
         }
 
+        genes_to_keep = {gene for genes in rgp_with_genes.values() for gene in genes}
+
         gene_to_family: dict[str, str] = {}
-        for table in reader.fetch(GeneFamTable):
+
+        for table in reader.fetch(
+            GeneFamTable,
+            override={
+                "gene": {
+                    "predicate": lambda x: x.decode("utf-8") in genes_to_keep,
+                }
+            },
+        ):
             gene_to_family[table.gene] = table.family
 
         # Sort before enumerating: iterating a set of strings depends on
@@ -688,7 +698,8 @@ class RGPClustering:
         with H5Reader(self.h5) as reader:
 
             rgp_to_genes = self._get_rgp_genes(reader)
-            self._rgp_to_genes = rgp_to_genes
+            if with_metadata:
+                self._rgp_to_genes = rgp_to_genes
 
             contigs_with_rgp = {rgp_name.split("_RGP_")[0] for rgp_name in rgp_to_genes}
 

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -178,21 +178,21 @@ class GeneDataTable:
     _table: str = "/annotations/genedata"
 
 
-@dataclass(slots=True)
+@dataclass
 class RGPGeneProxy:
     start: int
     stop: int
     position: int
 
 
-@dataclass(slots=True)
+@dataclass
 class RGPGenes:
     contig: int
     is_circular_contig: bool
     genes: list[RGPGeneProxy]
 
 
-@dataclass(slots=True)
+@dataclass
 class RGPInfo:
     name: str
     families: set[str]
@@ -202,7 +202,7 @@ class RGPInfo:
     contig: str
 
 
-@dataclass(slots=True)
+@dataclass
 class ContigBorderPosition:
     last_gene_position: int
     last_gene_idx: int
@@ -211,14 +211,14 @@ class ContigBorderPosition:
     gene_count: int
 
 
-@dataclass(slots=True)
+@dataclass
 class ContigBorderGenes:
     first_gene: str
     last_gene: str
     gene_count: int
 
 
-@dataclass(slots=False)
+@dataclass
 class RGPMetric:
     max_grr: float
     min_grr: float
@@ -226,7 +226,7 @@ class RGPMetric:
     shared_family: int
 
 
-@dataclass(slots=True)
+@dataclass
 class Contig:
     organism: str
     is_circular: bool

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -19,9 +19,478 @@ import pandas as pd
 from ppanggolin.pangenome import Pangenome
 from ppanggolin.region import Region, Spot, Module
 from ppanggolin.formats import check_pangenome_info
-from ppanggolin.utils import restricted_float, mk_outdir
+from ppanggolin.utils import restricted_float, mk_outdir, Timer
 from ppanggolin.geneFamily import GeneFamily
 
+import typing as tp
+from dataclasses import dataclass
+from pyroaring import BitMap
+from ppanggolin.formats.h5reader import H5Reader, TableAttribute
+
+class RegionProxy:
+    def __init__(self, ID: int, name: str, families: BitMap, *,
+                 children=None, modules=None, contig=None, organism=None, length=0):
+        self.ID: int = ID
+        self.name: str = name
+        self.families: BitMap = families
+        self.children: set[RegionProxy] = children
+        self.modules: set[int] = modules
+
+        if self.children:
+            self.organism: str = next(iter(self.children)).organism
+            self.contig: str = next(iter(self.children)).contig
+        else:
+            self.organism: str = organism
+            self.contig: str = contig
+
+        self.length: int = length
+        self.nb_families: int = len(self.families)
+        
+        # TODO
+        self.is_contig_border: bool = False
+        self.is_whole_contig: bool = False
+
+    @property
+    def is_identical_region(self) -> bool:
+        return self.children is not None and len(self.children) > 0
+    
+    def __repr__(self):
+        return f"RegionProxy2(ID={self.ID}, name='{self.name}')"
+    
+    def __str__(self):
+        return self.name
+    
+    def __hash__(self) -> int:
+        return id(self)
+    
+    def __eq__(self, rhs: "RegionProxy") -> bool:
+        return all(self.families == rhs.families,
+                   self.children == rhs.children,
+                   self.is_contig_border == rhs.is_contig_border)
+
+    def __lt__(self, obj):
+        return self.ID < obj.ID
+
+    def __gt__(self, obj):
+        return self.ID > obj.ID
+
+    def __le__(self, obj):
+        return self.ID <= obj.ID
+
+    def __ge__(self, obj):
+        return self.ID >= obj.ID
+    
+@dataclass
+class RGPTable:
+    rgp: tp.Annotated[str, TableAttribute(name="RGP", transform=lambda x: x.decode('utf-8'))]
+    gene: tp.Annotated[str, TableAttribute(name="gene", transform=lambda x: x.decode('utf-8'))]
+    _table: str = "/RGP"
+
+@dataclass
+class GeneFamTable:
+    gene: tp.Annotated[str, TableAttribute(name="gene", transform=lambda x: x.decode('utf-8'))]
+    family: tp.Annotated[str, TableAttribute(name="geneFam", transform=lambda x: x.decode('utf-8'))]
+    _table: str = "/geneFamilies"
+
+@dataclass
+class AnnotationsGeneTable:
+    name: tp.Annotated[str, TableAttribute(name="ID", transform=lambda x: x.decode('utf-8'))]
+    contig: tp.Annotated[int, TableAttribute(name="contig")]
+    _table: str = "/annotations/genes"
+
+@dataclass
+class RGPSpotTable:
+    rgp: tp.Annotated[str, TableAttribute(name="RGP", transform=lambda x: x.decode('utf-8'))]
+    spot: tp.Annotated[int, TableAttribute(name="spot")]
+    _table: str = "/spots"
+
+@dataclass
+class ModuleTable:
+    fam: tp.Annotated[str, TableAttribute(name="geneFam", transform=lambda x: x.decode('utf-8'))]
+    module: tp.Annotated[int, TableAttribute(name="module")]
+    _table: str = "/modules"
+
+@dataclass
+class ContigTable:
+    genome: tp.Annotated[str, TableAttribute(name="genome", transform=lambda x: x.decode('utf-8'))]
+    contig: tp.Annotated[str, TableAttribute(name="name", transform=lambda x: x.decode('utf-8'))]
+    is_circular: tp.Annotated[bool, TableAttribute(name="is_circular")]
+    idx: tp.Annotated[int, TableAttribute(name="ID")]
+    _table: str = "/annotations/contigs"
+
+@dataclass
+class GenesTable:
+    name: tp.Annotated[str, TableAttribute(name="ID", transform=lambda x: x.decode('utf-8'))]
+    genedata: tp.Annotated[int, TableAttribute(name="genedata_id")]
+    contig: tp.Annotated[int, TableAttribute(name="contig")]
+    _table: str = "/annotations/genes"
+
+@dataclass
+class GeneDataTable:
+    idx: tp.Annotated[int, TableAttribute(name="genedata_id")]
+    contig: tp.Annotated[int, TableAttribute(name="contig")]
+    start: tp.Annotated[int, TableAttribute(name="start")]
+    stop: tp.Annotated[int, TableAttribute(name="stop")]
+    position: tp.Annotated[int, TableAttribute(name="position")]
+    _table: str = "/annotations/genedata"
+
+@dataclass
+class RGPGeneProxy:
+    start: int
+    stop: int
+    position: int
+
+@dataclass
+class RGPGenes:
+    contig: int
+    is_circular_contig: bool   
+    genes: list[RGPGeneProxy] = []
+
+@dataclass
+class RGPMetric:
+    max_grr: float
+    min_grr: float
+    incomplete_aware_grr: float
+    shared_family: int
+
+RGPMetricType = tp.Literal["max_grr", "min_grr", "incomplete_aware_grr"]
+
+@dataclass
+class RGPClusteringOptions:
+    grr_cutoff: float = 0.3
+    metric: RGPMetricType = "incomplete_aware_grr"
+    unmerge_identical_rgps: bool = True
+    output: Path = Path("rgp_clustering")
+    basename: str = "rgp_cluster"
+    graph_formats: list[str] = ("gexf", "graphml")
+    with_metadata: bool = False
+    metadata_sources: list[str] = []
+    metadata_sep: str = "|"
+
+class RGPClustering:
+    def __init__(self, pangenome_h5: Path):
+        self.h5 = Path(pangenome_h5)
+        self.rgps: set[RegionProxy] = set()
+        self.metrics: list[RGPMetric] = []
+        self.identical_regions: int = 0
+        self.graph: nx.Graph = nx.Graph()
+        self._rgp_to_spot: dict[str, int] = None
+        self._fam_to_modules: dict[str, set[str]] = None
+        self._contig_to_organism: dict[str, str] = None
+        self._rgp_to_nb_genes: dict[str, int] = None
+    
+    def _get_rgp_spot(self, reader: H5Reader) -> dict[str, int]:
+        rgp_to_spot: dict[str, int] = {}
+        for table in reader.fetch(RGPSpotTable):
+            rgp_to_spot[table.rgp] = table.spot
+        return rgp_to_spot
+
+    def _get_fam_to_modules(self, reader: H5Reader) -> dict[str, set[str]]:
+        fam_to_modules: dict[str, set[str]] = defaultdict(set)
+        for table in reader.fetch(ModuleTable):
+            fam_to_modules[table.fam].add(table.module)
+        return fam_to_modules
+    
+    def _get_contig_to_organism(self, reader: H5Reader) -> dict[str, str]:
+        contig_to_organism: dict[str, str] = {}
+        for table in reader.fetch(ContigTable):
+            contig_to_organism[table.contig] = table.genome
+        return contig_to_organism
+    
+    def _get_rgp_genes(self, reader: H5Reader, all_rgp_genes: set[str], rgp_with_genes: dict[str, set[str]]) -> dict[str, RGPGenes]:
+        rgp_genes: dict[str, RGPGenes] = {}
+        override = {"name": {"predicate" : lambda x: x in all_rgp_genes}}
+        
+        genes: dict[str, tuple[int, int]] = {}
+        for table in reader.fetch(GenesTable, override):
+            genes[table.name] = (table.genedata, table.contig)
+
+        for rgp, rgenes in rgp_with_genes.items():
+            rgp_genes[rgp] = RGPGenes(
+                
+            )
+            
+
+
+    def _get_rgp_fam(self, reader: H5Reader) -> dict[str, set[tuple[str, int]]]:
+        rgp_with_genes: dict[str, set[str]] = defaultdict(set)
+        all_rgp_genes: set[str] = set()
+
+        for table in reader.fetch(RGPTable):
+            rgp_with_genes[table.rgp].add(table.gene)
+            all_rgp_genes.add(table.gene)
+
+        self._rgp_to_nb_genes: dict[str, int] = {
+            rgp_name: len(genes) for rgp_name, genes in rgp_with_genes.items()
+        }
+
+        gene_to_family: dict[str, str] = {}
+        for table in reader.fetch(GeneFamTable):
+            gene_to_family[table.gene] = table.family
+
+        unique_families = set(gene_to_family.values())
+        family_ids = {fam: idx for idx, fam in enumerate(unique_families)}
+        
+        rgp_with_fams = defaultdict(set)
+        for rgp_name, genes in rgp_with_genes.items():
+            for gene in genes:
+                fam = gene_to_family[gene]
+                fam_id = family_ids[fam]
+                rgp_with_fams[rgp_name].add((fam, fam_id))
+        
+        return rgp_with_fams
+    
+    def _construct_single(self, idx: int, rgp: tuple[str, set[tuple[str, int]]]):
+        contig = rgp[0].split("_RGP_")[0]
+        return RegionProxy(
+            ID=idx,
+            name=rgp[0],
+            families=BitMap(fam_id for _, fam_id in rgp[1]),
+            modules=BitMap(
+                module_id
+                for fam, _ in rgp[1]
+                for module_id in self._fam_to_modules.get(fam, [])
+            ),
+            contig=contig,
+            organism=self._contig_to_organism[contig],
+            length=self._rgp_to_nb_genes[rgp[0]],
+        )
+    
+    def _construct_single_and_add(self, idx: int, rgp: tuple[str, set[tuple[str, int]]]):
+        self.graph.add_node(idx)
+        self.rgps.add(self._construct_single(idx, rgp))
+
+    def _construct_multiple(self, idx: int, rgps: list[tuple[str, set[tuple[str, int]]]]):
+        return RegionProxy(
+            ID=idx,
+            name=f"identical_rgps_{self.identical_regions}",
+            families=BitMap(fam_id for _, fam_id in rgps[0][1]),
+            children=set(
+                self._construct_single(i, rgp)
+                for i, rgp in enumerate(rgps, start=idx + 1)
+            ),
+            modules=BitMap(
+                module_id
+                for fam, _ in rgps[0][1]
+                for module_id in self._fam_to_modules.get(fam, [])
+            ),
+            contig=self._contig_to_organism,
+        )
+    
+    def _construct_multiple_and_add(self, idx: int, rgps: list[tuple[str, set[tuple[str, int]]]]):
+        self.rgps.add(self._construct_multiple(idx, rgps))
+        self.graph.add_node(idx)
+        self.identical_regions += 1
+
+    def _construct_and_add(self, idx: int, rgps: list[tuple[str, set[tuple[str, int]]]]):
+        if len(rgps) == 1:
+            self._construct_single_and_add(idx, rgps[0])
+        else:
+            self._construct_multiple_and_add(idx, rgps)
+
+    def _grr(self, b1: BitMap, b2: BitMap, mode: Callable) -> float:
+        return len(b1 & b2) / mode(len(b1), len(b2))
+    
+    def _rgp_metric(self, r1: RegionProxy, r2: RegionProxy, grr_cutoff: float, metric: RGPMetricType) -> RGPMetric:
+        if r1.is_contig_border or r2.is_contig_border:
+            agrr = self._grr(r1.families, r2.families, min)
+            max_grr = self._grr(r1.families, r2.families, max)
+            min_grr = agrr
+        else:
+            agrr = self._grr(r1.families, r2.families, max)
+            min_grr = self._grr(r1.families, r2.families, min)
+            max_grr = agrr
+
+        m = RGPMetric(max_grr, min_grr, agrr, len(r1.families & r2.families))
+        return m if getattr(m, metric) >= grr_cutoff else None
+    
+    def _construct_regions(self):
+        logging.info("Loading RGPs from pangenome H5 file")
+
+        with H5Reader(self.h5) as reader:
+            rgp_with_fams = self._get_rgp_fam(reader)
+            self._rgp_to_spot = self._get_rgp_spot(reader)
+            self._fam_to_modules = self._get_fam_to_modules(reader)
+            self._contig_to_organism = self._get_contig_to_organism(reader)
+            fams_to_rgps = defaultdict(list)
+
+            for rgp_name, fams in rgp_with_fams.items():
+                fams_key = tuple(sorted(fam_id for _, fam_id in fams))
+                fams_to_rgps[fams_key].append((rgp_name, fams))
+
+            idx = 0
+            for rgps in fams_to_rgps.values():
+                self._construct_and_add(idx, rgps)
+                idx += len(rgps) + 1 if len(rgps) > 1 else 1
+
+        logging.info(f"{len(rgp_with_fams)} RGPs loaded from pangenome ({len(self.rgps)} unique RGPs after dereplication)")
+
+    def _compute_all_metrics(self, grr_cutoff: float, metric: RGPMetricType):
+        logging.info("Computing RGP metrics")
+        
+        nb_pairs = 0
+        for r1, r2 in combinations(self.rgps, 2):
+            if len(r1.families & r2.families) == 0:
+                continue
+        
+            nb_pairs += 1
+            if m := self._rgp_metric(r1, r2, grr_cutoff, metric):
+                self.metrics.append(m)
+                self.graph.add_edge(r1.ID, r2.ID, **m.__dict__)
+        logging.info(f"RGP metrics computed for {nb_pairs:,} pairs of RGPs ({len(self.metrics)} selected after GRR cutoff)")
+
+    def _louvain_clustering(self, metric: RGPMetricType):
+        logging.info(f"Clustering RGPs using Louvain communities on '{metric}' metric")
+        
+        partitions = nx.algorithms.community.louvain_communities(
+            self.graph, weight=metric
+        )
+        for i, nodes in enumerate(partitions):
+            nx.set_node_attributes(
+                self.graph,
+                {node: f"cluster_{i}" for node in nodes},
+                name=f"{metric}_cluster",
+            )
+        
+        logging.info(f"Graph has {len(partitions)} clusters using '{metric}'")
+
+    def _add_edges_to_identical_rgps(self):
+        logging.info("Unmerging identical RGPs in the graph")
+
+        unmerged = 0
+        edge_data = {
+            "max_grr": 1.0,
+            "min_grr": 1.0,
+            "grr": 1.0,
+            "identical_famillies": True,
+        }
+
+        for rgp in self.rgps:
+            if not rgp.is_identical_region:
+                continue
+
+            unmerged += 1
+            self.graph.add_nodes_from(
+                (child.ID for child in rgp.children),
+                identical_rcp_group=rgp.name,
+            )
+
+            edges = [
+                (r1.ID, r2.ID, edge_data)
+                for r1, r2 in combinations(rgp.children, 2)
+            ]
+
+            for connected in self.graph.neighbors(rgp.ID):
+                data = self.graph[rgp.ID][connected]
+                edges += [
+                    (child.ID, connected, data)
+                    for child in rgp.children
+                ]
+            
+            self.graph.add_edges_from(edges)
+            self.graph.remove_node(rgp.ID)
+        
+        logging.info(f"Unmerged {unmerged} identical RGPs")
+
+    def _spot_id(self, rgp: RegionProxy) -> str:
+        if rgp.name in self._rgp_to_spot:
+            return f"spot_{self._rgp_to_spot[rgp.name]}"
+        else:
+            return "No spot"
+        
+    def _add_info_to_identical_rgps(self):
+        logging.info("Adding info to identical RGPs in graph")
+
+        identical = 0
+        for rgp in self.rgps:
+            if not rgp.is_identical_region:
+                continue
+            
+            identical += 1
+            spots = {self._spot_id(child) for child in rgp.children}
+
+            self.graph.nodes[rgp.ID].update({
+                "identical_rgp_group": True,
+                "name": rgp.name,
+                "families_count": len(rgp.families),
+                "identical_rgp_count": len(rgp.children),
+                "identical_rgp_names": ";".join(child.name for child in rgp.children),
+                "identical_rgp_contig_border_count": len(
+                    [True for child in rgp.children if child.is_contig_border]
+                ),
+                "identical_rgp_whole_contig_count": len(
+                    [True for child in rgp.children if child.is_whole_contig]
+                ),
+                "identical_rgp_spots": ";".join(spots),
+                "spot_id": (
+                    spots.pop()
+                    if len(spots) == 1
+                    else "Multiple spots"
+                ),
+                "modules": ",".join(str(module) for module in rgp.modules),
+            })
+
+        logging.info(f"Added info to {identical} identical RGPs")
+
+    def _make_info_from_rgp(self, rgp: RegionProxy) -> dict:
+        return {
+            "contig": rgp.contig,
+            "genome": rgp.organism,
+            "name": rgp.name,
+            "genes_count": rgp.length,
+            "is_contig_border": rgp.is_contig_border,
+            "is_whole_contig": rgp.is_whole_contig,
+            "spot_id": self._spot_id(rgp),
+            "modules": ";".join(str(module) for module in rgp.modules),
+            "families_count": rgp.nb_families,
+        }
+    
+    def _add_info_to_rgps(self):
+        logging.info("Adding info to RGPs in graph")
+        annotated = 0
+        for rgp in self.rgps:
+            if rgp.ID in self.graph:
+                self.graph.nodes[rgp.ID].update(self._make_info_from_rgp(rgp))
+                annotated += 1
+            
+            if rgp.children:
+                for child in rgp.children:
+                    if child.ID in self.graph:
+                        self.graph.nodes[child.ID].update(self._make_info_from_rgp(child))
+                        annotated += 1
+
+        logging.info(f"Added info to {annotated} RGPs")
+
+    def _write_graphs(self, output: Path, basename: str, graph_formats: list[str]):
+        if "gexf" in graph_formats:
+            graph_filename = output / f"{basename}.gexf"
+            logging.info(f"Writing RGP graph in GEXF format to {graph_filename}")
+            nx.write_gexf(self.graph, graph_filename)
+        if "graphml" in graph_formats:
+            graph_filename = output / f"{basename}.graphml"
+            logging.info(f"Writing RGP graph in GraphML format to {graph_filename}")
+            nx.write_graphml(self.graph, graph_filename)
+    
+    def _write_outputs(self, output: Path, basename: str, graph_formats: list[str]):
+        self._write_graphs(output, basename, graph_formats)
+
+    def run(self, options: RGPClusteringOptions):
+        self._construct_regions()
+        self._compute_all_metrics(options.grr_cutoff, options.metric)
+        self._louvain_clustering(options.metric)
+        
+        if options.unmerge_identical_rgps:
+            self._add_edges_to_identical_rgps()
+        else:
+            self._add_info_to_identical_rgps()
+        
+        self._add_info_to_rgps()
+
+        self._write_outputs(options.output, options.basename, options.graph_formats)
+
+    @property
+    def rgp_count(self) -> int:
+        return len(self.rgps)
 
 class IdenticalRegions:
     """
@@ -491,7 +960,6 @@ def compute_rgp_metric(
     if edge_metrics[grr_metric] >= grr_cutoff:
         return rgp_a.ID, rgp_b.ID, edge_metrics
 
-
 def cluster_rgp_on_grr(graph: nx.Graph, clustering_attribute: str = "grr"):
     """
     Cluster rgp based on grr using louvain communities clustering.
@@ -702,7 +1170,6 @@ def cluster_rgp(
             pairs_of_rgps_metrics.append(pair_metrics)
 
     grr_graph.add_edges_from(pairs_of_rgps_metrics)
-
     identical_rgps_objects = [
         rgp for rgp in dereplicated_rgps if isinstance(rgp, IdenticalRegions)
     ]
@@ -776,20 +1243,40 @@ def launch(args: argparse.Namespace):
 
     pangenome.add_file(args.pangenome)
 
-    cluster_rgp(
-        pangenome,
-        grr_cutoff=args.grr_cutoff,
-        output=args.output,
-        basename=args.basename,
-        ignore_incomplete_rgp=args.ignore_incomplete_rgp,
-        unmerge_identical_rgps=args.no_identical_rgp_merging,
-        grr_metric=args.grr_metric,
-        disable_bar=args.disable_prog_bar,
-        graph_formats=args.graph_formats,
-        add_metadata=args.add_metadata,
-        metadata_sep=args.metadata_sep,
-        metadata_sources=args.metadata_sources,
-    )
+    A = int(os.environ.get("PPNEW"))
+
+    if A == 0 or A == 2:
+        with Timer("OLD", logging):
+            cluster_rgp(
+                pangenome,
+                grr_cutoff=args.grr_cutoff,
+                output=args.output,
+                basename=args.basename,
+                ignore_incomplete_rgp=args.ignore_incomplete_rgp,
+                unmerge_identical_rgps=args.no_identical_rgp_merging,
+                grr_metric=args.grr_metric,
+                disable_bar=args.disable_prog_bar,
+                graph_formats=args.graph_formats,
+                add_metadata=args.add_metadata,
+                metadata_sep=args.metadata_sep,
+                metadata_sources=args.metadata_sources,
+            )
+    if A == 1 or A == 2: 
+        with Timer("NEW", logging):
+            clustering = RGPClustering(args.pangenome)
+            clustering.run(
+                RGPClusteringOptions(
+                    unmerge_identical_rgps=args.no_identical_rgp_merging,
+                    grr_cutoff=args.grr_cutoff,
+                    metric=args.grr_metric,
+                    output=args.output,
+                    basename=args.basename,
+                    graph_formats=args.graph_formats,
+                    with_metadata=args.add_metadata,
+                    metadata_sep=args.metadata_sep,
+                    metadata_sources=args.metadata_sources,
+                )
+            )
 
 
 def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser:

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -335,8 +335,6 @@ class RGPClustering:
         }
         genedata_to_contig_ids: dict[int, list[int]] = defaultdict(list)
 
-        # contig_genedata_id_to_gene_name: dict[tuple[int, int], str] = {}
-
         # Map gene name with genetadata id
         # and contig id with genmetadata id in annotations/genes table
 
@@ -918,9 +916,9 @@ class RGPClustering:
             "name": rgp.name,
             "families_count": len(rgp.families),
             "identical_rgp_count": len(rgp.children),
-            "identical_rgp_names": ";".join(child.name for child in rgp.children),
+            "identical_rgp_names": ";".join(sorted(child.name for child in rgp.children)),
             "identical_rgp_genomes": ";".join(
-                {child.organism for child in rgp.children}
+                ";".join(sorted({child.organism for child in rgp.children}))
             ),
             "identical_rgp_contig_border_count": len(
                 [True for child in rgp.children if child.is_contig_border]
@@ -928,14 +926,14 @@ class RGPClustering:
             "identical_rgp_whole_contig_count": len(
                 [True for child in rgp.children if child.is_whole_contig]
             ),
-            "identical_rgp_spots": ";".join(spots),
+            "identical_rgp_spots": ";".join(sorted(spots)),
             "spot_id": (spots.pop() if len(spots) == 1 else "Multiple spots"),
-            "modules": ";".join(f"module_{module}" for module in rgp.modules),
+            "modules": ";".join(sorted(f"module_{module}" for module in rgp.modules)),
         }
 
         self._add_metadata_info(
             info,
-            [child.name for child in rgp.children],
+            sorted([child.name for child in rgp.children]),
             rgp.families,
             rgp.modules,
         )
@@ -1077,118 +1075,6 @@ class RGPClustering:
     @property
     def rgp_count(self) -> int:
         return len(self.rgps)
-
-
-class IdenticalRegions:
-    """
-    Represents a group of Identical Regions within a pangenome.
-
-    :param name: The name of the identical region group.
-    :param identical_rgps: A set of Region objects representing the identical regions.
-    :param families: A set of GeneFamily objects associated with the identical regions.
-    :param is_contig_border: A boolean indicating if the identical regions span across contig borders.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        identical_rgps: Set[Region],
-        families: Set[GeneFamily],
-        is_contig_border: bool,
-    ):
-        if not isinstance(identical_rgps, set):
-            raise TypeError("Expected 'identical_rgps' to be a set")
-        else:
-            if len(identical_rgps) == 0:
-                raise ValueError("Set of identical_rgps must not be empty")
-            if not all(isinstance(region, Region) for region in identical_rgps):
-                raise TypeError("All element in identical_rgps must be `Region`")
-        if not isinstance(families, set):
-            raise TypeError("Expected 'families' to be a set")
-        else:
-            if len(families) == 0:
-                raise ValueError("Set of families must not be empty")
-            if not all(isinstance(family, GeneFamily) for family in families):
-                raise TypeError("All element in families must be `GeneFamilies`")
-        self.name = name
-        self.families = families
-        self.rgps = identical_rgps
-        self.is_contig_border = is_contig_border
-        self.ID = Region.id_counter
-
-        Region.id_counter += 1
-
-    def __eq__(self, other: "IdenticalRegions") -> bool:
-        """
-        Check if two IdenticalRegions objects are equal based on their families,
-        identical regions, and contig border status.
-
-        :param other: The IdenticalRegions object to compare.
-        :return: True if the objects are equal, False otherwise.
-        """
-        if not isinstance(other, IdenticalRegions):
-            # don't attempt to compare against unrelated types
-            raise TypeError(
-                "'IdenticalRegions' type object was expected, "
-                f"but '{type(other)}' type object was provided."
-            )
-
-        return (
-            self.families == other.families
-            and self.rgps == other.rgps
-            and self.is_contig_border == other.is_contig_border
-        )
-
-    def __repr__(self):
-        return (
-            f"IdenticalRegions(name='{self.name}', num_rgps={len(self.rgps)}, num_families={len(self.families)},"
-            f" is_contig_border={self.is_contig_border})"
-        )
-
-    def __str__(self):
-        return self.name
-
-    def __hash__(self):
-        return id(self)
-
-    def __lt__(self, obj):
-        return self.ID < obj.ID
-
-    def __gt__(self, obj):
-        return self.ID > obj.ID
-
-    def __le__(self, obj):
-        return self.ID <= obj.ID
-
-    def __ge__(self, obj):
-        return self.ID >= obj.ID
-
-    @property
-    def genes(self):
-        """
-        Return iterable of genes from all RGPs that are identical in families
-        """
-        for rgp in self.rgps:
-            yield from rgp.genes
-
-    @property
-    def spots(self) -> Set[Spot]:
-        """
-        Return spots from all RGPs that are identical in families
-        """
-        spots = {rgp.spot for rgp in self.rgps if rgp.spot is not None}
-        return spots
-
-    @property
-    def modules(self) -> Set[Module]:
-        """
-        Return iterable of genes from all RGPs that are identical in families
-        """
-        modules = set()
-        for rgp in self.rgps:
-            modules |= rgp.modules
-
-        return modules
 
 
 def launch(args: argparse.Namespace):

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -16,6 +16,7 @@ import networkx as nx
 import pandas as pd
 
 # local libraries
+from ppanggolin import RGP
 from ppanggolin.pangenome import Pangenome
 from ppanggolin.region import Region, Spot, Module
 from ppanggolin.formats import check_pangenome_info
@@ -23,13 +24,25 @@ from ppanggolin.utils import restricted_float, mk_outdir, Timer
 from ppanggolin.geneFamily import GeneFamily
 
 import typing as tp
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pyroaring import BitMap
 from ppanggolin.formats.h5reader import H5Reader, TableAttribute
 
 class RegionProxy:
-    def __init__(self, ID: int, name: str, families: BitMap, *,
-                 children=None, modules=None, contig=None, organism=None, length=0):
+
+    def __init__(
+        self,
+        ID: int,
+        name: str,
+        families: BitMap,
+        is_contig_border: bool,
+        is_whole_contig: bool,
+        children=None,
+        modules=None,
+        contig=None,
+        organism=None,
+        length=0,
+    ):
         self.ID: int = ID
         self.name: str = name
         self.families: BitMap = families
@@ -45,24 +58,23 @@ class RegionProxy:
 
         self.length: int = length
         self.nb_families: int = len(self.families)
-        
-        # TODO
-        self.is_contig_border: bool = False
-        self.is_whole_contig: bool = False
+
+        self.is_contig_border: bool = is_contig_border
+        self.is_whole_contig: bool = is_whole_contig
 
     @property
     def is_identical_region(self) -> bool:
         return self.children is not None and len(self.children) > 0
-    
+
     def __repr__(self):
         return f"RegionProxy2(ID={self.ID}, name='{self.name}')"
-    
+
     def __str__(self):
         return self.name
-    
+
     def __hash__(self) -> int:
         return id(self)
-    
+
     def __eq__(self, rhs: "RegionProxy") -> bool:
         return all(self.families == rhs.families,
                    self.children == rhs.children,
@@ -79,7 +91,7 @@ class RegionProxy:
 
     def __ge__(self, obj):
         return self.ID >= obj.ID
-    
+
 @dataclass
 class RGPTable:
     rgp: tp.Annotated[str, TableAttribute(name="RGP", transform=lambda x: x.decode('utf-8'))]
@@ -127,8 +139,8 @@ class GenesTable:
 
 @dataclass
 class GeneDataTable:
+    # gene_type: tp.Annotated[str, TableAttribute(name="gene_type", transform=lambda x: x.decode('utf-8'))]
     idx: tp.Annotated[int, TableAttribute(name="genedata_id")]
-    contig: tp.Annotated[int, TableAttribute(name="contig")]
     start: tp.Annotated[int, TableAttribute(name="start")]
     stop: tp.Annotated[int, TableAttribute(name="stop")]
     position: tp.Annotated[int, TableAttribute(name="position")]
@@ -144,7 +156,34 @@ class RGPGeneProxy:
 class RGPGenes:
     contig: int
     is_circular_contig: bool   
-    genes: list[RGPGeneProxy] = []
+    genes: list[RGPGeneProxy]
+
+
+@dataclass
+class RGPInfo:
+    name: str
+    families: set[str]
+    families_ids: set[int]
+    is_contig_border: bool
+    is_whole_contig: bool
+    contig: str
+
+
+@dataclass
+class ContigBorderPosition:
+    last_gene_position: int
+    last_gene_idx: int
+    first_gene_idx: int
+    first_gene_position: int
+    gene_count: int
+
+
+@dataclass
+class ContigBorderGenes:
+    first_gene: str
+    last_gene: str
+    gene_count: int
+
 
 @dataclass
 class RGPMetric:
@@ -152,6 +191,15 @@ class RGPMetric:
     min_grr: float
     incomplete_aware_grr: float
     shared_family: int
+
+
+@dataclass
+class Contig:
+    organism: str
+    is_circular: bool
+    idx: int
+    name: str
+
 
 RGPMetricType = tp.Literal["max_grr", "min_grr", "incomplete_aware_grr"]
 
@@ -164,7 +212,7 @@ class RGPClusteringOptions:
     basename: str = "rgp_cluster"
     graph_formats: list[str] = ("gexf", "graphml")
     with_metadata: bool = False
-    metadata_sources: list[str] = []
+    metadata_sources: list[str] = field(default_factory=list)
     metadata_sep: str = "|"
 
 class RGPClustering:
@@ -178,7 +226,8 @@ class RGPClustering:
         self._fam_to_modules: dict[str, set[str]] = None
         self._contig_to_organism: dict[str, str] = None
         self._rgp_to_nb_genes: dict[str, int] = None
-    
+        self._rgp_to_contig_info: dict[str, RGPGenes] = None
+
     def _get_rgp_spot(self, reader: H5Reader) -> dict[str, int]:
         rgp_to_spot: dict[str, int] = {}
         for table in reader.fetch(RGPSpotTable):
@@ -190,35 +239,114 @@ class RGPClustering:
         for table in reader.fetch(ModuleTable):
             fam_to_modules[table.fam].add(table.module)
         return fam_to_modules
-    
+
     def _get_contig_to_organism(self, reader: H5Reader) -> dict[str, str]:
         contig_to_organism: dict[str, str] = {}
         for table in reader.fetch(ContigTable):
             contig_to_organism[table.contig] = table.genome
         return contig_to_organism
-    
-    def _get_rgp_genes(self, reader: H5Reader, all_rgp_genes: set[str], rgp_with_genes: dict[str, set[str]]) -> dict[str, RGPGenes]:
-        rgp_genes: dict[str, RGPGenes] = {}
-        override = {"name": {"predicate" : lambda x: x in all_rgp_genes}}
-        
-        genes: dict[str, tuple[int, int]] = {}
-        for table in reader.fetch(GenesTable, override):
-            genes[table.name] = (table.genedata, table.contig)
 
-        for rgp, rgenes in rgp_with_genes.items():
-            rgp_genes[rgp] = RGPGenes(
-                
+    def _get_contig_to_is_circular(self, reader: H5Reader) -> dict[str, bool]:
+        circular_contig_ids: dict[str, bool] = {}
+        for table in reader.fetch(ContigTable):
+            circular_contig_ids[table.idx] = table.is_circular
+        return circular_contig_ids
+
+    def _get_contig_to_info(self, reader: H5Reader):
+
+        contig_to_info: dict[str, Contig] = {}
+        for table in reader.fetch(ContigTable):
+            contig_to_info[table.contig] = Contig(
+                organism=table.genome,
+                is_circular=table.is_circular,
+                idx=table.idx,
+                name=table.contig,
             )
-            
 
+        return contig_to_info
 
-    def _get_rgp_fam(self, reader: H5Reader) -> dict[str, set[tuple[str, int]]]:
+    def _get_contig_border_genes(
+        self, reader: H5Reader, all_rgp_genes: set[str] = None
+    ) -> dict[str, ContigBorderPosition]:
+        """
+        Get contig information such as if it is circular, last gene position and last gene idx.
+        """
+
+        genedata_to_contig_ids: dict[int, list[int]] = defaultdict(list)
+
+        contig_genedata_id_to_gene_name: dict[tuple[int, int], str] = {}
+
+        # Map gene name with genetadata id
+        # and contig id with genmetadata id in annotations/genes table
+        # TODO do not process contig that have no RGP
+
+        for table in reader.fetch(GenesTable):
+            genedata_to_contig_ids[table.genedata].append(table.contig)
+            contig_genedata_id_to_gene_name[(table.contig, table.genedata)] = table.name
+
+        # Create a contig info dictionary to store contig information
+        contig_to_info: dict[int, ContigBorderPosition] = {}
+
+        for table in reader.fetch(GeneDataTable):
+            # Problem with RNA genes that are not in GenesTable
+            # We could filter based on gene_type columns but need to retrieve this column
+            # and convert it to string when parsing GeneDataTable which takes time
+            # quick and dirty solution for now:
+            try:
+                contig_ids = genedata_to_contig_ids[table.idx]
+            except KeyError:
+                continue
+            for contig_id in contig_ids:
+                if contig_id not in contig_to_info:
+                    contig_to_info[contig_id] = ContigBorderPosition(
+                        last_gene_position=table.position,
+                        last_gene_idx=table.idx,
+                        first_gene_position=table.position,
+                        first_gene_idx=table.idx,
+                        gene_count=0,
+                    )
+                contig_to_info[contig_id].gene_count += 1
+
+                if table.position > contig_to_info[contig_id].last_gene_position:
+                    contig_to_info[contig_id].last_gene_position = table.position
+                    contig_to_info[contig_id].last_gene_idx = table.idx
+
+                if table.position < contig_to_info[contig_id].first_gene_position:
+                    contig_to_info[contig_id].first_gene_position = table.position
+                    contig_to_info[contig_id].first_gene_idx = table.idx
+
+        assert all(
+            info.first_gene_position == 0 for info in contig_to_info.values()
+        ), "Some contigs have no gene at position 0"
+
+        contig_id_to_name = {
+            contig_info.idx: contig_info.name
+            for contig_info in self._contig_to_info.values()
+        }
+
+        contig_name_to_border_genes = {
+            contig_id_to_name[contig_id]: ContigBorderGenes(
+                first_gene=contig_genedata_id_to_gene_name[
+                    contig_id, info.first_gene_idx
+                ],
+                last_gene=contig_genedata_id_to_gene_name[
+                    contig_id, info.last_gene_idx
+                ],
+                gene_count=info.gene_count,
+            )
+            for contig_id, info in contig_to_info.items()
+        }
+        return contig_name_to_border_genes
+
+    def _get_rgp_info(self, reader: H5Reader) -> list[RGPInfo]:
         rgp_with_genes: dict[str, set[str]] = defaultdict(set)
         all_rgp_genes: set[str] = set()
 
         for table in reader.fetch(RGPTable):
             rgp_with_genes[table.rgp].add(table.gene)
             all_rgp_genes.add(table.gene)
+
+        contig_to_border_genes = self._get_contig_border_genes(reader)
 
         self._rgp_to_nb_genes: dict[str, int] = {
             rgp_name: len(genes) for rgp_name, genes in rgp_with_genes.items()
@@ -230,59 +358,95 @@ class RGPClustering:
 
         unique_families = set(gene_to_family.values())
         family_ids = {fam: idx for idx, fam in enumerate(unique_families)}
-        
-        rgp_with_fams = defaultdict(set)
+
+        rgp_infos: list[RGPInfo] = []
+
         for rgp_name, genes in rgp_with_genes.items():
+
+            rgp_families_ids: set[int] = set()  # TODO Use BitMap here directly??
+            rgp_families: set[str] = set()
+            contig_name = rgp_name.split("_RGP_")[0]
             for gene in genes:
+
                 fam = gene_to_family[gene]
                 fam_id = family_ids[fam]
-                rgp_with_fams[rgp_name].add((fam, fam_id))
-        
-        return rgp_with_fams
-    
-    def _construct_single(self, idx: int, rgp: tuple[str, set[tuple[str, int]]]):
-        contig = rgp[0].split("_RGP_")[0]
+                rgp_families.add(fam)
+                rgp_families_ids.add(fam_id)
+
+            contig_border_info = contig_to_border_genes[contig_name]
+            is_contig_circular = self._contig_to_info[contig_name].is_circular
+
+            is_contig_border = False
+            if not is_contig_circular and (
+                contig_border_info.first_gene in genes
+                or contig_border_info.last_gene in genes
+            ):
+                is_contig_border = True
+
+            is_whole_contig = False
+            if len(genes) == contig_border_info.gene_count:
+                is_whole_contig = True
+
+            info = RGPInfo(
+                name=rgp_name,
+                families=rgp_families,
+                families_ids=rgp_families_ids,
+                is_contig_border=is_contig_border,
+                is_whole_contig=is_whole_contig,
+                contig=contig_name,
+            )
+            rgp_infos.append(info)
+
+        return rgp_infos
+
+    def _construct_single(self, idx: int, rgp: RGPInfo):
         return RegionProxy(
             ID=idx,
-            name=rgp[0],
-            families=BitMap(fam_id for _, fam_id in rgp[1]),
+            name=rgp.name,
+            families=BitMap(rgp.families_ids),
             modules=BitMap(
                 module_id
-                for fam, _ in rgp[1]
+                for fam in rgp.families
                 for module_id in self._fam_to_modules.get(fam, [])
             ),
-            contig=contig,
-            organism=self._contig_to_organism[contig],
-            length=self._rgp_to_nb_genes[rgp[0]],
+            contig=rgp.contig,
+            organism=self._contig_to_info[rgp.contig].organism,
+            length=self._rgp_to_nb_genes[rgp.name],
+            is_contig_border=rgp.is_contig_border,
+            is_whole_contig=rgp.is_whole_contig,
         )
-    
-    def _construct_single_and_add(self, idx: int, rgp: tuple[str, set[tuple[str, int]]]):
+
+    def _construct_single_and_add(self, idx: int, rgp: RGPInfo):
         self.graph.add_node(idx)
         self.rgps.add(self._construct_single(idx, rgp))
 
-    def _construct_multiple(self, idx: int, rgps: list[tuple[str, set[tuple[str, int]]]]):
+    def _construct_multiple(self, idx: int, rgps: list[RGPInfo]):
         return RegionProxy(
             ID=idx,
             name=f"identical_rgps_{self.identical_regions}",
-            families=BitMap(fam_id for _, fam_id in rgps[0][1]),
+            families=BitMap(rgps[0].families_ids),
             children=set(
                 self._construct_single(i, rgp)
                 for i, rgp in enumerate(rgps, start=idx + 1)
             ),
             modules=BitMap(
                 module_id
-                for fam, _ in rgps[0][1]
+                for fam in rgps[0].families
                 for module_id in self._fam_to_modules.get(fam, [])
             ),
             contig=self._contig_to_organism,
+            # identical regions object is considered on a contig border if all rgp are contig border
+            is_contig_border=all(rgp.is_contig_border for rgp in rgps),
+            # identical regions object is considered as whole contig if all rgp are whole contig
+            is_whole_contig=all(rgp.is_whole_contig for rgp in rgps),
         )
-    
-    def _construct_multiple_and_add(self, idx: int, rgps: list[tuple[str, set[tuple[str, int]]]]):
+
+    def _construct_multiple_and_add(self, idx: int, rgps: list[RGPInfo]):
         self.rgps.add(self._construct_multiple(idx, rgps))
         self.graph.add_node(idx)
         self.identical_regions += 1
 
-    def _construct_and_add(self, idx: int, rgps: list[tuple[str, set[tuple[str, int]]]]):
+    def _construct_and_add(self, idx: int, rgps: list[RGPInfo]):
         if len(rgps) == 1:
             self._construct_single_and_add(idx, rgps[0])
         else:
@@ -290,7 +454,7 @@ class RGPClustering:
 
     def _grr(self, b1: BitMap, b2: BitMap, mode: Callable) -> float:
         return len(b1 & b2) / mode(len(b1), len(b2))
-    
+
     def _rgp_metric(self, r1: RegionProxy, r2: RegionProxy, grr_cutoff: float, metric: RGPMetricType) -> RGPMetric:
         if r1.is_contig_border or r2.is_contig_border:
             agrr = self._grr(r1.families, r2.families, min)
@@ -303,36 +467,45 @@ class RGPClustering:
 
         m = RGPMetric(max_grr, min_grr, agrr, len(r1.families & r2.families))
         return m if getattr(m, metric) >= grr_cutoff else None
-    
+
     def _construct_regions(self):
         logging.info("Loading RGPs from pangenome H5 file")
 
         with H5Reader(self.h5) as reader:
-            rgp_with_fams = self._get_rgp_fam(reader)
+
+            # self._contig_to_organism = self._get_contig_to_organism(reader)
+            # self._contig_id_to_is_circular = self._get_contig_to_is_circular(reader)
+            self._contig_to_info = self._get_contig_to_info(reader)
+
+            rgp_infos = self._get_rgp_info(reader)
             self._rgp_to_spot = self._get_rgp_spot(reader)
             self._fam_to_modules = self._get_fam_to_modules(reader)
-            self._contig_to_organism = self._get_contig_to_organism(reader)
-            fams_to_rgps = defaultdict(list)
 
-            for rgp_name, fams in rgp_with_fams.items():
-                fams_key = tuple(sorted(fam_id for _, fam_id in fams))
-                fams_to_rgps[fams_key].append((rgp_name, fams))
+            fams_to_rgps: defaultdict[tuple[int], list[RGPInfo]] = defaultdict(list)
 
+            for info in rgp_infos:
+                fams_key = tuple(sorted(fam_id for fam_id in info.families_ids))
+                fams_to_rgps[fams_key].append(info)
+            print(
+                f"{len(fams_to_rgps)} unique family combinations found for {len(rgp_infos)} RGPs"
+            )
             idx = 0
             for rgps in fams_to_rgps.values():
                 self._construct_and_add(idx, rgps)
                 idx += len(rgps) + 1 if len(rgps) > 1 else 1
 
-        logging.info(f"{len(rgp_with_fams)} RGPs loaded from pangenome ({len(self.rgps)} unique RGPs after dereplication)")
+        logging.info(
+            f"{len(rgp_infos)} RGPs loaded from pangenome ({len(self.rgps)} unique RGPs after dereplication)"
+        )
 
     def _compute_all_metrics(self, grr_cutoff: float, metric: RGPMetricType):
         logging.info("Computing RGP metrics")
-        
+
         nb_pairs = 0
         for r1, r2 in combinations(self.rgps, 2):
             if len(r1.families & r2.families) == 0:
                 continue
-        
+
             nb_pairs += 1
             if m := self._rgp_metric(r1, r2, grr_cutoff, metric):
                 self.metrics.append(m)
@@ -341,7 +514,7 @@ class RGPClustering:
 
     def _louvain_clustering(self, metric: RGPMetricType):
         logging.info(f"Clustering RGPs using Louvain communities on '{metric}' metric")
-        
+
         partitions = nx.algorithms.community.louvain_communities(
             self.graph, weight=metric
         )
@@ -351,7 +524,7 @@ class RGPClustering:
                 {node: f"cluster_{i}" for node in nodes},
                 name=f"{metric}_cluster",
             )
-        
+
         logging.info(f"Graph has {len(partitions)} clusters using '{metric}'")
 
     def _add_edges_to_identical_rgps(self):
@@ -386,10 +559,10 @@ class RGPClustering:
                     (child.ID, connected, data)
                     for child in rgp.children
                 ]
-            
+
             self.graph.add_edges_from(edges)
             self.graph.remove_node(rgp.ID)
-        
+
         logging.info(f"Unmerged {unmerged} identical RGPs")
 
     def _spot_id(self, rgp: RegionProxy) -> str:
@@ -397,7 +570,7 @@ class RGPClustering:
             return f"spot_{self._rgp_to_spot[rgp.name]}"
         else:
             return "No spot"
-        
+
     def _add_info_to_identical_rgps(self):
         logging.info("Adding info to identical RGPs in graph")
 
@@ -405,7 +578,7 @@ class RGPClustering:
         for rgp in self.rgps:
             if not rgp.is_identical_region:
                 continue
-            
+
             identical += 1
             spots = {self._spot_id(child) for child in rgp.children}
 
@@ -444,7 +617,7 @@ class RGPClustering:
             "modules": ";".join(str(module) for module in rgp.modules),
             "families_count": rgp.nb_families,
         }
-    
+
     def _add_info_to_rgps(self):
         logging.info("Adding info to RGPs in graph")
         annotated = 0
@@ -452,7 +625,7 @@ class RGPClustering:
             if rgp.ID in self.graph:
                 self.graph.nodes[rgp.ID].update(self._make_info_from_rgp(rgp))
                 annotated += 1
-            
+
             if rgp.children:
                 for child in rgp.children:
                     if child.ID in self.graph:
@@ -470,7 +643,7 @@ class RGPClustering:
             graph_filename = output / f"{basename}.graphml"
             logging.info(f"Writing RGP graph in GraphML format to {graph_filename}")
             nx.write_graphml(self.graph, graph_filename)
-    
+
     def _write_outputs(self, output: Path, basename: str, graph_formats: list[str]):
         self._write_graphs(output, basename, graph_formats)
 
@@ -478,12 +651,12 @@ class RGPClustering:
         self._construct_regions()
         self._compute_all_metrics(options.grr_cutoff, options.metric)
         self._louvain_clustering(options.metric)
-        
+
         if options.unmerge_identical_rgps:
             self._add_edges_to_identical_rgps()
         else:
             self._add_info_to_identical_rgps()
-        
+
         self._add_info_to_rgps()
 
         self._write_outputs(options.output, options.basename, options.graph_formats)
@@ -1277,6 +1450,49 @@ def launch(args: argparse.Namespace):
                     metadata_sources=args.metadata_sources,
                 )
             )
+    if A == 2:
+        # comparison of RGP between old and new implementation
+        rgp_name_to_rgp_proxy = {}
+        for rgp_proxy in clustering.rgps:
+            if rgp_proxy.children:
+                for child_rgp_proxy in rgp_proxy.children:
+                    rgp_name_to_rgp_proxy[child_rgp_proxy.name] = child_rgp_proxy
+            else:
+                rgp_name_to_rgp_proxy[rgp_proxy.name] = rgp_proxy
+
+        for region in pangenome.regions:
+            rgp_proxy = rgp_name_to_rgp_proxy[region.name]
+
+            # Log debug info when either region has is_contig_border=True or is_whole_contig=True
+            if region.is_contig_border or rgp_proxy.is_contig_border or region.is_whole_contig or rgp_proxy.is_whole_contig:
+                logging.debug(
+                    f"Comparing RGP: {region.name}\n"
+                    f"  Region object:\n"
+                    f"    - name: {region.name}\n"
+                    f"    - is_contig_border: {region.is_contig_border}\n"
+                    f"    - is_whole_contig: {region.is_whole_contig}\n"
+                    f"    - families count: {region.number_of_families}\n"
+                    f"    - genes count: {len(region)}\n"
+                    f"    - contig: {region.contig.name}\n"
+                    f"    - organism: {region.organism.name}\n"
+                    f"  RegionProxy object:\n"
+                    f"    - name: {rgp_proxy.name}\n"
+                    f"    - is_contig_border: {rgp_proxy.is_contig_border}\n"
+                    f"    - is_whole_contig: {rgp_proxy.is_whole_contig}\n"
+                    f"    - families count: {len(rgp_proxy.families)}\n"
+                    f"    - genes count: {rgp_proxy.length}\n"
+                    f"    - contig: {rgp_proxy.contig}\n"
+                    f"    - organism: {rgp_proxy.organism}"
+                )
+
+            if region.is_contig_border != rgp_proxy.is_contig_border:
+                logging.error(f"Mismatch in is_contig_border for RGP: {region.name}")
+
+            if region.is_whole_contig != rgp_proxy.is_whole_contig:
+                logging.error(f"Mismatch in is_whole_contig for RGP: {region.name}")
+
+            assert region.is_contig_border == rgp_proxy.is_contig_border, region.name
+            assert region.is_whole_contig == rgp_proxy.is_whole_contig, region.name
 
 
 def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser:

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -1309,7 +1309,7 @@ def parser_cluster_rgp(parser: argparse.ArgumentParser):
         type=str,
         choices=["gexf", "graphml"],
         nargs="+",
-        default=["gexf", "graphml"],
+        default=["graphml"],
         help="Format of the output graph.",
     )
 

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -100,50 +100,78 @@ class RegionProxy:
     def __ge__(self, obj):
         return self.ID >= obj.ID
 
+
 @dataclass
 class RGPTable:
-    rgp: tp.Annotated[str, TableAttribute(name="RGP", transform=lambda x: x.decode('utf-8'))]
-    gene: tp.Annotated[str, TableAttribute(name="gene", transform=lambda x: x.decode('utf-8'))]
+    rgp: tp.Annotated[
+        str, TableAttribute(name="RGP", transform=lambda x: x.decode("utf-8"))
+    ]
+    gene: tp.Annotated[
+        str, TableAttribute(name="gene", transform=lambda x: x.decode("utf-8"))
+    ]
     _table: str = "/RGP"
+
 
 @dataclass
 class GeneFamTable:
-    gene: tp.Annotated[str, TableAttribute(name="gene", transform=lambda x: x.decode('utf-8'))]
-    family: tp.Annotated[str, TableAttribute(name="geneFam", transform=lambda x: x.decode('utf-8'))]
+    gene: tp.Annotated[
+        str, TableAttribute(name="gene", transform=lambda x: x.decode("utf-8"))
+    ]
+    family: tp.Annotated[
+        str, TableAttribute(name="geneFam", transform=lambda x: x.decode("utf-8"))
+    ]
     _table: str = "/geneFamilies"
+
 
 @dataclass
 class AnnotationsGeneTable:
-    name: tp.Annotated[str, TableAttribute(name="ID", transform=lambda x: x.decode('utf-8'))]
+    name: tp.Annotated[
+        str, TableAttribute(name="ID", transform=lambda x: x.decode("utf-8"))
+    ]
     contig: tp.Annotated[int, TableAttribute(name="contig")]
     _table: str = "/annotations/genes"
 
+
 @dataclass
 class RGPSpotTable:
-    rgp: tp.Annotated[str, TableAttribute(name="RGP", transform=lambda x: x.decode('utf-8'))]
+    rgp: tp.Annotated[
+        str, TableAttribute(name="RGP", transform=lambda x: x.decode("utf-8"))
+    ]
     spot: tp.Annotated[int, TableAttribute(name="spot")]
     _table: str = "/spots"
 
+
 @dataclass
 class ModuleTable:
-    fam: tp.Annotated[str, TableAttribute(name="geneFam", transform=lambda x: x.decode('utf-8'))]
+    fam: tp.Annotated[
+        str, TableAttribute(name="geneFam", transform=lambda x: x.decode("utf-8"))
+    ]
     module: tp.Annotated[int, TableAttribute(name="module")]
     _table: str = "/modules"
 
+
 @dataclass
 class ContigTable:
-    genome: tp.Annotated[str, TableAttribute(name="genome", transform=lambda x: x.decode('utf-8'))]
-    contig: tp.Annotated[str, TableAttribute(name="name", transform=lambda x: x.decode('utf-8'))]
+    genome: tp.Annotated[
+        str, TableAttribute(name="genome", transform=lambda x: x.decode("utf-8"))
+    ]
+    contig: tp.Annotated[
+        str, TableAttribute(name="name", transform=lambda x: x.decode("utf-8"))
+    ]
     is_circular: tp.Annotated[bool, TableAttribute(name="is_circular")]
     idx: tp.Annotated[int, TableAttribute(name="ID")]
     _table: str = "/annotations/contigs"
 
+
 @dataclass
 class GenesTable:
-    name: tp.Annotated[str, TableAttribute(name="ID", transform=lambda x: x.decode('utf-8'))]
+    name: tp.Annotated[
+        str, TableAttribute(name="ID", transform=lambda x: x.decode("utf-8"))
+    ]
     genedata: tp.Annotated[int, TableAttribute(name="genedata_id")]
     contig: tp.Annotated[int, TableAttribute(name="contig")]
     _table: str = "/annotations/genes"
+
 
 @dataclass
 class GeneDataTable:
@@ -154,16 +182,18 @@ class GeneDataTable:
     position: tp.Annotated[int, TableAttribute(name="position")]
     _table: str = "/annotations/genedata"
 
+
 @dataclass
 class RGPGeneProxy:
     start: int
     stop: int
     position: int
 
+
 @dataclass
 class RGPGenes:
     contig: int
-    is_circular_contig: bool   
+    is_circular_contig: bool
     genes: list[RGPGeneProxy]
 
 
@@ -211,6 +241,7 @@ class Contig:
 
 RGPMetricType = tp.Literal["max_grr", "min_grr", "incomplete_aware_grr"]
 
+
 @dataclass
 class RGPClusteringOptions:
     grr_cutoff: float = 0.3
@@ -223,7 +254,7 @@ class RGPClusteringOptions:
     metadata_sources: list[str] = field(default_factory=list)
     ignore_incomplete_rgp: bool = False
     disable_prog_bar: bool = False
-    
+
 
 class RGPClustering:
     def __init__(self, pangenome_h5: Path):
@@ -261,7 +292,7 @@ class RGPClustering:
                     f"Cannot compute RGP metrics: {description} is not available "
                     "in the pangenome H5 file."
                 )
-            
+
     def _get_rgp_spot(self, reader: H5Reader) -> dict[str, int]:
         rgp_to_spot: dict[str, int] = {}
         for table in reader.fetch(RGPSpotTable):
@@ -301,7 +332,7 @@ class RGPClustering:
                 )
 
         return contig_to_info
-        
+
     def _fetch_required_table(self, reader: H5Reader, table_type):
         try:
             return reader.fetch(table_type)
@@ -310,7 +341,7 @@ class RGPClustering:
                 f"Required table '{table_type.__name__}' is missing from the "
                 "pangenome H5 file."
             ) from e
-        
+
     def _get_contig_border_genes(
         self, reader: H5Reader
     ) -> dict[str, ContigBorderPosition]:
@@ -484,6 +515,7 @@ class RGPClustering:
                     if isinstance(value, bytes):
                         value = value.decode("utf-8")
                     value_target[identifier][f"{source}_{field}"].append(str(value))
+
     def _load_metadata(
         self, reader: H5Reader, metadata_sources: list[str] = None
     ) -> None:
@@ -508,11 +540,17 @@ class RGPClustering:
                     )
                 elif metatype == "genes":
                     self._read_metadata_source(
-                        reader, metatype, source, source_target=self._gene_metadata_sources
+                        reader,
+                        metatype,
+                        source,
+                        source_target=self._gene_metadata_sources,
                     )
                 elif metatype == "spots":
                     self._read_metadata_source(
-                        reader, metatype, source, source_target=self._spot_metadata_sources
+                        reader,
+                        metatype,
+                        source,
+                        source_target=self._spot_metadata_sources,
                     )
                 elif metatype == "modules":
                     self._read_metadata_source(
@@ -643,7 +681,9 @@ class RGPClustering:
     def _grr(self, b1: BitMap, b2: BitMap, mode: Callable) -> float:
         return len(b1 & b2) / mode(len(b1), len(b2))
 
-    def _rgp_metric(self, r1: RegionProxy, r2: RegionProxy, grr_cutoff: float, metric: RGPMetricType) -> RGPMetric:
+    def _rgp_metric(
+        self, r1: RegionProxy, r2: RegionProxy, grr_cutoff: float, metric: RGPMetricType
+    ) -> RGPMetric:
         if r1.is_contig_border or r2.is_contig_border:
             agrr = self._grr(r1.families, r2.families, min)
             max_grr = self._grr(r1.families, r2.families, max)
@@ -657,7 +697,10 @@ class RGPClustering:
         return m if getattr(m, metric) >= grr_cutoff else None
 
     def _construct_regions(
-        self, with_metadata: bool = False, metadata_sources: list[str] = None, ignore_incomplete_rgp: bool = False
+        self,
+        with_metadata: bool = False,
+        metadata_sources: list[str] = None,
+        ignore_incomplete_rgp: bool = False,
     ):
         logging.info("Loading RGPs from pangenome H5 file")
 
@@ -676,9 +719,7 @@ class RGPClustering:
 
             if ignore_incomplete_rgp:
                 rgp_infos = [
-                    rgp_info
-                    for rgp_info in rgp_infos
-                    if not rgp_info.is_contig_border
+                    rgp_info for rgp_info in rgp_infos if not rgp_info.is_contig_border
                 ]
                 logging.info(
                     f"{len(rgp_infos)} RGPs loaded from pangenome after filtering out incomplete RGPs"
@@ -719,8 +760,13 @@ class RGPClustering:
                 family_to_rgps[family].append(rgp)
 
         nb_pairs = 0
-        
-        with tqdm(total=len(family_to_rgps), desc="Computing metrics", disable=disable_bar, bar_format="{desc}: {percentage:3.0f}%|{bar}") as pbar:
+
+        with tqdm(
+            total=len(family_to_rgps),
+            desc="Computing metrics",
+            disable=disable_bar,
+            bar_format="{desc}: {percentage:3.0f}%|{bar}",
+        ) as pbar:
             for family in sorted(family_to_rgps):
                 for r1, r2 in combinations(family_to_rgps[family], 2):
                     shared_families = r1.families & r2.families
@@ -800,7 +846,7 @@ class RGPClustering:
         for rgp in self.rgps:
             if not rgp.is_identical_region:
                 continue
-            
+
             unmerged += 1
             self.graph.add_nodes_from(
                 (child.ID for child in rgp.children),
@@ -842,22 +888,28 @@ class RGPClustering:
             return
 
         element_to_sources = {
-            "family": set().union(
-                *(
-                    self._family_metadata_sources.get(self._family_id_to_name[fid], set())
-                    for fid in families_ids
+            "family": (
+                set().union(
+                    *(
+                        self._family_metadata_sources.get(
+                            self._family_id_to_name[fid], set()
+                        )
+                        for fid in families_ids
+                    )
                 )
-            )
-            if families_ids
-            else set(),
-            "module": set().union(
-                *(
-                    self._module_metadata_sources.get(module_id, set())
-                    for module_id in module_ids
+                if families_ids
+                else set()
+            ),
+            "module": (
+                set().union(
+                    *(
+                        self._module_metadata_sources.get(module_id, set())
+                        for module_id in module_ids
+                    )
                 )
-            )
-            if module_ids
-            else set(),
+                if module_ids
+                else set()
+            ),
             "gene": set(),
             "spot": set(),
         }
@@ -895,9 +947,7 @@ class RGPClustering:
             "name": rgp.name,
             "families_count": len(rgp.families),
             "identical_rgp_count": len(rgp.children),
-            "identical_rgp_names": ";".join(
-                child.name for child in rgp.children
-            ),
+            "identical_rgp_names": ";".join(child.name for child in rgp.children),
             "identical_rgp_genomes": ";".join(
                 {child.organism for child in rgp.children}
             ),
@@ -910,7 +960,7 @@ class RGPClustering:
             "identical_rgp_spots": ";".join(spots),
             "spot_id": (spots.pop() if len(spots) == 1 else "Multiple spots"),
             "modules": ";".join(f"module_{module}" for module in rgp.modules),
-            }
+        }
 
         self._add_metadata_info(
             info,
@@ -955,7 +1005,7 @@ class RGPClustering:
 
                 annotated += 1
 
-            if rgp.children: # in case identical rgp are unmerged
+            if rgp.children:  # in case identical rgp are unmerged
                 for child in rgp.children:
                     if child.ID in self.graph:
                         self.graph.nodes[child.ID].update(
@@ -1036,19 +1086,27 @@ class RGPClustering:
             self._construct_regions(
                 with_metadata=options.with_metadata,
                 metadata_sources=options.metadata_sources or None,
-                ignore_incomplete_rgp=options.ignore_incomplete_rgp
+                ignore_incomplete_rgp=options.ignore_incomplete_rgp,
             )
 
-        rss_peak_after_construct_regions = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        logging.info(f"Memory after _construct_regions: RSS peak={rss_peak_after_construct_regions:.2f} MB")
+        rss_peak_after_construct_regions = (
+            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        )
+        logging.info(
+            f"Memory after _construct_regions: RSS peak={rss_peak_after_construct_regions:.2f} MB"
+        )
 
+        with Timer("_compute_all_metrics", logging):
+            self._compute_all_metrics(
+                options.grr_cutoff, options.metric, disable_bar=options.disable_prog_bar
+            )
 
-        with Timer('_compute_all_metrics', logging):
-            self._compute_all_metrics(options.grr_cutoff, options.metric, disable_bar=options.disable_prog_bar)
-        
-        rss_peak_after_compute_all_metrics = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        logging.info(f"Memory after _compute_all_metrics: RSS peak={rss_peak_after_compute_all_metrics:.2f} MB")
-
+        rss_peak_after_compute_all_metrics = (
+            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        )
+        logging.info(
+            f"Memory after _compute_all_metrics: RSS peak={rss_peak_after_compute_all_metrics:.2f} MB"
+        )
 
         if options.unmerge_identical_rgps:
             self._add_edges_to_identical_rgps()
@@ -1057,7 +1115,6 @@ class RGPClustering:
 
         # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         # logging.info(f"Memory after _louvain_clustering: RSS peak={rss_peak:.2f} MB")
-
 
         # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         # logging.info(
@@ -1079,6 +1136,7 @@ class RGPClustering:
     @property
     def rgp_count(self) -> int:
         return len(self.rgps)
+
 
 class IdenticalRegions:
     """
@@ -1553,6 +1611,7 @@ def compute_rgp_metric(
     if edge_metrics[grr_metric] >= grr_cutoff:
         return rgp_a.ID, rgp_b.ID, edge_metrics
 
+
 def cluster_rgp_on_grr(graph: nx.Graph, clustering_attribute: str = "grr"):
     """
     Cluster rgp based on grr using louvain communities clustering.
@@ -1746,7 +1805,6 @@ def cluster_rgp(
     print("<" * 40)
     # Get all pairs of RGP that share at least one family
 
-    
     with Timer("OLD get pair to compute", logging):
         family2rgp = defaultdict(set)
         for rgp in dereplicated_rgps:
@@ -1846,7 +1904,7 @@ def launch(args: argparse.Namespace):
     """
     # Get initial memory
     rss_start = (
-    resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
     )  # Convert to MB (on Linux, ru_maxrss is in KB)
     logging.info(f"Memory before start: RSS peak={rss_start:.2f} MB")
 
@@ -1881,7 +1939,7 @@ def launch(args: argparse.Namespace):
                 metadata_sep=args.metadata_sep,
                 metadata_sources=args.metadata_sources,
             )
-    if A == 1 or A == 2: 
+    if A == 1 or A == 2:
         with Timer("NEW", logging):
             clustering = RGPClustering(args.pangenome)
             clustering.run(
@@ -1895,10 +1953,9 @@ def launch(args: argparse.Namespace):
                     with_metadata=args.add_metadata,
                     metadata_sources=args.metadata_sources,
                     ignore_incomplete_rgp=args.ignore_incomplete_rgp,
-                    disable_prog_bar=args.disable_prog_bar
+                    disable_prog_bar=args.disable_prog_bar,
                 )
             )
-
 
 
 def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser:

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -743,6 +743,7 @@ class RGPClustering:
                 family_to_rgps[family].append(rgp)
 
         nb_pairs = 0
+        selected_count = 0
 
         with tqdm(
             total=len(family_to_rgps),
@@ -758,13 +759,13 @@ class RGPClustering:
 
                     nb_pairs += 1
                     if m := self._rgp_metric(r1, r2, grr_cutoff, metric):
-                        self.metrics.append(m)
+                        selected_count += 1
                         self.graph.add_edge(r1.ID, r2.ID, **m.__dict__)
                 pbar.update(1)
 
         logging.getLogger("PPanGGOLiN").info(
             f"RGP metrics computed for {nb_pairs:,} pairs of RGPs "
-            f"({len(self.metrics):,} selected after GRR cutoff)"
+            f"({selected_count:,} selected after GRR cutoff)"
         )
 
     def _louvain_clustering(self, metric: RGPMetricType):

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -3,6 +3,7 @@
 # default libraries
 import logging
 import argparse
+import json
 import os
 import resource
 from itertools import combinations
@@ -215,7 +216,6 @@ class RGPClusteringOptions:
     graph_formats: list[str] = ("gexf", "graphml")
     with_metadata: bool = False
     metadata_sources: list[str] = field(default_factory=list)
-    metadata_sep: str = "|"
 
 class RGPClustering:
     def __init__(self, pangenome_h5: Path):
@@ -229,6 +229,16 @@ class RGPClustering:
         self._contig_to_organism: dict[str, str] = None
         self._rgp_to_nb_genes: dict[str, int] = None
         self._rgp_to_contig_info: dict[str, RGPGenes] = None
+        self._rgp_to_genes: dict[str, set[str]] = None
+        self._family_id_to_name: dict[int, str] = None
+        self._has_metadata: bool = False
+        self._rgp_metadata_values: Dict[str, Dict[str, list]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        self._family_metadata_sources: Dict[str, set] = defaultdict(set)
+        self._gene_metadata_sources: Dict[str, set] = defaultdict(set)
+        self._spot_metadata_sources: Dict[int, set] = defaultdict(set)
+        self._module_metadata_sources: Dict[int, set] = defaultdict(set)
 
     def _get_rgp_spot(self, reader: H5Reader) -> dict[str, int]:
         rgp_to_spot: dict[str, int] = {}
@@ -374,6 +384,115 @@ class RGPClustering:
 
         return rgp_genes
 
+    def _get_metadata_sources(
+        self, reader: H5Reader, metadata_sources: list[str] = None
+    ) -> dict[str, list[str]]:
+        """
+        Get, per metatype, the list of metadata sources present in the pangenome file,
+        restricted to the requested sources (if any).
+        """
+        status_attrs = reader.handle.root.status._v_attrs
+        if not (hasattr(status_attrs, "metadata") and status_attrs.metadata):
+            return {}
+
+        metastatus = reader.handle.root.status.metastatus._v_attrs
+        metasources = reader.handle.root.status.metasources._v_attrs
+
+        metatype_to_sources: dict[str, list[str]] = {}
+        for metatype in ("RGPs", "genes", "spots", "families", "modules"):
+            if not getattr(metastatus, metatype, False):
+                continue
+
+            sources = list(getattr(metasources, metatype, []))
+            if metadata_sources is not None:
+                sources = [source for source in sources if source in metadata_sources]
+
+            if sources:
+                metatype_to_sources[metatype] = sources
+                logging.info(
+                    f"Metadata for {metatype} found in pangenome with sources {sources}. "
+                    "They will be included in the RGP graph."
+                )
+            elif metadata_sources is not None:
+                logging.info(
+                    f"Metadata for {metatype} found in pangenome, but none match the "
+                    f"specified sources {metadata_sources}."
+                )
+
+        return metatype_to_sources
+
+    def _read_metadata_source(
+        self,
+        reader: H5Reader,
+        metatype: str,
+        source: str,
+        value_target: Dict[str, Dict[str, list]] = None,
+        source_target: Dict[Union[str, int], set] = None,
+    ) -> None:
+        """
+        Read a single metadata source table directly from the H5 file (lightweight, no
+        pangenome object creation), and accumulate either the raw values (for RGPs metadata,
+        which are written as node attributes) and/or the set of sources providing metadata
+        for each identifier (used for family/gene/module/spot presence flags).
+        """
+        table = reader.handle.get_node(f"/metadata/{metatype}/{source}")
+
+        for row in table.iterrows():
+            identifier = row["ID"]
+            if isinstance(identifier, bytes):
+                identifier = identifier.decode("utf-8")
+
+            if source_target is not None:
+                source_target[identifier].add(source)
+
+            if value_target is not None:
+                for field in table.colnames:
+                    if field == "ID":
+                        continue
+                    value = row[field]
+                    if isinstance(value, bytes):
+                        value = value.decode("utf-8")
+                    value_target[identifier][f"{source}_{field}"].append(str(value))
+    def _load_metadata(
+        self, reader: H5Reader, metadata_sources: list[str] = None
+    ) -> None:
+        """
+        Load metadata directly from the H5 file, in the same lightweight way RGP info is
+        loaded (reading tables directly instead of building full pangenome objects).
+        """
+        metatype_to_sources = self._get_metadata_sources(reader, metadata_sources)
+
+        for metatype, sources in metatype_to_sources.items():
+            for source in sources:
+                if metatype == "RGPs":
+                    self._read_metadata_source(
+                        reader, metatype, source, value_target=self._rgp_metadata_values
+                    )
+                elif metatype == "families":
+                    self._read_metadata_source(
+                        reader,
+                        metatype,
+                        source,
+                        source_target=self._family_metadata_sources,
+                    )
+                elif metatype == "genes":
+                    self._read_metadata_source(
+                        reader, metatype, source, source_target=self._gene_metadata_sources
+                    )
+                elif metatype == "spots":
+                    self._read_metadata_source(
+                        reader, metatype, source, source_target=self._spot_metadata_sources
+                    )
+                elif metatype == "modules":
+                    self._read_metadata_source(
+                        reader,
+                        metatype,
+                        source,
+                        source_target=self._module_metadata_sources,
+                    )
+
+        self._has_metadata = bool(metatype_to_sources)
+
     def _get_rgp_info(
         self,
         reader: H5Reader,
@@ -392,6 +511,7 @@ class RGPClustering:
 
         unique_families = set(gene_to_family.values())
         family_ids = {fam: idx for idx, fam in enumerate(unique_families)}
+        self._family_id_to_name = {idx: fam for fam, idx in family_ids.items()}
 
         rgp_infos: list[RGPInfo] = []
 
@@ -502,12 +622,15 @@ class RGPClustering:
         m = RGPMetric(max_grr, min_grr, agrr, len(r1.families & r2.families))
         return m if getattr(m, metric) >= grr_cutoff else None
 
-    def _construct_regions(self):
+    def _construct_regions(
+        self, with_metadata: bool = False, metadata_sources: list[str] = None
+    ):
         logging.info("Loading RGPs from pangenome H5 file")
 
         with H5Reader(self.h5) as reader:
 
             rgp_to_genes = self._get_rgp_genes(reader)
+            self._rgp_to_genes = rgp_to_genes
 
             contigs_with_rgp = {rgp_name.split("_RGP_")[0] for rgp_name in rgp_to_genes}
 
@@ -519,6 +642,9 @@ class RGPClustering:
 
             self._rgp_to_spot = self._get_rgp_spot(reader)
             self._fam_to_modules = self._get_fam_to_modules(reader)
+
+            if with_metadata:
+                self._load_metadata(reader, metadata_sources)
 
             fams_to_rgps: defaultdict[tuple[int], list[RGPInfo]] = defaultdict(list)
 
@@ -611,11 +737,71 @@ class RGPClustering:
         else:
             return "No spot"
 
+    def _add_metadata_info(
+        self,
+        info: dict,
+        rgp_names: List[str],
+        families_ids: BitMap,
+        module_ids: Set[int],
+    ) -> None:
+        """
+        Add metadata-derived attributes to a node info dict: booleans indicating whether
+        family/gene/module/spot metadata is present from a given source, and the RGP's own
+        metadata fields.
+        """
+        if not self._has_metadata:
+            return
+
+        element_to_sources = {
+            "family": set().union(
+                *(
+                    self._family_metadata_sources.get(self._family_id_to_name[fid], set())
+                    for fid in families_ids
+                )
+            )
+            if families_ids
+            else set(),
+            "module": set().union(
+                *(
+                    self._module_metadata_sources.get(module_id, set())
+                    for module_id in module_ids
+                )
+            )
+            if module_ids
+            else set(),
+            "gene": set(),
+            "spot": set(),
+        }
+
+        for rgp_name in rgp_names:
+            for gene_name in self._rgp_to_genes.get(rgp_name, ()):
+                element_to_sources["gene"] |= self._gene_metadata_sources.get(
+                    gene_name, set()
+                )
+
+            spot_id = self._rgp_to_spot.get(rgp_name)
+            if spot_id is not None:
+                element_to_sources["spot"] |= self._spot_metadata_sources.get(
+                    spot_id, set()
+                )
+
+        for element, sources in element_to_sources.items():
+            for source in sources:
+                info[f"has_{element}_with_{source}"] = True
+
+        combined_rgp_metadata: Dict[str, list] = defaultdict(list)
+        for rgp_name in rgp_names:
+            for key, values in self._rgp_metadata_values.get(rgp_name, {}).items():
+                combined_rgp_metadata[key].extend(values)
+
+        for key, values in combined_rgp_metadata.items():
+            info[key] = json.dumps(values)
+
     def _make_info_identical_rgp(self, rgp: RegionProxy) -> dict:
 
         spots = {self._spot_id(child) for child in rgp.children}
 
-        return {
+        info = {
             "identical_rgp_group": True,
             "name": rgp.name,
             "families_count": len(rgp.families),
@@ -637,9 +823,18 @@ class RGPClustering:
             "modules": ";".join(f"module_{module}" for module in rgp.modules),
             }
 
+        self._add_metadata_info(
+            info,
+            [child.name for child in rgp.children],
+            rgp.families,
+            rgp.modules,
+        )
+
+        return info
+
     def _make_info_from_rgp(self, rgp: RegionProxy) -> dict:
 
-        return {
+        info = {
             "contig": rgp.contig,
             "genome": rgp.organism,
             "name": rgp.name,
@@ -650,6 +845,10 @@ class RGPClustering:
             "modules": ";".join(f"module_{module}" for module in rgp.modules),
             "families_count": rgp.nb_families,
         }
+
+        self._add_metadata_info(info, [rgp.name], rgp.families, rgp.modules)
+
+        return info
 
     def _add_info_to_rgps(self):
 
@@ -745,13 +944,16 @@ class RGPClustering:
     def run(self, options: RGPClusteringOptions):
 
         # Get initial memory
-        rss_start = (
-            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        )  # Convert to MB (on Linux, ru_maxrss is in KB)
-        logging.info(f"Memory at start: RSS peak={rss_start:.2f} MB")
+        # rss_start = (
+        #     resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        # )  # Convert to MB (on Linux, ru_maxrss is in KB)
+        # logging.info(f"Memory at start: RSS peak={rss_start:.2f} MB")
 
         with Timer("_construct_regions", logging):
-            self._construct_regions()
+            self._construct_regions(
+                with_metadata=options.with_metadata,
+                metadata_sources=options.metadata_sources or None,
+            )
 
         # print("NEW", ">" * 40)
 
@@ -759,38 +961,38 @@ class RGPClustering:
         # print(self.graph.number_of_nodes(), "nodes in graph")
         # print(self.graph.number_of_edges(), "edges in graph")
         # print("<" * 40)
-        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        logging.info(f"Memory after _construct_regions: RSS peak={rss_peak:.2f} MB")
+        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        # logging.info(f"Memory after _construct_regions: RSS peak={rss_peak:.2f} MB")
+        with Timer("_compute_all_metrics", logging):
+            self._compute_all_metrics(options.grr_cutoff, options.metric)
 
-        self._compute_all_metrics(options.grr_cutoff, options.metric)
-
-        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        logging.info(f"Memory after _compute_all_metrics: RSS peak={rss_peak:.2f} MB")
+        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        # logging.info(f"Memory after _compute_all_metrics: RSS peak={rss_peak:.2f} MB")
 
         self._louvain_clustering(options.metric)
 
-        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        logging.info(f"Memory after _louvain_clustering: RSS peak={rss_peak:.2f} MB")
+        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        # logging.info(f"Memory after _louvain_clustering: RSS peak={rss_peak:.2f} MB")
 
         if options.unmerge_identical_rgps:
             self._add_edges_to_identical_rgps()
 
-        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        logging.info(
-            f"Memory after identical_rgps processing: RSS peak={rss_peak:.2f} MB"
-        )
+        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        # logging.info(
+        #     f"Memory after identical_rgps processing: RSS peak={rss_peak:.2f} MB"
+        # )
 
         self._add_info_to_rgps()
 
-        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        logging.info(f"Memory after _add_info_to_rgps: RSS peak={rss_peak:.2f} MB")
+        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        # logging.info(f"Memory after _add_info_to_rgps: RSS peak={rss_peak:.2f} MB")
 
         self._write_outputs(
             options.output, options.basename, options.graph_formats, options.metric
         )
 
-        rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        logging.info(f"Memory after _write_outputs: RSS peak={rss_peak:.2f} MB")
+        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        # logging.info(f"Memory after _write_outputs: RSS peak={rss_peak:.2f} MB")
 
     @property
     def rgp_count(self) -> int:
@@ -1462,29 +1664,29 @@ def cluster_rgp(
     print("<" * 40)
     # Get all pairs of RGP that share at least one family
 
-    family2rgp = defaultdict(set)
-    for rgp in dereplicated_rgps:
-        for fam in rgp.families:
-            family2rgp[fam].add(rgp)
+    with Timer("OLD compute_all_metrics", logging):
+        family2rgp = defaultdict(set)
+        for rgp in dereplicated_rgps:
+            for fam in rgp.families:
+                family2rgp[fam].add(rgp)
+        rgp_pairs = set()
+        for rgps in family2rgp.values():
+            rgp_pairs |= {tuple(sorted(rgp_pair)) for rgp_pair in combinations(rgps, 2)}
 
-    rgp_pairs = set()
-    for rgps in family2rgp.values():
-        rgp_pairs |= {tuple(sorted(rgp_pair)) for rgp_pair in combinations(rgps, 2)}
+        pairs_count = len(rgp_pairs)
 
-    pairs_count = len(rgp_pairs)
+        logging.getLogger("PPanGGOLiN").info(
+            f"Computing GRR metric for {pairs_count:,} pairs of RGP."
+        )
 
-    logging.getLogger("PPanGGOLiN").info(
-        f"Computing GRR metric for {pairs_count:,} pairs of RGP."
-    )
+        pairs_of_rgps_metrics = []
 
-    pairs_of_rgps_metrics = []
+        for rgp_a, rgp_b in rgp_pairs:
 
-    for rgp_a, rgp_b in rgp_pairs:
+            pair_metrics = compute_rgp_metric(rgp_a, rgp_b, grr_cutoff, grr_metric)
 
-        pair_metrics = compute_rgp_metric(rgp_a, rgp_b, grr_cutoff, grr_metric)
-
-        if pair_metrics:
-            pairs_of_rgps_metrics.append(pair_metrics)
+            if pair_metrics:
+                pairs_of_rgps_metrics.append(pair_metrics)
 
     grr_graph.add_edges_from(pairs_of_rgps_metrics)
     identical_rgps_objects = [
@@ -1554,6 +1756,17 @@ def launch(args: argparse.Namespace):
 
     :param args: All arguments provided by user
     """
+    # Get initial memory
+    rss_start = (
+    resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+    )  # Convert to MB (on Linux, ru_maxrss is in KB)
+    logging.info(f"Memory before start: RSS peak={rss_start:.2f} MB")
+
+    if args.metadata_sep is not None:
+        logging.getLogger("PPanGGOLiN").warning(
+            "--metadata_sep is obsolete and ignored; metadata values are JSON-encoded in graphs."
+        )
+
     pangenome = Pangenome()
 
     mk_outdir(args.output, args.force)
@@ -1592,7 +1805,6 @@ def launch(args: argparse.Namespace):
                     basename=args.basename,
                     graph_formats=args.graph_formats,
                     with_metadata=args.add_metadata,
-                    metadata_sep=args.metadata_sep,
                     metadata_sources=args.metadata_sources,
                 )
             )
@@ -1761,6 +1973,5 @@ def parser_cluster_rgp(parser: argparse.ArgumentParser):
         "--metadata_sep",
         required=False,
         default="|",
-        help="The separator used to join multiple metadata values for elements with multiple metadata"
-        " values from the same source. This character should not appear in metadata values.",
+        help=argparse.SUPPRESS,
     )

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -274,20 +274,6 @@ class RGPClustering:
         self._spot_metadata_sources: Dict[int, set] = defaultdict(set)
         self._module_metadata_sources: Dict[int, set] = defaultdict(set)
 
-    def _check_required_status(
-        self,
-        status: dict,
-        required_statuses: dict[str, str],
-    ):
-        """Check that all required pangenome information is available in the H5 file."""
-
-        for status_name, description in required_statuses.items():
-            if status.get(status_name) != "inFile":
-                raise ValueError(
-                    f"Cannot compute RGP metrics: {description} is not available "
-                    "in the pangenome H5 file."
-                )
-
     def _get_rgp_spot(self, reader: H5Reader) -> dict[str, int]:
         rgp_to_spot: dict[str, int] = {}
         for table in reader.fetch(RGPSpotTable):
@@ -741,7 +727,9 @@ class RGPClustering:
             f"{len(rgp_infos)} RGPs loaded from pangenome ({len(self.rgps)} unique RGPs after dereplication)"
         )
         if len(rgp_infos) == 0:
-            logging.getLogger("PPanGGOLiN").warning("Pangenome contains no RGPs. Output files will be empty.")
+            logging.getLogger("PPanGGOLiN").warning(
+                "Pangenome contains no RGPs. Output files will be empty."
+            )
 
     def _compute_all_metrics(
         self, grr_cutoff: float, metric: RGPMetricType, disable_bar: bool = False
@@ -779,9 +767,10 @@ class RGPClustering:
             f"({len(self.metrics):,} selected after GRR cutoff)"
         )
 
-
     def _louvain_clustering(self, metric: RGPMetricType):
-        logging.getLogger("PPanGGOLiN").info(f"Clustering RGPs using Louvain communities on '{metric}' metric")
+        logging.getLogger("PPanGGOLiN").info(
+            f"Clustering RGPs using Louvain communities on '{metric}' metric"
+        )
 
         partitions = nx.algorithms.community.louvain_communities(
             self.graph, weight=metric, seed=42
@@ -798,7 +787,9 @@ class RGPClustering:
                 name=f"{metric}_cluster",
             )
 
-        logging.getLogger("PPanGGOLiN").info(f"Graph has {len(ordered_partitions)} RGP clusters using '{metric}'")
+        logging.getLogger("PPanGGOLiN").info(
+            f"Graph has {len(ordered_partitions)} RGP clusters using '{metric}'"
+        )
 
     def _add_edges_to_identical_rgps(self):
         logging.getLogger("PPanGGOLiN").info("Unmerging identical RGPs in the graph")
@@ -986,12 +977,16 @@ class RGPClustering:
     def _write_graphs(self, output: Path, basename: str, graph_formats: list[str]):
         if "gexf" in graph_formats:
             graph_filename = output / f"{basename}.gexf"
-            logging.getLogger("PPanGGOLiN").info(f"Writing RGP graph in GEXF format to {graph_filename}")
+            logging.getLogger("PPanGGOLiN").info(
+                f"Writing RGP graph in GEXF format to {graph_filename}"
+            )
             nx.write_gexf(self.graph, graph_filename)
 
         if "graphml" in graph_formats:
             graph_filename = output / f"{basename}.graphml"
-            logging.getLogger("PPanGGOLiN").info(f"Writing RGP graph in GraphML format to {graph_filename}")
+            logging.getLogger("PPanGGOLiN").info(
+                f"Writing RGP graph in GraphML format to {graph_filename}"
+            )
             nx.write_graphml(self.graph, graph_filename)
 
     def _write_cluster_table(self, output: Path, basename: str, metric: str):
@@ -1034,7 +1029,9 @@ class RGPClustering:
             sep="\t",
             index=False,
         )
-        logging.getLogger("PPanGGOLiN").info(f"Writing RGP clusters in TSV format to {outfile}")
+        logging.getLogger("PPanGGOLiN").info(
+            f"Writing RGP clusters in TSV format to {outfile}"
+        )
 
     def _write_outputs(
         self, output: Path, basename: str, graph_formats: list[str], metric: str
@@ -1058,7 +1055,6 @@ class RGPClustering:
             self._add_edges_to_identical_rgps()
 
         self._louvain_clustering(options.metric)
-
 
         self._add_info_to_rgps()
 
@@ -1181,6 +1177,7 @@ class IdenticalRegions:
             modules |= rgp.modules
 
         return modules
+
 
 def launch(args: argparse.Namespace):
     """

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -4,12 +4,10 @@
 import logging
 import argparse
 import json
-import os
-import resource
 from itertools import combinations
 from collections.abc import Callable
 from collections import defaultdict
-from typing import Dict, List, Tuple, Set, Union, Any
+from typing import Dict, List, Set, Union
 from pathlib import Path
 
 # installed libraries
@@ -18,11 +16,8 @@ import networkx as nx
 import pandas as pd
 
 # local libraries
-from ppanggolin import RGP
-from ppanggolin.pangenome import Pangenome
 from ppanggolin.region import Region, Spot, Module
-from ppanggolin.formats import check_pangenome_info
-from ppanggolin.utils import restricted_float, mk_outdir, Timer
+from ppanggolin.utils import restricted_float, mk_outdir
 from ppanggolin.geneFamily import GeneFamily
 
 import typing as tp
@@ -471,12 +466,12 @@ class RGPClustering:
 
             if sources:
                 metatype_to_sources[metatype] = sources
-                logging.info(
+                logging.getLogger("PPanGGOLiN").info(
                     f"Metadata for {metatype} found in pangenome with sources {sources}. "
                     "They will be included in the RGP graph."
                 )
             elif metadata_sources is not None:
-                logging.info(
+                logging.getLogger("PPanGGOLiN").info(
                     f"Metadata for {metatype} found in pangenome, but none match the "
                     f"specified sources {metadata_sources}."
                 )
@@ -702,7 +697,7 @@ class RGPClustering:
         metadata_sources: list[str] = None,
         ignore_incomplete_rgp: bool = False,
     ):
-        logging.info("Loading RGPs from pangenome H5 file")
+        logging.getLogger("PPanGGOLiN").info("Loading RGPs from pangenome H5 file")
 
         with H5Reader(self.h5) as reader:
 
@@ -721,7 +716,7 @@ class RGPClustering:
                 rgp_infos = [
                     rgp_info for rgp_info in rgp_infos if not rgp_info.is_contig_border
                 ]
-                logging.info(
+                logging.getLogger("PPanGGOLiN").info(
                     f"{len(rgp_infos)} RGPs loaded from pangenome after filtering out incomplete RGPs"
                 )
 
@@ -742,7 +737,7 @@ class RGPClustering:
                 self._construct_and_add(idx, rgps)
                 idx += len(rgps) + 1 if len(rgps) > 1 else 1
 
-        logging.info(
+        logging.getLogger("PPanGGOLiN").info(
             f"{len(rgp_infos)} RGPs loaded from pangenome ({len(self.rgps)} unique RGPs after dereplication)"
         )
 
@@ -750,9 +745,7 @@ class RGPClustering:
         self, grr_cutoff: float, metric: RGPMetricType, disable_bar: bool = False
     ):
         """Compute metrics without materializing the set of candidate pairs."""
-        logging.info("Computing RGP metrics")
-
-        memory_before = self._memory_snapshot()
+        logging.getLogger("PPanGGOLiN").info("Computing RGP metrics")
 
         family_to_rgps = defaultdict(list)
         for rgp in self.rgps:
@@ -779,41 +772,14 @@ class RGPClustering:
                         self.graph.add_edge(r1.ID, r2.ID, **m.__dict__)
                 pbar.update(1)
 
-        logging.info(
+        logging.getLogger("PPanGGOLiN").info(
             f"RGP metrics computed for {nb_pairs:,} pairs of RGPs "
             f"({len(self.metrics):,} selected after GRR cutoff)"
         )
-        self._log_memory_usage("_compute_all_metrics_streaming", memory_before)
 
-    @staticmethod
-    def _memory_snapshot() -> tuple[float, float]:
-        current_rss_mb = None
-        with open("/proc/self/status") as status:
-            for line in status:
-                if line.startswith("VmRSS:"):
-                    current_rss_mb = int(line.split()[1]) / 1024
-                    break
-
-        if current_rss_mb is None:
-            raise RuntimeError("VmRSS is unavailable")
-
-        peak_rss_mb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        return current_rss_mb, peak_rss_mb
-
-    def _log_memory_usage(
-        self, method_name: str, memory_before: tuple[float, float]
-    ) -> None:
-        current_before, peak_before = memory_before
-        current_after, peak_after = self._memory_snapshot()
-        logging.info(
-            f"Memory for {method_name}: "
-            f"current RSS delta={current_after - current_before:.2f} MB, "
-            f"peak RSS increase={peak_after - peak_before:.2f} MB, "
-            f"peak RSS={peak_after:.2f} MB"
-        )
 
     def _louvain_clustering(self, metric: RGPMetricType):
-        logging.info(f"Clustering RGPs using Louvain communities on '{metric}' metric")
+        logging.getLogger("PPanGGOLiN").info(f"Clustering RGPs using Louvain communities on '{metric}' metric")
 
         partitions = nx.algorithms.community.louvain_communities(
             self.graph, weight=metric, seed=42
@@ -830,10 +796,10 @@ class RGPClustering:
                 name=f"{metric}_cluster",
             )
 
-        logging.info(f"Graph has {len(ordered_partitions)} clusters using '{metric}'")
+        logging.getLogger("PPanGGOLiN").info(f"Graph has {len(ordered_partitions)} clusters using '{metric}'")
 
     def _add_edges_to_identical_rgps(self):
-        logging.info("Unmerging identical RGPs in the graph")
+        logging.getLogger("PPanGGOLiN").info("Unmerging identical RGPs in the graph")
 
         unmerged = 0
         edge_data = {
@@ -864,7 +830,7 @@ class RGPClustering:
             self.graph.add_edges_from(edges)
             self.graph.remove_node(rgp.ID)
 
-        logging.info(f"Unmerged {unmerged} identical RGPs")
+        logging.getLogger("PPanGGOLiN").info(f"Unmerged {unmerged} identical RGPs")
 
     def _spot_id(self, rgp: RegionProxy) -> str:
         if rgp.name in self._rgp_to_spot:
@@ -991,7 +957,7 @@ class RGPClustering:
 
     def _add_info_to_rgps(self):
 
-        logging.info("Adding info to RGPs in graph")
+        logging.getLogger("PPanGGOLiN").info("Adding info to RGPs in graph")
 
         annotated = 0
         for rgp in self.rgps:
@@ -1013,24 +979,18 @@ class RGPClustering:
                         )
                         annotated += 1
 
-        logging.info(f"Added info to {annotated} RGPs")
+        logging.getLogger("PPanGGOLiN").info(f"Added info to {annotated} RGPs")
 
     def _write_graphs(self, output: Path, basename: str, graph_formats: list[str]):
         if "gexf" in graph_formats:
             graph_filename = output / f"{basename}.gexf"
-            logging.info(f"Writing RGP graph in GEXF format to {graph_filename}")
+            logging.getLogger("PPanGGOLiN").info(f"Writing RGP graph in GEXF format to {graph_filename}")
             nx.write_gexf(self.graph, graph_filename)
-
-            rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-            logging.info(f"Memory after writing GEXF: RSS peak={rss_peak:.2f} MB")
 
         if "graphml" in graph_formats:
             graph_filename = output / f"{basename}.graphml"
-            logging.info(f"Writing RGP graph in GraphML format to {graph_filename}")
+            logging.getLogger("PPanGGOLiN").info(f"Writing RGP graph in GraphML format to {graph_filename}")
             nx.write_graphml(self.graph, graph_filename)
-
-            rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-            logging.info(f"Memory after writing GraphML: RSS peak={rss_peak:.2f} MB")
 
     def _write_cluster_table(self, output: Path, basename: str, metric: str):
         outfile = output / f"{basename}.tsv"
@@ -1072,7 +1032,7 @@ class RGPClustering:
             sep="\t",
             index=False,
         )
-        logging.info(f"Writing RGP clusters in TSV format to {outfile}")
+        logging.getLogger("PPanGGOLiN").info(f"Writing RGP clusters in TSV format to {outfile}")
 
     def _write_outputs(
         self, output: Path, basename: str, graph_formats: list[str], metric: str
@@ -1082,30 +1042,14 @@ class RGPClustering:
 
     def run(self, options: RGPClusteringOptions):
 
-        with Timer("_construct_regions", logging):
-            self._construct_regions(
-                with_metadata=options.with_metadata,
-                metadata_sources=options.metadata_sources or None,
-                ignore_incomplete_rgp=options.ignore_incomplete_rgp,
-            )
-
-        rss_peak_after_construct_regions = (
-            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        )
-        logging.info(
-            f"Memory after _construct_regions: RSS peak={rss_peak_after_construct_regions:.2f} MB"
+        self._construct_regions(
+            with_metadata=options.with_metadata,
+            metadata_sources=options.metadata_sources or None,
+            ignore_incomplete_rgp=options.ignore_incomplete_rgp,
         )
 
-        with Timer("_compute_all_metrics", logging):
-            self._compute_all_metrics(
-                options.grr_cutoff, options.metric, disable_bar=options.disable_prog_bar
-            )
-
-        rss_peak_after_compute_all_metrics = (
-            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        )
-        logging.info(
-            f"Memory after _compute_all_metrics: RSS peak={rss_peak_after_compute_all_metrics:.2f} MB"
+        self._compute_all_metrics(
+            options.grr_cutoff, options.metric, disable_bar=options.disable_prog_bar
         )
 
         if options.unmerge_identical_rgps:
@@ -1113,25 +1057,12 @@ class RGPClustering:
 
         self._louvain_clustering(options.metric)
 
-        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        # logging.info(f"Memory after _louvain_clustering: RSS peak={rss_peak:.2f} MB")
-
-        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        # logging.info(
-        #     f"Memory after identical_rgps processing: RSS peak={rss_peak:.2f} MB"
-        # )
 
         self._add_info_to_rgps()
-
-        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        # logging.info(f"Memory after _add_info_to_rgps: RSS peak={rss_peak:.2f} MB")
 
         self._write_outputs(
             options.output, options.basename, options.graph_formats, options.metric
         )
-
-        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        # logging.info(f"Memory after _write_outputs: RSS peak={rss_peak:.2f} MB")
 
     @property
     def rgp_count(self) -> int:
@@ -1249,713 +1180,35 @@ class IdenticalRegions:
 
         return modules
 
-
-def compute_grr(
-    rgp_a_families: Set[GeneFamily], rgp_b_families: Set[GeneFamily], mode: Callable
-) -> float:
-    """
-    Compute gene repertoire relatedness (GRR) between two rgp.
-    Mode can be the function min to compute min GRR or max to compute max_grr
-
-    :param rgp_a_families: Rgp A
-    :param rgp_b_families: rgp B
-    :param mode: min or max function
-
-    :return: GRR value between 0 and 1
-    """
-
-    grr = len(rgp_a_families & rgp_b_families) / mode(
-        len(rgp_a_families), len(rgp_b_families)
-    )
-
-    return grr
-
-
-def compute_jaccard_index(rgp_a_families: set, rgp_b_families: set) -> float:
-    """
-    Compute jaccard index between two rgp based on their families.
-
-    :param rgp_a_families: Rgp A
-    :param rgp_b_families: rgp B
-
-    :return : Jaccard index
-    """
-
-    jaccard_index = len(rgp_a_families & rgp_b_families) / len(
-        rgp_a_families | rgp_b_families
-    )
-
-    return jaccard_index
-
-
-def add_info_to_rgp_nodes(graph, regions: List[Region], region_to_spot: dict):
-    """
-    Format RGP information into a dictionary for adding to the graph.
-
-    This function takes a list of RGPs and a dictionary mapping each RGP to its corresponding spot ID,
-    and formats the RGP information into a dictionary for further processing or addition to a graph.
-
-    :param graph: RGPs graph
-    :param regions: A list of RGPs.
-    :param region_to_spot: A dictionary mapping each RGP to its corresponding spot ID.
-    :return: A dictionary with RGP id as the key and a dictionary containing information on the corresponding RGP as value.
-    """
-
-    region_attributes = {}
-    for region in regions:
-        region_info = {
-            "contig": region.contig.name,
-            "genome": region.organism.name,
-            "name": region.name,
-            "genes_count": len(region),
-            "is_contig_border": region.is_contig_border,
-            "is_whole_contig": region.is_whole_contig,
-            "spot_id": get_spot_id(region, region_to_spot),
-            "modules": ";".join({str(module) for module in region.modules}),
-            "families_count": region.number_of_families,
-        }
-
-        region_attributes[region.ID] = region_info
-
-        node_attributes = graph.nodes[region.ID]
-        node_attributes.update(region_info)
-
-    return region_attributes
-
-
-def join_dicts(dicts: List[Dict[str, Any]], delimiter: str = ";") -> Dict[str, Any]:
-    """
-    Join dictionaries by concatenating the values with a custom delimiter for common keys.
-
-    Given a list of dictionaries, this function creates a new dictionary where the values for common keys
-    are concatenated with the specified delimiter.
-
-    :param dicts: A list of dictionaries to be joined.
-    :param delimiter: The delimiter to use for joining values. Default is ';'.
-    :return: A dictionary with joined values for common keys.
-    """
-    final_dict = defaultdict(list)
-    for dict_obj in dicts:
-        for k, v in dict_obj.items():
-            final_dict[k].append(str(v))
-    return {k: delimiter.join(v) for k, v in final_dict.items()}
-
-
-def format_rgp_metadata(rgp: Region) -> Dict[str, str]:
-    """
-    Format RGP metadata by combining source and field values.
-
-    Given an RGP object with metadata, this function creates a new dictionary where the keys
-    are formatted as 'source_field' and the values are concatenated with '|' as the delimiter.
-
-    :param rgp: The RGP object with metadata.
-    :return: A dictionary with formatted metadata.
-    """
-    source_field_2_value = defaultdict(list)
-    for rgp_metadata in rgp.metadata:
-        source = rgp_metadata.source
-        for field in rgp_metadata.fields:
-            source_field_2_value[f"{source}_{field}"].append(
-                str(rgp_metadata.get(field))
-            )
-
-    return {
-        col_name: "|".join(values) for col_name, values in source_field_2_value.items()
-    }
-
-
-def add_rgp_metadata_to_graph(
-    graph: nx.Graph, rgps: List[Union[Region, IdenticalRegions]]
-) -> None:
-    """
-    Add metadata from Region or IdenticalRegions objects to the graph.
-
-    :param graph: The graph to which the metadata will be added.
-    :param rgps: A set of Region or IdenticalRegions objects containing the metadata to be added.
-
-    """
-    for rgp in rgps:
-        element_to_metadata_sources = {
-            "family": set(),
-            "gene": set(),
-            "module": set(),
-            "spot": set(),
-        }
-
-        for family in rgp.families:
-            element_to_metadata_sources["family"] |= {
-                metadata.source for metadata in family.metadata
-            }
-            if family.module:
-                element_to_metadata_sources["module"] |= {
-                    metadata.source for metadata in family.module.metadata
-                }
-
-        for gene in rgp.genes:
-            element_to_metadata_sources["gene"] |= {
-                metadata.source for metadata in gene.metadata
-            }
-
-        if isinstance(rgp, Region):
-            rgp_metadata = rgp.formatted_metadata_dict_to_string()
-            if rgp.spot is not None:
-                element_to_metadata_sources["spot"] = {
-                    metadata.source for metadata in rgp.spot.metadata
-                }
-
-        elif isinstance(rgp, IdenticalRegions):
-            rgp_metadata_dicts = [
-                ident_rgp.formatted_metadata_dict_to_string() for ident_rgp in rgp.rgps
-            ]
-            rgp_metadata = join_dicts(rgp_metadata_dicts)
-
-            element_to_metadata_sources["spot"] |= {
-                metadata.source for spot in rgp.spots for metadata in spot.metadata
-            }
-
-        else:
-            raise TypeError(
-                f"Expect Region or IdenticalRegions object, not {type(rgp)}"
-            )
-
-        for element, metadata_sources in element_to_metadata_sources.items():
-            for source in metadata_sources:
-                graph.nodes[rgp.ID][f"has_{element}_with_{source}"] = True
-
-        for metadata_name, value in rgp_metadata.items():
-            graph.nodes[rgp.ID][metadata_name] = value
-
-
-def add_info_to_identical_rgps(
-    rgp_graph: nx.Graph,
-    identical_rgps_objects: List[IdenticalRegions],
-    rgp_to_spot: Dict[Region, int],
-):
-    """
-    Add identical rgps info in the graph as node attributes.
-
-    :params rgp_graph: Graph with rgp id as node and grr value as edges
-    :params rgp_to_identical_rgps: dict with uniq RGP as the key and set of identical rgps as value
-    """
-
-    for identical_rgp_obj in identical_rgps_objects:
-        spots_of_identical_rgp_obj = {
-            get_spot_id(i_rgp, rgp_to_spot) for i_rgp in identical_rgp_obj.rgps
-        }
-
-        rgp_graph.add_node(
-            identical_rgp_obj.ID,
-            identical_rgp_group=True,
-            name=identical_rgp_obj.name,
-            families_count=len(identical_rgp_obj.families),
-            identical_rgp_count=len(identical_rgp_obj.rgps),
-            identical_rgp_names=";".join(
-                i_rgp.name for i_rgp in identical_rgp_obj.rgps
-            ),
-            identical_rgp_genomes=";".join(
-                {i_rgp.organism.name for i_rgp in identical_rgp_obj.rgps}
-            ),
-            identical_rgp_contig_border_count=len(
-                [True for i_rgp in identical_rgp_obj.rgps if i_rgp.is_contig_border]
-            ),
-            identical_rgp_whole_contig_count=len(
-                [True for i_rgp in identical_rgp_obj.rgps if i_rgp.is_whole_contig]
-            ),
-            identical_rgp_spots=";".join(spots_of_identical_rgp_obj),
-            spot_id=(
-                spots_of_identical_rgp_obj.pop()
-                if len(spots_of_identical_rgp_obj) == 1
-                else "Multiple spots"
-            ),
-            modules=";".join(
-                f"module_{module.ID}" for module in identical_rgp_obj.modules
-            ),
-        )
-
-
-def add_edges_to_identical_rgps(
-    rgp_graph: nx.Graph, identical_rgps_objects: List[IdenticalRegions]
-):
-    """
-    Replace identical rgp objects by all identical RGPs it contains.
-
-    :param rgp_graph: The RGP graph to add edges to.
-    :param identical_rgps_objects: A dictionary mapping RGPs to sets of identical RGPs.
-    """
-
-    identical_edge_data = {
-        "grr": 1.0,
-        "max_grr": 1.0,
-        "min_grr": 1.0,
-        "identical_famillies": True,
-    }
-
-    added_identical_rgps = []
-
-    for identical_rgp_obj in identical_rgps_objects:
-
-        rgp_graph.add_nodes_from(
-            [ident_rgp.ID for ident_rgp in identical_rgp_obj.rgps],
-            identical_rgp_group=identical_rgp_obj.name,
-        )
-
-        # add edge between identical rgp with metrics at one (perfect score)
-        edges_to_add = [
-            (rgp_a.ID, rgp_b.ID, identical_edge_data)
-            for rgp_a, rgp_b in combinations(identical_rgp_obj.rgps, 2)
-        ]
-
-        # replicate all edges that connect identical rgp object to other rgps
-        for connected_rgp in rgp_graph.neighbors(identical_rgp_obj.ID):
-            edge_data = rgp_graph[identical_rgp_obj.ID][connected_rgp]
-            edges_to_add += [
-                (identical_rgp.ID, connected_rgp, edge_data)
-                for identical_rgp in identical_rgp_obj.rgps
-            ]
-
-        rgp_graph.add_edges_from(edges_to_add)
-
-        # remove node of the identical rgp object
-        rgp_graph.remove_node(identical_rgp_obj.ID)
-
-        added_identical_rgps += list(identical_rgp_obj.rgps)
-
-    return added_identical_rgps
-
-
-def dereplicate_rgp(
-    rgps: Set[Union[Region, IdenticalRegions]], disable_bar: bool = False
-) -> List[Union[Region, IdenticalRegions]]:
-    """
-    Dereplicate RGPs that have the same families.
-
-    Given a list of Region or IdenticalRegions objects representing RGPs, this function groups together
-    RGPs with the same families into IdenticalRegions objects and returns a list of dereplicated RGPs.
-
-    :param rgps: A set of Region or IdenticalRegions objects representing the RGPs to be dereplicated.
-    :param disable_bar: If True, disable the progress bar.
-
-    :return: A list of dereplicated RGPs (Region or IdenticalRegions objects). For RGPs with the same families,
-             they will be grouped together in IdenticalRegions objects.
-    """
-    logging.getLogger("PPanGGOLiN").info(f"Dereplicating {len(rgps)} RGPs")
-    families_to_rgps = defaultdict(list)
-
-    for rgp in tqdm(rgps, total=len(rgps), unit="RGP", disable=disable_bar):
-        families_to_rgps[tuple(sorted(set(f.ID for f in rgp.families)))].append(rgp)
-
-    print(
-        f"{len(families_to_rgps)} unique family combinations found in {len(rgps)} RGPs"
-    )
-    dereplicated_rgps = []
-    identical_region_count = 0
-    for rgps in families_to_rgps.values():
-        if len(rgps) == 1:
-            dereplicated_rgps.append(rgps[0])
-        else:
-            families = set(rgps[0].families)
-
-            # identical regions object is considered on a contig border if all rgp are contig border
-            is_contig_border = all(rgp.is_contig_border for rgp in rgps)
-
-            # create a new object that will represent the identical rgps
-            identical_rgp = IdenticalRegions(
-                name=f"identical_rgps_{identical_region_count}",
-                identical_rgps=set(rgps),
-                families=families,
-                is_contig_border=is_contig_border,
-            )
-            identical_region_count += 1
-            dereplicated_rgps.append(identical_rgp)
-
-    logging.getLogger("PPanGGOLiN").info(f"{len(dereplicated_rgps)} unique RGPs")
-    return dereplicated_rgps
-
-
-def compute_rgp_metric(
-    rgp_a: Region, rgp_b: Region, grr_cutoff: float, grr_metric: str
-) -> Union[Tuple[int, int, dict], None]:
-    """
-    Compute GRR metric between two RGPs.
-
-    :param rgp_a: A rgp
-    :param rgp_b: another rgp
-    :param grr_cutoff: Cutoff filter
-    :param grr_metric: grr mode between min_grr, max_grr and incomplete_aware_grr
-
-    :returns: Tuple containing the IDs of the two RGPs and the computed metrics as a dictionary
-    """
-
-    edge_metrics = {}
-
-    # RGP at a contig border are seen as incomplete and min GRR is used instead of max GRR
-    if rgp_a.is_contig_border or rgp_b.is_contig_border:
-        edge_metrics["incomplete_aware_grr"] = compute_grr(
-            set(rgp_a.families), set(rgp_b.families), min
-        )
-    else:
-        edge_metrics["incomplete_aware_grr"] = compute_grr(
-            set(rgp_a.families), set(rgp_b.families), max
-        )
-
-    # Compute max and min GRR metrics
-    edge_metrics["max_grr"] = compute_grr(set(rgp_a.families), set(rgp_b.families), max)
-    edge_metrics["min_grr"] = compute_grr(set(rgp_a.families), set(rgp_b.families), min)
-
-    # The number of shared families can be useful when visualizing the graph
-    edge_metrics["shared_family"] = len(
-        set(rgp_a.families).intersection(set(rgp_b.families))
-    )
-
-    # Only return the metrics if the GRR value is above the cutoff
-    if edge_metrics[grr_metric] >= grr_cutoff:
-        return rgp_a.ID, rgp_b.ID, edge_metrics
-
-
-def cluster_rgp_on_grr(graph: nx.Graph, clustering_attribute: str = "grr"):
-    """
-    Cluster rgp based on grr using louvain communities clustering.
-
-    :param graph: NetworkX graph object representing the RGPs and their relationship
-    :param clustering_attribute: Attribute of the graph to use for clustering (default is "grr")
-    """
-
-    partitions = nx.algorithms.community.louvain_communities(
-        graph, weight=clustering_attribute, seed=42
-    )
-    ordered_partitions = sorted(
-        partitions,
-        key=lambda nodes: (min(nodes), len(nodes)),
-    )
-
-    for i, nodes in enumerate(ordered_partitions):
-        nx.set_node_attributes(
-            graph,
-            {node: f"cluster_{i}" for node in nodes},
-            name=f"{clustering_attribute}_cluster",
-        )
-
-    logging.getLogger("PPanGGOLiN").info(
-        f"Graph has {len(partitions)} clusters using {clustering_attribute}"
-    )
-
-
-def get_spot_id(rgp: Region, rgp_to_spot: Dict[Region, int]) -> str:
-    """
-    Return Spot ID associated to an RGP.
-    It adds the prefix "spot" to the spot ID. When no spot is associated with the RGP,
-    then the string "No spot" is return
-
-    :param rgp: RGP id
-    :param rgp_to_spot: A dictionary mapping an RGP to its spot.
-
-    :return: Spot ID of the given RGP with the prefix spot or "No spot".
-    """
-    if rgp in rgp_to_spot:
-        return f"spot_{rgp_to_spot[rgp]}"
-    else:
-        return "No spot"
-
-
-def write_rgp_cluster_table(
-    outfile: str,
-    grr_graph: nx.Graph,
-    rgps_in_graph: List[Union[Region, IdenticalRegions]],
-    grr_metric: str,
-    rgp_to_spot: Dict[Region, int],
-) -> None:
-    """
-    Writes RGP cluster info to a TSV file using pandas.
-
-    :param outfile: Name of the tsv file
-    :param grr_graph: The GRR graph.
-    :param rgps_in_graph: A dictionary mapping an RGP to a set of identical RGPs.
-    :param grr_metric: The GRR metric used for clustering.
-    :param rgp_to_spot: A dictionary mapping an RGP to its spot.
-    :return: None
-    """
-
-    all_rgps_infos = []
-    for rgp_in_graph in rgps_in_graph:
-        cluster = grr_graph.nodes[rgp_in_graph.ID][f"{grr_metric}_cluster"]
-
-        identical_rgps = (
-            [rgp_in_graph] if isinstance(rgp_in_graph, Region) else rgp_in_graph.rgps
-        )
-
-        all_rgps_infos += [
-            {"RGPs": r.name, "cluster": cluster, "spot_id": get_spot_id(r, rgp_to_spot)}
-            for r in identical_rgps
-        ]
-
-    df = pd.DataFrame(all_rgps_infos)
-    df.to_csv(outfile, sep="\t", index=False)
-
-
-def cluster_rgp(
-    pangenome,
-    grr_cutoff: float,
-    output: str,
-    basename: str,
-    ignore_incomplete_rgp: bool,
-    unmerge_identical_rgps: bool,
-    grr_metric: str,
-    disable_bar: bool,
-    graph_formats: Set[str],
-    add_metadata: bool = False,
-    metadata_sep: str = "|",
-    metadata_sources: List[str] = None,
-):
-    """
-    Main function to cluster regions of genomic plasticity based on their GRR
-
-    :param pangenome: pangenome object
-    :param grr_cutoff: GRR cutoff value for clustering
-    :param output: Directory where the output files will be saved
-    :param basename: Basename for the output files
-    :param ignore_incomplete_rgp: Whether to ignore incomplete RGPs located at a contig border
-    :param unmerge_identical_rgps: Whether to unmerge identical RGPs into separate nodes in the graph
-    :param grr_metric: GRR metric to use for clustering
-    :param disable_bar: Whether to disable the progress bar
-    :param graph_formats: Set of graph file formats to save the output
-    :param add_metadata: Add metadata to cluster files
-    :param metadata_sep: The separator used to join multiple metadata values
-    :param metadata_sources: Sources of the metadata to use and write in the outputs. None means all sources are used.
-    """
-
-    metatypes = set()
-    need_metadata = False
-    if add_metadata:
-        for element in ["RGPs", "genes", "spots", "families", "modules"]:
-            if pangenome.status["metadata"][element] == "inFile":
-
-                sources_to_use = set(pangenome.status["metasources"][element])
-
-                if metadata_sources is not None:
-                    if (
-                        len(
-                            set(pangenome.status["metasources"][element])
-                            & set(metadata_sources)
-                        )
-                        == 0
-                    ):
-                        logging.getLogger("PPanGGOLiN").info(
-                            f"Metadata for {element} found in pangenome, but none match the specified sources {metadata_sources}. "
-                            f"Current source for {element}: {sources_to_use}."
-                        )
-                        continue
-                    else:
-                        sources_to_use = set(
-                            pangenome.status["metasources"][element]
-                        ) & set(metadata_sources)
-
-                need_metadata = True
-                metatypes.add(element)
-                logging.getLogger("PPanGGOLiN").info(
-                    f"Metadata for {element} found in pangenome with sources {sources_to_use}. They will be included in the RGP graph."
-                )
-
-    # check statuses and load info
-    check_pangenome_info(
-        pangenome,
-        need_families=True,
-        need_annotations=True,
-        disable_bar=disable_bar,
-        need_rgp=True,
-        need_spots=True,
-        need_modules=True,
-        need_metadata=need_metadata,
-        sources=metadata_sources,
-        metatypes=metatypes,
-    )
-
-    if pangenome.regions == 0:
-        raise Exception(
-            "The pangenome has no RGPs. The clustering of RGP is then not possible."
-        )
-
-    # add all rgp as node
-    if ignore_incomplete_rgp:
-        valid_rgps = [rgp for rgp in pangenome.regions if not rgp.is_contig_border]
-
-        ignored_rgp_count = pangenome.number_of_rgp - len(valid_rgps)
-        total_rgp_count = pangenome.number_of_rgp
-
-        logging.getLogger("PPanGGOLiN").info(
-            f"Ignoring {ignored_rgp_count}/{total_rgp_count} ({100 * ignored_rgp_count / total_rgp_count:.2f}%) "
-            "RGPs that are located at a contig border and are likely incomplete."
-        )
-
-        if len(valid_rgps) == 0:
-            raise Exception(
-                "The pangenome has no complete RGPs. The clustering of RGP is then not possible."
-            )
-    else:
-        valid_rgps = set(pangenome.regions)
-
-    dereplicated_rgps = dereplicate_rgp(valid_rgps, disable_bar=disable_bar)
-
-    grr_graph = nx.Graph()
-    grr_graph.add_nodes_from(rgp.ID for rgp in dereplicated_rgps)
-
-    print("OLD", ">" * 40)
-    print(f"Constructed {len(dereplicated_rgps)} unique RGPs from pangenome")
-    print(grr_graph.number_of_nodes(), "nodes in graph")
-    print(grr_graph.number_of_edges(), "edges in graph")
-    print("<" * 40)
-    # Get all pairs of RGP that share at least one family
-
-    with Timer("OLD get pair to compute", logging):
-        family2rgp = defaultdict(set)
-        for rgp in dereplicated_rgps:
-            for fam in rgp.families:
-                family2rgp[fam].add(rgp)
-        rgp_pairs = set()
-        for rgps in family2rgp.values():
-            rgp_pairs |= {tuple(sorted(rgp_pair)) for rgp_pair in combinations(rgps, 2)}
-
-        pairs_count = len(rgp_pairs)
-
-        print(f"Computing GRR metric for {pairs_count:,} pairs of RGP.")
-
-        logging.getLogger("PPanGGOLiN").info(
-            f"Computing GRR metric for {pairs_count:,} pairs of RGP."
-        )
-
-    with Timer("OLD compute all metrics", logging):
-
-        pairs_of_rgps_metrics = []
-
-        for rgp_a, rgp_b in rgp_pairs:
-
-            pair_metrics = compute_rgp_metric(rgp_a, rgp_b, grr_cutoff, grr_metric)
-
-            if pair_metrics:
-                pairs_of_rgps_metrics.append(pair_metrics)
-
-        grr_graph.add_edges_from(pairs_of_rgps_metrics)
-
-    identical_rgps_objects = [
-        rgp for rgp in dereplicated_rgps if isinstance(rgp, IdenticalRegions)
-    ]
-    rgp_objects_in_graph = [rgp for rgp in dereplicated_rgps if isinstance(rgp, Region)]
-
-    if unmerge_identical_rgps:
-        rgp_objects_in_graph += add_edges_to_identical_rgps(
-            grr_graph, identical_rgps_objects
-        )
-
-    # cluster rgp based on grr value
-    logging.getLogger("PPanGGOLiN").info(
-        f"Louvain_communities clustering of RGP  based on {grr_metric} on {grr_graph}."
-    )
-
-    cluster_rgp_on_grr(grr_graph, grr_metric)
-
-    rgp_to_spot = {
-        region: int(spot.ID) for spot in pangenome.spots for region in spot.regions
-    }
-
-    if not unmerge_identical_rgps:
-        logging.getLogger("PPanGGOLiN").info(
-            "Add info on identical RGPs merged in the graph"
-        )
-        add_info_to_identical_rgps(grr_graph, identical_rgps_objects, rgp_to_spot)
-
-    rgps_in_graph = (
-        rgp_objects_in_graph if unmerge_identical_rgps else dereplicated_rgps
-    )
-
-    # add some attribute to the graph nodes.
-    logging.getLogger("PPanGGOLiN").info("Add RGP information to the graph")
-    add_info_to_rgp_nodes(grr_graph, rgp_objects_in_graph, rgp_to_spot)
-
-    if need_metadata:
-        add_rgp_metadata_to_graph(grr_graph, rgps_in_graph)
-
-    if "gexf" in graph_formats:
-        # writing graph in gexf format
-        graph_file_name = os.path.join(output, f"{basename}.gexf")
-        logging.getLogger("PPanGGOLiN").info(
-            f"Writing graph in gexf format in {graph_file_name}."
-        )
-        nx.readwrite.gexf.write_gexf(grr_graph, graph_file_name)
-
-    if "graphml" in graph_formats:
-        graph_file_name = os.path.join(output, f"{basename}.graphml")
-        logging.getLogger("PPanGGOLiN").info(
-            f"Writing graph in graphml format in {graph_file_name}."
-        )
-        nx.readwrite.graphml.write_graphml(grr_graph, graph_file_name)
-
-    outfile = os.path.join(output, f"{basename}.tsv")
-    logging.getLogger("PPanGGOLiN").info(
-        f"Writing rgp clusters in tsv format in {outfile}"
-    )
-
-    write_rgp_cluster_table(outfile, grr_graph, rgps_in_graph, grr_metric, rgp_to_spot)
-
-
 def launch(args: argparse.Namespace):
     """
     Command launcher
 
     :param args: All arguments provided by user
     """
-    # Get initial memory
-    rss_start = (
-        resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-    )  # Convert to MB (on Linux, ru_maxrss is in KB)
-    logging.info(f"Memory before start: RSS peak={rss_start:.2f} MB")
+
+    mk_outdir(args.output, args.force)
 
     if args.metadata_sep is not None:
         logging.getLogger("PPanGGOLiN").warning(
             "--metadata_sep is obsolete and ignored; metadata values are JSON-encoded in graphs."
         )
 
-    pangenome = Pangenome()
-
-    mk_outdir(args.output, args.force)
-    mk_outdir(args.output / "old", args.force)
-    mk_outdir(args.output / "new", args.force)
-
-    pangenome.add_file(args.pangenome)
-
-    A = int(os.environ.get("PPNEW"))
-
-    if A == 0 or A == 2:
-        with Timer("OLD", logging):
-            cluster_rgp(
-                pangenome,
-                grr_cutoff=args.grr_cutoff,
-                output=args.output / "old",
-                basename=args.basename,
-                ignore_incomplete_rgp=args.ignore_incomplete_rgp,
-                unmerge_identical_rgps=args.no_identical_rgp_merging,
-                grr_metric=args.grr_metric,
-                disable_bar=args.disable_prog_bar,
-                graph_formats=args.graph_formats,
-                add_metadata=args.add_metadata,
-                metadata_sep=args.metadata_sep,
-                metadata_sources=args.metadata_sources,
-            )
-    if A == 1 or A == 2:
-        with Timer("NEW", logging):
-            clustering = RGPClustering(args.pangenome)
-            clustering.run(
-                RGPClusteringOptions(
-                    unmerge_identical_rgps=args.no_identical_rgp_merging,
-                    grr_cutoff=args.grr_cutoff,
-                    metric=args.grr_metric,
-                    output=args.output / "new",
-                    basename=args.basename,
-                    graph_formats=args.graph_formats,
-                    with_metadata=args.add_metadata,
-                    metadata_sources=args.metadata_sources,
-                    ignore_incomplete_rgp=args.ignore_incomplete_rgp,
-                    disable_prog_bar=args.disable_prog_bar,
-                )
-            )
+    clustering = RGPClustering(args.pangenome)
+    clustering.run(
+        RGPClusteringOptions(
+            unmerge_identical_rgps=args.no_identical_rgp_merging,
+            grr_cutoff=args.grr_cutoff,
+            metric=args.grr_metric,
+            output=args.output,
+            basename=args.basename,
+            graph_formats=args.graph_formats,
+            with_metadata=args.add_metadata,
+            metadata_sources=args.metadata_sources,
+            ignore_incomplete_rgp=args.ignore_incomplete_rgp,
+            disable_prog_bar=args.disable_prog_bar,
+        )
+    )
 
 
 def subparser(sub_parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
@@ -2077,6 +1330,6 @@ def parser_cluster_rgp(parser: argparse.ArgumentParser):
     optional.add_argument(
         "--metadata_sep",
         required=False,
-        default="|",
+        default=None,
         help=argparse.SUPPRESS,
     )

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -76,12 +76,17 @@ class RegionProxy:
         return self.name
 
     def __hash__(self) -> int:
-        return id(self)
+        # Hash on the stable, deterministically-assigned ID rather than id(self):
+        # object addresses vary between runs and make set/dict iteration order
+        # (and therefore graph construction order) non-reproducible.
+        return hash(self.ID)
 
     def __eq__(self, rhs: "RegionProxy") -> bool:
-        return all(self.families == rhs.families,
-                   self.children == rhs.children,
-                   self.is_contig_border == rhs.is_contig_border)
+        return (
+            self.families == rhs.families
+            and self.children == rhs.children
+            and self.is_contig_border == rhs.is_contig_border
+        )
 
     def __lt__(self, obj):
         return self.ID < obj.ID
@@ -509,7 +514,10 @@ class RGPClustering:
         for table in reader.fetch(GeneFamTable):
             gene_to_family[table.gene] = table.family
 
-        unique_families = set(gene_to_family.values())
+        # Sort before enumerating: iterating a set of strings depends on
+        # PYTHONHASHSEED, which is randomized per process by default and would
+        # make family ID assignment (and therefore node ordering) non-reproducible.
+        unique_families = sorted(set(gene_to_family.values()))
         family_ids = {fam: idx for idx, fam in enumerate(unique_families)}
         self._family_id_to_name = {idx: fam for fam, idx in family_ids.items()}
 
@@ -653,7 +661,7 @@ class RGPClustering:
                 fams_to_rgps[fams_key].append(info)
 
             idx = 0
-            for rgps in fams_to_rgps.values():
+            for _fams, rgps in sorted(fams_to_rgps.items(), key=lambda x: x[0]):
                 self._construct_and_add(idx, rgps)
                 idx += len(rgps) + 1 if len(rgps) > 1 else 1
 
@@ -661,27 +669,69 @@ class RGPClustering:
             f"{len(rgp_infos)} RGPs loaded from pangenome ({len(self.rgps)} unique RGPs after dereplication)"
         )
 
-    def _compute_all_metrics(self, grr_cutoff: float, metric: RGPMetricType):
+    def _compute_all_metrics(
+        self, grr_cutoff: float, metric: RGPMetricType
+    ):
+        """Compute metrics without materializing the set of candidate pairs."""
         logging.info("Computing RGP metrics")
 
-        nb_pairs = 0
-        for r1, r2 in combinations(self.rgps, 2):
-            if len(r1.families & r2.families) == 0:
-                continue
+        memory_before = self._memory_snapshot()
 
-            nb_pairs += 1
-            if m := self._rgp_metric(r1, r2, grr_cutoff, metric):
-                self.metrics.append(m)
-                self.graph.add_edge(r1.ID, r2.ID, **m.__dict__)
+        family_to_rgps = defaultdict(list)
+        for rgp in self.rgps:
+            for family in rgp.families:
+                family_to_rgps[family].append(rgp)
+
+        nb_pairs = 0
+        for family in sorted(family_to_rgps):
+            for r1, r2 in combinations(family_to_rgps[family], 2):
+                shared_families = r1.families & r2.families
+                if family != next(iter(shared_families)):
+                    continue
+
+                nb_pairs += 1
+                if m := self._rgp_metric(r1, r2, grr_cutoff, metric):
+                    self.metrics.append(m)
+                    self.graph.add_edge(r1.ID, r2.ID, **m.__dict__)
+
         logging.info(
-            f"RGP metrics computed for {nb_pairs:,} pairs of RGPs ({len(self.metrics)} selected after GRR cutoff)"
+            f"RGP metrics computed for {nb_pairs:,} pairs of RGPs "
+            f"({len(self.metrics):,} selected after GRR cutoff)"
+        )
+        self._log_memory_usage("_compute_all_metrics_streaming", memory_before)
+
+    @staticmethod
+    def _memory_snapshot() -> tuple[float, float]:
+        current_rss_mb = None
+        with open("/proc/self/status") as status:
+            for line in status:
+                if line.startswith("VmRSS:"):
+                    current_rss_mb = int(line.split()[1]) / 1024
+                    break
+
+        if current_rss_mb is None:
+            raise RuntimeError("VmRSS is unavailable")
+
+        peak_rss_mb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        return current_rss_mb, peak_rss_mb
+
+    def _log_memory_usage(
+        self, method_name: str, memory_before: tuple[float, float]
+    ) -> None:
+        current_before, peak_before = memory_before
+        current_after, peak_after = self._memory_snapshot()
+        logging.info(
+            f"Memory for {method_name}: "
+            f"current RSS delta={current_after - current_before:.2f} MB, "
+            f"peak RSS increase={peak_after - peak_before:.2f} MB, "
+            f"peak RSS={peak_after:.2f} MB"
         )
 
     def _louvain_clustering(self, metric: RGPMetricType):
         logging.info(f"Clustering RGPs using Louvain communities on '{metric}' metric")
 
         partitions = nx.algorithms.community.louvain_communities(
-            self.graph, weight=metric
+            self.graph, weight=metric, seed=42
         )
         ordered_partitions = sorted(
             partitions,
@@ -955,19 +1005,15 @@ class RGPClustering:
                 metadata_sources=options.metadata_sources or None,
             )
 
-        # print("NEW", ">" * 40)
+        rss_peak_after_construct_regions = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        logging.info(f"Memory after _construct_regions: RSS peak={rss_peak_after_construct_regions:.2f} MB")
 
-        # print(f"Constructed {len(self.rgps)} unique RGPs from pangenome")
-        # print(self.graph.number_of_nodes(), "nodes in graph")
-        # print(self.graph.number_of_edges(), "edges in graph")
-        # print("<" * 40)
-        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        # logging.info(f"Memory after _construct_regions: RSS peak={rss_peak:.2f} MB")
-        with Timer("_compute_all_metrics", logging):
+
+        with Timer('_compute_all_metrics', logging):
             self._compute_all_metrics(options.grr_cutoff, options.metric)
-
-        # rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        # logging.info(f"Memory after _compute_all_metrics: RSS peak={rss_peak:.2f} MB")
+        
+        rss_peak_after_compute_all_metrics = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        logging.info(f"Memory after _compute_all_metrics: RSS peak={rss_peak_after_compute_all_metrics:.2f} MB")
 
         self._louvain_clustering(options.metric)
 
@@ -1480,7 +1526,7 @@ def cluster_rgp_on_grr(graph: nx.Graph, clustering_attribute: str = "grr"):
     """
 
     partitions = nx.algorithms.community.louvain_communities(
-        graph, weight=clustering_attribute
+        graph, weight=clustering_attribute, seed=42
     )
     ordered_partitions = sorted(
         partitions,
@@ -1664,7 +1710,8 @@ def cluster_rgp(
     print("<" * 40)
     # Get all pairs of RGP that share at least one family
 
-    with Timer("OLD compute_all_metrics", logging):
+    
+    with Timer("OLD get pair to compute", logging):
         family2rgp = defaultdict(set)
         for rgp in dereplicated_rgps:
             for fam in rgp.families:
@@ -1675,9 +1722,13 @@ def cluster_rgp(
 
         pairs_count = len(rgp_pairs)
 
+        print(f"Computing GRR metric for {pairs_count:,} pairs of RGP.")
+
         logging.getLogger("PPanGGOLiN").info(
             f"Computing GRR metric for {pairs_count:,} pairs of RGP."
         )
+
+    with Timer("OLD compute all metrics", logging):
 
         pairs_of_rgps_metrics = []
 
@@ -1688,7 +1739,8 @@ def cluster_rgp(
             if pair_metrics:
                 pairs_of_rgps_metrics.append(pair_metrics)
 
-    grr_graph.add_edges_from(pairs_of_rgps_metrics)
+        grr_graph.add_edges_from(pairs_of_rgps_metrics)
+
     identical_rgps_objects = [
         rgp for rgp in dereplicated_rgps if isinstance(rgp, IdenticalRegions)
     ]

--- a/ppanggolin/formats/h5reader.py
+++ b/ppanggolin/formats/h5reader.py
@@ -1,0 +1,95 @@
+import tables
+from pathlib import Path
+from dataclasses import dataclass
+import typing as tp
+
+@dataclass
+class TableAttribute:
+    name: str
+    predicate: tp.Callable = lambda x: True
+    transform: tp.Callable = lambda x: x
+
+def get_table_attributes(cls):
+    attrs = {}
+    for field_name, annotated_type in tp.get_type_hints(cls, include_extras=True).items():
+        if tp.get_origin(annotated_type) is tp.Annotated:
+            _, table_attr = tp.get_args(annotated_type)
+            attrs[field_name] = table_attr
+    return attrs
+
+class H5Reader:
+    def __init__(self, h5_file: Path) -> None:
+        if not h5_file.exists():
+            raise FileNotFoundError(f"The file {h5_file} does not exist.")
+        self.h5_file = h5_file
+        self.handle: tables.File | None = None 
+
+    def open(self) -> None:
+        self.handle = tables.open_file(str(self.h5_file), mode='r')
+    
+    def close(self) -> None:
+        if self.handle:
+            self.handle.close()
+            self.handle = None
+    
+    def __enter__(self) -> "H5Reader":
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def _check(self, obj: tp.Any) -> dict[str, TableAttribute]:
+        attrs = get_table_attributes(obj)
+        if not attrs:
+            raise ValueError(f"No TableAttributes found in {obj.__name__}.")
+        if "_table" not in obj.__dict__:
+            raise ValueError(f'Missing required TableAttribute "_table" in {obj.__name__}.')
+        return obj._table, attrs
+    
+    def _apply_override(self, attrs, override):
+        if not override:
+            return
+        
+        for field_name, attr in attrs.items():
+            if field_name in override:
+                if "transform" in override[field_name]:
+                    attr.transform = override[field_name]["transform"]
+                if "predicate" in override[field_name]["predicate"]:
+                    attr.predicate = override[field_name]["predicate"]
+
+    def fetch(self, obj: tp.Any, override: dict = {}) -> tp.Generator[tp.Any, None, None]:
+        if self.handle is None:
+            raise RuntimeError("H5 file is not opened. Use 'with' statement or call open() method.")
+        
+        table_name, attrs = self._check(obj)
+        h5_table = self.handle.get_node(table_name)
+        self._apply_override(attrs, override)
+
+        for row in h5_table.iterrows():
+            args = {}
+            for field_name, attr in attrs.items():
+                value = row[attr.name]
+                if not attr.predicate(value):
+                    break
+                else:
+                    args[field_name] = attr.transform(value)
+            else:
+                yield obj(**args)
+
+    def fetch_raw(self, obj: tp.Any) -> tp.Generator[tp.Any, None, None]:
+        if self.handle is None:
+            raise RuntimeError("H5 file is not opened. Use 'with' statement or call open() method.")
+        
+        table_name, attrs = self._check(obj)
+        h5_table = self.handle.get_node(table_name)
+        
+        for row in h5_table.iterrows():
+            obj(**{field_name: row[attr.name] for field_name, attr in attrs.items()})
+    
+    def fetch_rows(self, obj: tp.Any) -> tp.Generator[tp.Any, None, None]:
+        if self.handle is None:
+            raise RuntimeError("H5 file is not opened. Use 'with' statement or call open() method.")
+        table_name, _ = self._check(obj)
+        yield from self.handle.get_node(table_name).iterrows()
+        

--- a/ppanggolin/formats/h5reader.py
+++ b/ppanggolin/formats/h5reader.py
@@ -70,7 +70,7 @@ class H5Reader:
             if field_name in override:
                 if "transform" in override[field_name]:
                     attr.transform = override[field_name]["transform"]
-                if "predicate" in override[field_name]["predicate"]:
+                if "predicate" in override[field_name]:
                     attr.predicate = override[field_name]["predicate"]
 
     def fetch(

--- a/ppanggolin/formats/h5reader.py
+++ b/ppanggolin/formats/h5reader.py
@@ -45,7 +45,15 @@ class H5Reader:
             raise ValueError(f"No TableAttributes found in {obj.__name__}.")
         if "_table" not in obj.__dict__:
             raise ValueError(f'Missing required TableAttribute "_table" in {obj.__name__}.')
-        return obj._table, attrs
+        
+        table_name = obj._table
+
+        if table_name not in self.handle:
+            raise ValueError(
+                f"Required table '{table_name}' is missing from the pangenome H5 file: {self.h5_file}"
+            )
+    
+        return table_name, attrs
     
     def _apply_override(self, attrs, override):
         if not override:
@@ -63,7 +71,9 @@ class H5Reader:
             raise RuntimeError("H5 file is not opened. Use 'with' statement or call open() method.")
         
         table_name, attrs = self._check(obj)
+
         h5_table = self.handle.get_node(table_name)
+        
         self._apply_override(attrs, override)
 
         for row in h5_table.iterrows():

--- a/ppanggolin/formats/h5reader.py
+++ b/ppanggolin/formats/h5reader.py
@@ -3,35 +3,40 @@ from pathlib import Path
 from dataclasses import dataclass
 import typing as tp
 
+
 @dataclass
 class TableAttribute:
     name: str
     predicate: tp.Callable = lambda x: True
     transform: tp.Callable = lambda x: x
 
+
 def get_table_attributes(cls):
     attrs = {}
-    for field_name, annotated_type in tp.get_type_hints(cls, include_extras=True).items():
+    for field_name, annotated_type in tp.get_type_hints(
+        cls, include_extras=True
+    ).items():
         if tp.get_origin(annotated_type) is tp.Annotated:
             _, table_attr = tp.get_args(annotated_type)
             attrs[field_name] = table_attr
     return attrs
+
 
 class H5Reader:
     def __init__(self, h5_file: Path) -> None:
         if not h5_file.exists():
             raise FileNotFoundError(f"The file {h5_file} does not exist.")
         self.h5_file = h5_file
-        self.handle: tables.File | None = None 
+        self.handle: tables.File | None = None
 
     def open(self) -> None:
-        self.handle = tables.open_file(str(self.h5_file), mode='r')
-    
+        self.handle = tables.open_file(str(self.h5_file), mode="r")
+
     def close(self) -> None:
         if self.handle:
             self.handle.close()
             self.handle = None
-    
+
     def __enter__(self) -> "H5Reader":
         self.open()
         return self
@@ -44,21 +49,23 @@ class H5Reader:
         if not attrs:
             raise ValueError(f"No TableAttributes found in {obj.__name__}.")
         if "_table" not in obj.__dict__:
-            raise ValueError(f'Missing required TableAttribute "_table" in {obj.__name__}.')
-        
+            raise ValueError(
+                f'Missing required TableAttribute "_table" in {obj.__name__}.'
+            )
+
         table_name = obj._table
 
         if table_name not in self.handle:
             raise ValueError(
                 f"Required table '{table_name}' is missing from the pangenome H5 file: {self.h5_file}"
             )
-    
+
         return table_name, attrs
-    
+
     def _apply_override(self, attrs, override):
         if not override:
             return
-        
+
         for field_name, attr in attrs.items():
             if field_name in override:
                 if "transform" in override[field_name]:
@@ -66,14 +73,18 @@ class H5Reader:
                 if "predicate" in override[field_name]["predicate"]:
                     attr.predicate = override[field_name]["predicate"]
 
-    def fetch(self, obj: tp.Any, override: dict = {}) -> tp.Generator[tp.Any, None, None]:
+    def fetch(
+        self, obj: tp.Any, override: dict = {}
+    ) -> tp.Generator[tp.Any, None, None]:
         if self.handle is None:
-            raise RuntimeError("H5 file is not opened. Use 'with' statement or call open() method.")
-        
+            raise RuntimeError(
+                "H5 file is not opened. Use 'with' statement or call open() method."
+            )
+
         table_name, attrs = self._check(obj)
 
         h5_table = self.handle.get_node(table_name)
-        
+
         self._apply_override(attrs, override)
 
         for row in h5_table.iterrows():
@@ -89,17 +100,20 @@ class H5Reader:
 
     def fetch_raw(self, obj: tp.Any) -> tp.Generator[tp.Any, None, None]:
         if self.handle is None:
-            raise RuntimeError("H5 file is not opened. Use 'with' statement or call open() method.")
-        
+            raise RuntimeError(
+                "H5 file is not opened. Use 'with' statement or call open() method."
+            )
+
         table_name, attrs = self._check(obj)
         h5_table = self.handle.get_node(table_name)
-        
+
         for row in h5_table.iterrows():
             obj(**{field_name: row[attr.name] for field_name, attr in attrs.items()})
-    
+
     def fetch_rows(self, obj: tp.Any) -> tp.Generator[tp.Any, None, None]:
         if self.handle is None:
-            raise RuntimeError("H5 file is not opened. Use 'with' statement or call open() method.")
+            raise RuntimeError(
+                "H5 file is not opened. Use 'with' statement or call open() method."
+            )
         table_name, _ = self._check(obj)
         yield from self.handle.get_node(table_name).iterrows()
-        

--- a/ppanggolin/formats/h5reader.py
+++ b/ppanggolin/formats/h5reader.py
@@ -6,12 +6,24 @@ import typing as tp
 
 @dataclass
 class TableAttribute:
+    """Describe how a table column should be read and converted.
+
+    :param name: Name of the HDF5 column in the table.
+    :param predicate: Optional filter used to decide whether a row should be kept.
+    :param transform: Optional callable used to transform the raw value before instantiation.
+    """
+
     name: str
     predicate: tp.Callable = lambda x: True
     transform: tp.Callable = lambda x: x
 
 
 def get_table_attributes(cls):
+    """Collect table column metadata annotations from a dataclass.
+
+    :param cls: Dataclass type describing the HDF5 table schema.
+    :return: Mapping of field names to their TableAttribute metadata.
+    """
     attrs = {}
     for field_name, annotated_type in tp.get_type_hints(
         cls, include_extras=True
@@ -23,28 +35,48 @@ def get_table_attributes(cls):
 
 
 class H5Reader:
+    """Lightweight HDF5 table reader for PPanGGOLiN-style dataclass mappings."""
+
     def __init__(self, h5_file: Path) -> None:
+        """Initialize the reader for an HDF5 file.
+
+        :param h5_file: Path to the pangenome HDF5 file.
+        :raises FileNotFoundError: If the HDF5 file does not exist.
+        """
         if not h5_file.exists():
             raise FileNotFoundError(f"The file {h5_file} does not exist.")
         self.h5_file = h5_file
         self.handle: tables.File | None = None
 
     def open(self) -> None:
+        """Open the underlying HDF5 file in read mode."""
         self.handle = tables.open_file(str(self.h5_file), mode="r")
 
     def close(self) -> None:
+        """Close the HDF5 file if it is currently open."""
         if self.handle:
             self.handle.close()
             self.handle = None
 
     def __enter__(self) -> "H5Reader":
+        """Open the reader when used as a context manager.
+
+        :return: The initialized H5Reader instance.
+        """
         self.open()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Close the reader when leaving a context manager block."""
         self.close()
 
     def _check(self, obj: tp.Any) -> dict[str, TableAttribute]:
+        """Validate that a dataclass exposes a readable HDF5 table definition.
+
+        :param obj: Dataclass type describing the table schema.
+        :raises ValueError: If the schema is missing required metadata or the table is absent.
+        :return: The table name and column metadata mapping.
+        """
         attrs = get_table_attributes(obj)
         if not attrs:
             raise ValueError(f"No TableAttributes found in {obj.__name__}.")
@@ -63,6 +95,11 @@ class H5Reader:
         return table_name, attrs
 
     def _apply_override(self, attrs, override):
+        """Apply row-level overrides to a table attribute mapping.
+
+        :param attrs: Mapping of fields to TableAttribute definitions.
+        :param override: Optional per-field overrides with transform and/or predicate values.
+        """
         if not override:
             return
 
@@ -76,6 +113,13 @@ class H5Reader:
     def fetch(
         self, obj: tp.Any, override: dict = {}
     ) -> tp.Generator[tp.Any, None, None]:
+        """Yield dataclass instances generated from rows in the matching HDF5 table.
+
+        :param obj: Dataclass type used to construct each row object.
+        :param override: Optional field overrides for transform and predicate hooks.
+        :raises RuntimeError: If the HDF5 file is not open.
+        :return: Generator of instantiated dataclass objects.
+        """
         if self.handle is None:
             raise RuntimeError(
                 "H5 file is not opened. Use 'with' statement or call open() method."
@@ -99,6 +143,12 @@ class H5Reader:
                 yield obj(**args)
 
     def fetch_raw(self, obj: tp.Any) -> tp.Generator[tp.Any, None, None]:
+        """Yield raw table rows as dataclass instances without applying row filtering.
+
+        :param obj: Dataclass type used to construct each object.
+        :raises RuntimeError: If the HDF5 file is not open.
+        :return: Generator of dataclass objects with raw column values.
+        """
         if self.handle is None:
             raise RuntimeError(
                 "H5 file is not opened. Use 'with' statement or call open() method."
@@ -111,6 +161,12 @@ class H5Reader:
             obj(**{field_name: row[attr.name] for field_name, attr in attrs.items()})
 
     def fetch_rows(self, obj: tp.Any) -> tp.Generator[tp.Any, None, None]:
+        """Yield the raw row objects stored in a table without object conversion.
+
+        :param obj: Dataclass type describing the table schema.
+        :raises RuntimeError: If the HDF5 file is not open.
+        :return: Generator of raw rows from the selected HDF5 table.
+        """
         if self.handle is None:
             raise RuntimeError(
                 "H5 file is not opened. Use 'with' statement or call open() method."

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -1805,3 +1805,27 @@ def check_translation_table_to_use(
         f"Using the default translation table: {user_translation_table}."
     )
     return int(user_translation_table)
+class Timer:
+    def __init__(self, name: str = None, logger: logging.Logger = None):
+        """
+        Context manager to measure execution time.
+
+        :param name: Optional name of the code block
+        :param logger: Optional logger to log the elapsed time
+        """
+        self.name = name
+        self.logger = logger
+        self.start_time = None
+        self.elapsed = None
+
+    def __enter__(self):
+        self.start_time = time.perf_counter()
+        return self  
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.elapsed = time.perf_counter() - self.start_time
+        msg = f"[Timer:{self.name if self.name else ''}] {self.elapsed:.4f} seconds"
+        if self.logger:
+            self.logger.info(msg)
+        else:
+            print(msg)

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -1805,6 +1805,8 @@ def check_translation_table_to_use(
         f"Using the default translation table: {user_translation_table}."
     )
     return int(user_translation_table)
+
+
 class Timer:
     def __init__(self, name: str = None, logger: logging.Logger = None):
         """
@@ -1820,7 +1822,7 @@ class Timer:
 
     def __enter__(self):
         self.start_time = time.perf_counter()
-        return self  
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.elapsed = time.perf_counter() - self.start_time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
     "scipy>=1.0.0,<2.0.0",
     "plotly>=5.0.0,<6.0.0",
     "gmpy2>=2.0.0,<3.0.0",
-    "bokeh>=3.0.0,<3.4.0"
+    "bokeh>=3.0.0,<3.4.0",
+    "pyroaring>=1.0.0,<2.0.0",
 ]
 
 license = {file="LICENSE.txt"}

--- a/tests/functional_tests/test_rgp_clustering.py
+++ b/tests/functional_tests/test_rgp_clustering.py
@@ -67,7 +67,7 @@ def test_rgp_cluster_with_metadata(pangenome_with_metadata, tmp_path):
 
     cmd = (
         f"ppanggolin rgp_cluster --pangenome {pangenome_with_metadata} "
-        f"--output {outdir} --add_metadata --graph_formats graphml gexf" 
+        f"--output {outdir} --add_metadata --graph_formats graphml gexf"
     )
     run_ppanggolin_command(cmd)
 

--- a/tests/functional_tests/test_rgp_clustering.py
+++ b/tests/functional_tests/test_rgp_clustering.py
@@ -21,7 +21,7 @@ OUTDIR_COMMANDS_AND_FILES = [
     (
         "rgp_cluster_default",
         "ppanggolin rgp_cluster --pangenome {pangenome} --output {outdir}",
-        ["rgp_cluster.gexf", "rgp_cluster.tsv"],
+        ["rgp_cluster.graphml", "rgp_cluster.tsv"],
     ),
     (
         "rgp_cluster_graph_formats",
@@ -67,7 +67,7 @@ def test_rgp_cluster_with_metadata(pangenome_with_metadata, tmp_path):
 
     cmd = (
         f"ppanggolin rgp_cluster --pangenome {pangenome_with_metadata} "
-        f"--output {outdir} --add_metadata"
+        f"--output {outdir} --add_metadata --graph_formats graphml gexf" 
     )
     run_ppanggolin_command(cmd)
 

--- a/tests/unit_tests/region/test_rgp_cluster.py
+++ b/tests/unit_tests/region/test_rgp_cluster.py
@@ -6,7 +6,6 @@ from pyroaring import BitMap
 from ppanggolin.RGP.rgp_cluster import RGPClustering, RegionProxy, RGPInfo, Contig
 
 
-
 @pytest.fixture
 def rgp_a():
     return RegionProxy(
@@ -28,6 +27,7 @@ def rgp_b():
         is_whole_contig=False,
     )
 
+
 @pytest.fixture
 def clustering(tmp_path):
     clustering = RGPClustering(tmp_path / "pangenome.h5")
@@ -42,6 +42,7 @@ def clustering(tmp_path):
         )
     }
     return clustering
+
 
 @pytest.mark.parametrize(
     ("families_a", "families_b", "operation", "expected"),
@@ -64,7 +65,6 @@ def test_grr(clustering, families_a, families_b, operation, expected):
     assert clustering._grr(families_a, families_b, operation) == expected
 
 
-
 def test_rgp_metric(clustering, rgp_a, rgp_b):
     metric = clustering._rgp_metric(
         rgp_a,
@@ -78,6 +78,7 @@ def test_rgp_metric(clustering, rgp_a, rgp_b):
     assert metric.max_grr == 0.5
     assert metric.incomplete_aware_grr == 1.0
     assert metric.shared_family == 5
+
 
 def test_rgp_metric_below_cutoff(clustering, rgp_a, rgp_b):
     metric = clustering._rgp_metric(

--- a/tests/unit_tests/region/test_rgp_cluster.py
+++ b/tests/unit_tests/region/test_rgp_cluster.py
@@ -1,236 +1,136 @@
 #! /usr/bin/env python3
 
 import pytest
-from random import randint
-from typing import Generator, Set
-from ppanggolin.RGP import rgp_cluster
-from ppanggolin.genome import Gene, Contig, Organism
-from ppanggolin.geneFamily import GeneFamily
-from ppanggolin.region import Region
-from ppanggolin.RGP.rgp_cluster import IdenticalRegions
+from pyroaring import BitMap
+
+from ppanggolin.RGP.rgp_cluster import RGPClustering, RegionProxy, RGPInfo, Contig
+
 
 
 @pytest.fixture
-def genes() -> Generator[Set[Gene], None, None]:
-    """Create a set of genes to fill gene families"""
-    organism = Organism("organism")
-    contig = Contig(0, "contig")
-    genes = []
-    for i in range(randint(11, 20)):
-        gene = Gene(f"gene_{str(i)}")
-        gene.fill_annotations(
-            start=10 * i + 1, stop=10 * (i + 1), strand="+", position=i, genetic_code=4
-        )
-        gene.fill_parents(organism, contig)
-        contig[gene.start] = gene
-        genes.append(gene)
-    return genes
-
-
-@pytest.fixture
-def families(genes) -> Generator[Set[GeneFamily], None, None]:
-    """Create a set of gene families fill with genes to test edges"""
-    families = set()
-    genes = list(genes)
-    nb_families = randint(9, 20)
-    nb_genes_per_family = len(genes) // nb_families
-    idx_fam = 1
-    while idx_fam < nb_families:
-        family = GeneFamily(idx_fam, f"family_{idx_fam}")
-        idx_genes = 0
-        while idx_genes < nb_genes_per_family:
-            gene = genes[(idx_fam - 1) * nb_genes_per_family + idx_genes]
-            family.add(gene)
-            gene.family = family
-            idx_genes += 1
-        families.add(family)
-        idx_fam += 1
-    # last family fill with all the gene left
-    family = GeneFamily(idx_fam, f"family_{idx_fam}")
-    idx_genes = (idx_fam - 1) * nb_genes_per_family
-    while idx_genes < len(genes):
-        gene = genes[idx_genes]
-        family.add(gene)
-        gene.family = family
-        idx_genes += 1
-    families.add(family)
-    yield families
-
-
-@pytest.fixture
-def identical_rgps(genes, families) -> Generator[Set[Region], None, None]:
-    """Create a set of identical rgps"""
-    identical_rgps = set()
-    for i in range(1, randint(6, 21)):
-        rgp = Region(f"RGP_{i}")
-        # the three rgp have the gene content.
-        # in terms of family they are identical
-        for gene in genes:
-            rgp[gene.position] = gene
-        identical_rgps.add(rgp)
-    yield identical_rgps
-
-
-class TestIdenticalRegions:
-    def test_init_with_valid_inputs(self, identical_rgps, families):
-        """Tests that the IdenticalRegions object is initialized correctly with valid inputs."""
-        is_contig_border = True
-        identical_regions = IdenticalRegions(
-            "IdenticalRegions", identical_rgps, families, is_contig_border
-        )
-
-        assert identical_regions.name == "IdenticalRegions"
-        assert identical_regions.rgps == identical_rgps
-        assert identical_regions.families == families
-        assert identical_regions.is_contig_border == is_contig_border
-
-    @pytest.mark.parametrize("wrong_type", ["string", 1, 0.8, list(), dict()])
-    def test_init_with_identical_rgps_not_isintance_set(self, wrong_type, families):
-        """Tests that the IdenticalRegions object cannot be initialized with a not instance set for identical_rgps."""
-        with pytest.raises(TypeError):
-            IdenticalRegions("IdenticalRegions", wrong_type, families, True)
-
-    def test_init_with_rgp_is_not_instance_region_in_identical_rgps(
-        self, identical_rgps, families
-    ):
-        """Tests that the IdenticalRegions object raise TypeError if one element is not instance Region."""
-        with pytest.raises(TypeError):
-            IdenticalRegions(
-                "IdenticalRegions", identical_rgps.union({1}), families, True
-            )
-
-    def test_init_with_empty_identical_rgps(self, families):
-        """Tests that the IdenticalRegions object cannot be initialized with an empty set of identical regions."""
-        with pytest.raises(ValueError):
-            IdenticalRegions("IdenticalRegions", set(), families, True)
-
-    @pytest.mark.parametrize("wrong_type", ["string", 1, 0.8, list(), dict()])
-    def test_init_with_families_not_isintance_set(self, wrong_type, identical_rgps):
-        """Tests that the IdenticalRegions object cannot be initialized with a not instance set."""
-        with pytest.raises(TypeError):
-            IdenticalRegions("IdenticalRegions", identical_rgps, wrong_type, True)
-
-    def test_init_with_family_is_not_instance_genefamilies_in_families(
-        self, identical_rgps, families
-    ):
-        """Tests that the IdenticalRegions object raise TypeError if one element is not instance Region."""
-        with pytest.raises(TypeError):
-            IdenticalRegions(
-                "IdenticalRegions", identical_rgps, families.union({1}), True
-            )
-
-    def test_init_with_empty_families(self, identical_rgps):
-        """Tests that the IdenticalRegions object cannot be initialized with an empty set of identical regions."""
-        with pytest.raises(ValueError):
-            IdenticalRegions("IdenticalRegions", identical_rgps, set(), True)
-
-    def test_eq_with_equal_identical_regions(self):
-        """Tests that the __eq__ method returns Trueè when comparing two IdenticalRegions objects that have the same families,
-        identical regions, and contig border status.
-        """
-        rgp1 = Region("RGP1")
-        rgp2 = Region("RGP2")
-        family1 = GeneFamily(1, "Family1")
-        family2 = GeneFamily(2, "Family2")
-        identical_rgps1 = {rgp1, rgp2}
-        identical_rgps2 = {rgp1, rgp2}
-        families1 = {family1, family2}
-        families2 = {family1, family2}
-        is_contig_border = True
-
-        identical_regions1 = IdenticalRegions(
-            "IdenticalRegions", identical_rgps1, families1, is_contig_border
-        )
-        identical_regions2 = IdenticalRegions(
-            "IdenticalRegions", identical_rgps2, families2, is_contig_border
-        )
-
-        assert identical_regions1 == identical_regions2
-
-    def test_eq_with_non_identical_regions(self):
-        """Tests that the __eq__ method returns False when comparing
-        two IdenticalRegions objects that have different families.
-        """
-        rgp1 = Region("RGP1")
-        rgp2 = Region("RGP2")
-        family1 = GeneFamily(1, "Family1")
-        family2 = GeneFamily(2, "Family2")
-        identical_rgps1 = {rgp1, rgp2}
-        identical_rgps2 = {rgp1, rgp2}
-        families1 = {family1, family2}
-        families2 = {family1}
-        is_contig_border = True
-
-        identical_regions1 = IdenticalRegions(
-            "IdenticalRegions", identical_rgps1, families1, is_contig_border
-        )
-        identical_regions2 = IdenticalRegions(
-            "IdenticalRegions", identical_rgps2, families2, is_contig_border
-        )
-
-        assert identical_regions1 != identical_regions2
-
-
-def test_compute_grr():
-    """Tests that compute_grr returns the correct value when there is a non-zero intersection between families"""
-    set1 = {1, 2, 3, 4, 5}
-    set2 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-
-    assert rgp_cluster.compute_grr(set1, set2, min) == 1.0
-    assert rgp_cluster.compute_grr(set1, set2, max) == 0.5
-
-
-def test_dereplicate_rgp(identical_rgps):
-    list_identical_rgps = list(identical_rgps)
-    rgp1 = list_identical_rgps[0]
-    assert rgp_cluster.dereplicate_rgp({rgp1}) == [rgp1]
-
-    identical_region_obj = rgp_cluster.IdenticalRegions(
-        name="identical_rgps_0",
-        identical_rgps=identical_rgps,
-        families=set(list_identical_rgps[0].families),
+def rgp_a():
+    return RegionProxy(
+        ID=1,
+        name="RGP_A",
+        families=BitMap([1, 2, 3, 4, 5]),
         is_contig_border=True,
-    )
-    assert rgp_cluster.dereplicate_rgp(rgps=identical_rgps)[0] == identical_region_obj
-
-
-def test_compute_rgp_metric(genes, families):
-    RGP_a = Region("A")
-    RGP_b = Region("B")
-    list_genes = sorted(genes, key=lambda x: x.position)
-
-    for g in list_genes[:8]:
-        RGP_a[g.position] = g
-    for g in list_genes[3:7]:
-        RGP_b[g.position] = g
-
-    assert RGP_a.is_contig_border
-    assert not RGP_b.is_contig_border
-
-    shared_families = len(set(RGP_a.families).intersection(set(RGP_b.families)))
-    expected_grr = (
-        RGP_a.ID,
-        RGP_b.ID,
-        {
-            "incomplete_aware_grr": shared_families
-            / min(len(set(RGP_a.families)), len(set(RGP_b.families))),
-            "min_grr": shared_families
-            / min(len(set(RGP_a.families)), len(set(RGP_b.families))),
-            "max_grr": shared_families
-            / max(len(set(RGP_a.families)), len(set(RGP_b.families))),
-            "shared_family": shared_families,
-        },
-    )
-    # min_grr
-    min_result = rgp_cluster.compute_rgp_metric(RGP_a, RGP_b, 0, "min_grr")
-    assert min_result == expected_grr
-
-    # incomplete_aware_grr: same as min grr as rgp1 is incomplete
-    incomplete_aware_result = rgp_cluster.compute_rgp_metric(
-        RGP_a, RGP_b, 0, "incomplete_aware_grr"
+        is_whole_contig=False,
     )
 
-    assert incomplete_aware_result == expected_grr
 
-    # max grr is below cutoff so None is returned
-    assert rgp_cluster.compute_rgp_metric(RGP_a, RGP_b, 1000, "max_grr") is None
+@pytest.fixture
+def rgp_b():
+    return RegionProxy(
+        ID=2,
+        name="RGP_B",
+        families=BitMap([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        is_contig_border=False,
+        is_whole_contig=False,
+    )
+
+@pytest.fixture
+def clustering(tmp_path):
+    clustering = RGPClustering(tmp_path / "pangenome.h5")
+    clustering._fam_to_modules = {}
+    clustering._rgp_to_nb_genes = {}
+    clustering._rgp_contig_to_info = {
+        "contig_1": Contig(
+            organism="organism_1",
+            is_circular=False,
+            idx=0,
+            name="contig_1",
+        )
+    }
+    return clustering
+
+@pytest.mark.parametrize(
+    ("families_a", "families_b", "operation", "expected"),
+    [
+        (
+            BitMap([1, 2, 3, 4, 5]),
+            BitMap([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            min,
+            1.0,
+        ),
+        (
+            BitMap([1, 2, 3, 4, 5]),
+            BitMap([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            max,
+            0.5,
+        ),
+    ],
+)
+def test_grr(clustering, families_a, families_b, operation, expected):
+    assert clustering._grr(families_a, families_b, operation) == expected
+
+
+
+def test_rgp_metric(clustering, rgp_a, rgp_b):
+    metric = clustering._rgp_metric(
+        rgp_a,
+        rgp_b,
+        grr_cutoff=0,
+        metric="min_grr",
+    )
+
+    assert metric is not None
+    assert metric.min_grr == 1.0
+    assert metric.max_grr == 0.5
+    assert metric.incomplete_aware_grr == 1.0
+    assert metric.shared_family == 5
+
+def test_rgp_metric_below_cutoff(clustering, rgp_a, rgp_b):
+    metric = clustering._rgp_metric(
+        rgp_a,
+        rgp_b,
+        grr_cutoff=1.0,
+        metric="max_grr",
+    )
+
+    assert metric is None
+
+
+def test_rgp_metric_for_complete_rgps(clustering, rgp_a, rgp_b):
+    rgp_a.is_contig_border = False
+    rgp_a.is_whole_contig = False
+
+    rgp_b.is_contig_border = False
+    rgp_b.is_whole_contig = False
+
+    metric = clustering._rgp_metric(
+        rgp_a,
+        rgp_b,
+        grr_cutoff=0,
+        metric="max_grr",
+    )
+
+    assert metric is not None
+    assert metric.min_grr == 1.0
+    assert metric.max_grr == 0.5
+    assert metric.incomplete_aware_grr == 0.5
+    assert metric.shared_family == 5
+
+
+def test_construct_single(clustering):
+    rgp = RGPInfo(
+        name="RGP_1",
+        families_ids=BitMap([1, 2, 3]),
+        families=set(),
+        contig="contig_1",
+        is_contig_border=True,
+        is_whole_contig=False,
+    )
+
+    clustering._rgp_to_nb_genes["RGP_1"] = 10
+
+    region = clustering._construct_single(1, rgp)
+
+    assert region.ID == 1
+    assert region.name == "RGP_1"
+    assert region.families == BitMap([1, 2, 3])
+    assert region.organism == "organism_1"
+    assert region.contig == "contig_1"
+    assert region.length == 10
+    assert region.is_contig_border
+    assert not region.is_whole_contig
+    assert not region.is_identical_region


### PR DESCRIPTION
This PR refactors `rgp_cluster.py` to reduce runtime and memory usage and fixes RGP dereplication to consistently use family sets. The refactoring was primarily carried out by @tlemane .

### Faster and lighter H5 reading

* Introduces a new H5 reader that retrieves only the required columns instead of loading complete objects into Python.
* Uses `pyroaring` bitmaps to represent family IDs, making RGP family comparisons and GRR metric computation faster and more memory-efficient.

### Set-based RGP dereplication

RGPs are considered identical when they contain the same **set of families**, regardless of repeated occurrences of the same family.

The previous implementation used lists of family IDs for the dereplication key, meaning duplicated families could cause otherwise equivalent RGPs to be considered different.

This change aligns RGP dereplication with the set-based family comparison already used by the GRR calculation and avoids artificial distinctions caused by repeated family occurrences.

This is a subtle change that can slightly alter the graph structure, but does not fundamentally change the resulting clustering.

### Reproducibility

RGP clustering is now deterministic for a given pangenome:

* Family IDs are assigned by enumerating sorted family names instead of iterating over a Python `set`.
* `louvain_communities` is called with a fixed `seed`.

This removes the previous non-determinism caused by Python's randomized string hashing and the stochastic Louvain algorithm.

### Metadata support (`--add_metadata`)

The new `RGPClustering` implementation supports `--add_metadata`.

* Metadata values are no longer joined with a separator but are stored as JSON-encoded lists in the graph node attributes.
* This makes the `--metadata_sep` option obsolete; it is now hidden from the command-line help.

### Benchmarks 

A benchmark was performed on a set of pangenomes from PanGBank, comparing the original RGP clustering implementation with the optimized implementation. The optimization consistently reduces both runtime and memory usage, with the largest gains observed on larger pangenomes containing many RGPs.

| Pangenome | Genomes | RGPs | `rgp_optim` time speedup \(x\) | rgp_optim memory reduction \(x\) | ppanggolin2\.3\.1 time \(min\) | rgp_optim time \(min\) | ppanggolin2\.3\.1 memory \(GB\) | rgp_optim memory \(GB\) |
| --------- | ------- | ---- | ------------------------------ | -------------------------------- | ------------------------------ | ---------------------- | ------------------------------- | ----------------------- |
| GTDB_refseq_s__Clavibacter_sepedonicus_id11358 | 50 | 15 | 0\.95 | 1\.50 | 0\.20 | 0\.21 | 0\.39 | 0\.26 | 
| GTDB_refseq_s__Alistipes_muris_id10936 | 340 | 4736 | 1\.72 | 2\.18 | 0\.43 | 0\.25 | 0\.86 | 0\.40 | 
| GTDB_refseq_s__Aliarcobacter_butzleri_id10925 | 332 | 8515 | 2\.68 | 2\.94 | 0\.77 | 0\.29 | 1\.27 | 0\.43 | 
| GTDB_refseq_s__Aquipseudomonas_alloputida_id10974 | 232 | 12724 | 3\.60 | 3\.62 | 1\.38 | 0\.38 | 2\.03 | 0\.56 | 
| GTDB_refseq_s__Acinetobacter_pittii_id10854 | 776 | 36923 | 4\.83 | 2\.87 | 5\.76 | 1\.19 | 5\.32 | 1\.86 | 
| GTDB_all_s__Acinetobacter_baumannii_id12947 | 2002 | 97247 | 8\.49 | 2\.18 | 67\.35 | 7\.93 | 27\.44 | 12\.56 | 
| GTDB_refseq_s__Acinetobacter_baumannii_id10832 | 2002 | 107885 | 10\.47 | 1\.93 | 102\.48 | 9\.79 | 30\.67 | 15\.93 | 
| GTDB_refseq_s__Escherichia_coli_id11587 | 2002 | 165128 | 8\.83 | 2\.60 | 137\.23 | 15\.54 | 39\.09 | 15\.02 |
