### PR TITLE
normalize cli help with copilot

### DIFF
--- a/ppanggolin/RGP/genomicIsland.py
+++ b/ppanggolin/RGP/genomicIsland.py
@@ -431,7 +431,11 @@ def parser_rgp(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
 
     optional = parser.add_argument_group(title="Optional arguments")

--- a/ppanggolin/RGP/rgp_cluster.py
+++ b/ppanggolin/RGP/rgp_cluster.py
@@ -820,7 +820,11 @@ def parser_cluster_rgp(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=True, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=True,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
 
     optional = parser.add_argument_group(title="Optional arguments")
@@ -870,7 +874,7 @@ def parser_cluster_rgp(parser: argparse.ArgumentParser):
         "--basename",
         required=False,
         default="rgp_cluster",
-        help="basename for the output file",
+        help="Basename for the output file.",
     )
 
     optional.add_argument(
@@ -879,7 +883,7 @@ def parser_cluster_rgp(parser: argparse.ArgumentParser):
         required=False,
         type=Path,
         default="rgp_clustering",
-        help="Output directory",
+        help="Output directory.",
     )
 
     optional.add_argument(

--- a/ppanggolin/RGP/spot.py
+++ b/ppanggolin/RGP/spot.py
@@ -352,7 +352,11 @@ def parser_spot(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     optional = parser.add_argument_group(title="Optional arguments")
     optional.add_argument(
@@ -364,7 +368,7 @@ def parser_spot(parser: argparse.ArgumentParser):
             f"ppanggolin_output{time.strftime('DATE%Y-%m-%d_HOUR%H.%M.%S', time.localtime())}"
             f"_PID{str(os.getpid())}"
         ),
-        help="Output directory",
+        help="Output directory.",
     )
     optional.add_argument(
         "--spot_graph",

--- a/ppanggolin/align/alignOnPang.py
+++ b/ppanggolin/align/alignOnPang.py
@@ -880,18 +880,22 @@ def parser_align(parser: argparse.ArgumentParser):
         "--sequences",
         required=False,
         type=Path,
-        help="sequences (nucleotides or amino acids) to align on the pangenome gene families",
+        help="Sequences (nucleotides or amino acids) to align against the pangenome gene families.",
     )
 
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     required.add_argument(
         "-o",
         "--output",
         required=True,
         type=Path,
-        help="Output directory where the file(s) will be written",
+        help="Output directory where the file(s) will be written.",
     )
 
     optional = parser.add_argument_group(title="Optional arguments")
@@ -899,22 +903,22 @@ def parser_align(parser: argparse.ArgumentParser):
         "--no_defrag",
         required=False,
         action="store_true",
-        help="DO NOT Realign gene families to link fragments with"
-        "their non-fragmented gene family. (default: False)",
+        help="Do not realign gene families to link fragments with their non-fragmented gene family."
+        " (Default: False)",
     )
     optional.add_argument(
         "--identity",
         required=False,
         type=float,
         default=0.5,
-        help="min identity percentage threshold",
+        help="Minimum identity percentage threshold.",
     )
     optional.add_argument(
         "--coverage",
         required=False,
         type=float,
         default=0.8,
-        help="min coverage percentage threshold",
+        help="Minimum coverage percentage threshold.",
     )
     optional.add_argument(
         "--fast",
@@ -936,15 +940,14 @@ def parser_align(parser: argparse.ArgumentParser):
         "--getinfo",
         required=False,
         action="store_true",
-        help="Use this option to extract info related to the best hit of each query, "
-        "such as the RGP it is in, or the spots.",
+        help="Use this option to extract information related to the best hit of each query, "
+        "such as the RGP it is in or the spots it belongs to.",
     )
     optional.add_argument(
         "--draw_related",
         required=False,
         action="store_true",
-        help="Draw figures and provide graphs in a gexf format of the eventual spots"
-        " associated to the input sequences",
+        help="Draw figures and provide graphs in GEXF format for the spots associated with the input sequences.",
     )
     # but does not use the option
     optional.add_argument(
@@ -952,7 +955,7 @@ def parser_align(parser: argparse.ArgumentParser):
         required=False,
         action="store_true",
         help="In the context of provided annotation, use this option to read pseudogenes. "
-        "(Default behavior is to ignore them)",
+        "(Default behavior is to ignore them).",
     )
     optional.add_argument(
         "-c",
@@ -960,21 +963,21 @@ def parser_align(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
     optional.add_argument(
         "--tmpdir",
         required=False,
         type=Path,
         default=Path(tempfile.gettempdir()),
-        help="directory for storing temporary files",
+        help="Directory for storing temporary files.",
     )
     optional.add_argument(
         "--keep_tmp",
         required=False,
         default=False,
         action="store_true",
-        help="Keeping temporary files (useful for debugging).",
+        help="Keep temporary files (useful for debugging).",
     )
 
 

--- a/ppanggolin/annotate/annotate.py
+++ b/ppanggolin/annotate/annotate.py
@@ -1996,16 +1996,15 @@ def parser_annot(parser: argparse.ArgumentParser):
         "--fasta",
         required=False,
         type=Path,
-        help="A tab-separated file listing the genome names, and the fasta filepath of its genomic "
-        "sequence(s) (the fastas can be compressed with gzip). One line per genome.",
+        help="A tab-separated file listing genome names and the FASTA file paths of their genomic sequences "
+        "(the FASTA files can be compressed with gzip). One line per genome.",
     )
     required.add_argument(
         "--anno",
         required=False,
         type=Path,
-        help="A tab-separated file listing the genome names, and the gff/gbff filepath of its "
-        "annotations (the files can be compressed with gzip). One line per genome. "
-        "If this is provided, those annotations will be used.",
+        help="A tab-separated file listing genome names and the GFF/GBFF file paths of their annotations "
+        "(the files can be compressed with gzip). One line per genome. If this is provided, those annotations will be used.",
     )
 
     optional = parser.add_argument_group(title="Optional arguments")
@@ -2015,21 +2014,21 @@ def parser_annot(parser: argparse.ArgumentParser):
         required=False,
         type=Path,
         default=Path(f"ppanggolin_output{date}_PID{str(os.getpid())}"),
-        help="Output directory",
+        help="Output directory.",
     )
     optional.add_argument(
         "--allow_overlap",
         required=False,
         action="store_true",
         default=False,
-        help="Use to not remove genes overlapping with RNA features.",
+        help="Use this option to keep genes overlapping with RNA features.",
     )
     optional.add_argument(
         "--norna",
         required=False,
         action="store_true",
         default=False,
-        help="Use to avoid annotating RNA features.",
+        help="Use this option to avoid annotating RNA features.",
     )
     optional.add_argument(
         "--kingdom",
@@ -2037,8 +2036,7 @@ def parser_annot(parser: argparse.ArgumentParser):
         type=str.lower,
         default="bacteria",
         choices=["bacteria", "archaea"],
-        help="Kingdom to which the prokaryota belongs to, "
-        "to know which models to use for rRNA annotation.",
+        help="Kingdom to which the prokaryote belongs, to determine which models to use for rRNA annotation.",
     )
     optional.add_argument(
         "--translation_table",
@@ -2054,14 +2052,14 @@ def parser_annot(parser: argparse.ArgumentParser):
         "--basename",
         required=False,
         default="pangenome",
-        help="basename for the output file",
+        help="Basename for the output file.",
     )
     optional.add_argument(
         "--use_pseudo",
         required=False,
         action="store_true",
         help="In the context of provided annotation, use this option to read pseudogenes. "
-        "(Default behavior is to ignore them)",
+        "(Default behavior is to ignore them).",
     )
     optional.add_argument(
         "-p",
@@ -2070,8 +2068,7 @@ def parser_annot(parser: argparse.ArgumentParser):
         type=str.lower,
         choices=["single", "meta"],
         default=None,
-        help="Allow to force the prodigal procedure. "
-        "If nothing given, PPanGGOLiN will decide in function of contig length",
+        help="Allow forcing the Prodigal procedure. If not specified, PPanGGOLiN will decide based on contig length.",
     )
     optional.add_argument(
         "-c",
@@ -2079,14 +2076,14 @@ def parser_annot(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
     optional.add_argument(
         "--tmpdir",
         required=False,
         type=str,
         default=Path(tempfile.gettempdir()),
-        help="directory for storing temporary files",
+        help="Directory for storing temporary files.",
     )
 
 

--- a/ppanggolin/cluster/cluster.py
+++ b/ppanggolin/cluster/cluster.py
@@ -926,7 +926,11 @@ def parser_clust(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     clust = parser.add_argument_group(title="Clustering arguments")
     clust.add_argument(
@@ -934,30 +938,29 @@ def parser_clust(parser: argparse.ArgumentParser):
         required=False,
         type=restricted_float,
         default=0.8,
-        help="Minimal identity percent for two proteins to be in the same cluster",
+        help="Minimum identity percentage for two proteins to be in the same cluster.",
     )
     clust.add_argument(
         "--coverage",
         required=False,
         type=restricted_float,
         default=0.8,
-        help="Minimal coverage of the alignment for two proteins to be in the same cluster",
+        help="Minimum coverage of the alignment for two proteins to be in the same cluster.",
     )
     clust.add_argument(
         "--mode",
         required=False,
         default="1",
         choices=["0", "1", "2", "3"],
-        help="the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component),"
-        " 2: CD-HIT-like, 3: CD-HIT-like (lowmem)",
+        help="MMseqs2 clustering mode: 0 = Setcover, 1 = single linkage (or connected component), "
+        "2 = CD-HIT-like, 3 = CD-HIT-like (lowmem).",
     )
     clust.add_argument(
         "--no_defrag",
         required=False,
         default=False,
         action="store_true",
-        help="DO NOT Use the defragmentation strategy to link potential fragments "
-        "with their original gene family.",
+        help="Do not use the defragmentation strategy to link potential fragments with their original gene family.",
     )
 
     read = parser.add_argument_group(title="Read clustering arguments")
@@ -966,14 +969,14 @@ def parser_clust(parser: argparse.ArgumentParser):
         required=False,
         type=Path,
         help="A tab-separated list containing the result of a clustering. One line per gene. "
-        "First column is cluster ID, and second is gene ID",
+        "The first column is the cluster ID and the second is the gene ID.",
     )
     read.add_argument(
         "--infer_singletons",
         required=False,
         action="store_true",
-        help="When reading a clustering result with --clusters, if a gene is not in the provided file"
-        " it will be placed in a cluster where the gene is the only member.",
+        help="When reading a clustering result with --clusters, if a gene is not in the provided file, "
+        "it will be placed in a cluster where the gene is the only member.",
     )
     optional = parser.add_argument_group(title="Optional arguments")
     optional.add_argument(
@@ -991,21 +994,21 @@ def parser_clust(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
     optional.add_argument(
         "--tmpdir",
         required=False,
         type=Path,
         default=Path(tempfile.gettempdir()),
-        help="directory for storing temporary files",
+        help="Directory for storing temporary files.",
     )
     optional.add_argument(
         "--keep_tmp",
         required=False,
         default=False,
         action="store_true",
-        help="Keeping temporary files (useful for debugging).",
+        help="Keep temporary files (useful for debugging).",
     )
 
 

--- a/ppanggolin/context/searchGeneContext.py
+++ b/ppanggolin/context/searchGeneContext.py
@@ -827,7 +827,11 @@ def parser_context(parser: argparse.ArgumentParser):
         description="All of the following arguments are required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome.h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     required.add_argument(
         "-o",
@@ -838,24 +842,24 @@ def parser_context(parser: argparse.ArgumentParser):
         + time.strftime("_DATE%Y-%m-%d_HOUR%H.%M.%S", time.localtime())
         + "_PID"
         + str(os.getpid()),
-        help="Output directory where the file(s) will be written",
+        help="Output directory where the file(s) will be written.",
     )
     onereq = parser.add_argument_group(
-        title="Input file", description="One of the following argument is required :"
+        title="Input file", description="One of the following arguments is required:"
     )
     onereq.add_argument(
         "-S",
         "--sequences",
         required=False,
         type=Path,
-        help="Fasta file with the sequences of interest",
+        help="FASTA file with the sequences of interest.",
     )
     onereq.add_argument(
         "-F",
         "--family",
         required=False,
         type=Path,
-        help="List of family IDs of interest from the pangenome",
+        help="List of family IDs of interest from the pangenome.",
     )
     optional = parser.add_argument_group(title="Optional arguments")
     optional.add_argument(
@@ -865,8 +869,7 @@ def parser_context(parser: argparse.ArgumentParser):
         type=int,
         default=4,
         help="Size of the transitive closure used to build the graph. This indicates the number of "
-        "non related genes allowed in-between two related genes. Increasing it will improve "
-        "precision but lower sensitivity a little.",
+        "unrelated genes allowed between two related genes. Increasing it will improve precision but lower sensitivity slightly.",
     )
     optional.add_argument(
         "-w",
@@ -874,8 +877,7 @@ def parser_context(parser: argparse.ArgumentParser):
         required=False,
         type=int,
         default=5,
-        help="Number of neighboring genes that are considered on each side of "
-        "a gene of interest when searching for conserved genomic contexts.",
+        help="Number of neighboring genes considered on each side of a gene of interest when searching for conserved genomic contexts.",
     )
 
     optional.add_argument(
@@ -884,25 +886,23 @@ def parser_context(parser: argparse.ArgumentParser):
         required=False,
         type=restricted_float,
         default=0.85,
-        help="minimum jaccard similarity used to filter edges between gene families. Increasing it "
-        "will improve precision but lower sensitivity a lot.",
+        help="Minimum Jaccard similarity used to filter edges between gene families. Increasing it will improve precision but lower sensitivity considerably.",
     )
     optional.add_argument(
         "--graph_format",
-        help="Format of the context graph. Can be gexf or graphml.",
+        help="Format of the context graph. Can be GEXF or GraphML.",
         default="graphml",
         choices=["gexf", "graphml"],
     )
     align = parser.add_argument_group(
         title="Alignment arguments",
-        description="This argument makes sense only when --sequence is provided.",
+        description="This argument only makes sense when --sequence is provided.",
     )
     align.add_argument(
         "--no_defrag",
         required=False,
         action="store_true",
-        help="DO NOT Realign gene families to link fragments with"
-        "their non-fragmented gene family.",
+        help="Do not realign gene families to link fragments with their non-fragmented gene family.",
     )
     align.add_argument(
         "--fast",
@@ -917,14 +917,14 @@ def parser_context(parser: argparse.ArgumentParser):
         required=False,
         type=float,
         default=0.8,
-        help="min identity percentage threshold",
+        help="Minimum identity percentage threshold.",
     )
     align.add_argument(
         "--coverage",
         required=False,
         type=float,
         default=0.8,
-        help="min coverage percentage threshold",
+        help="Minimum coverage percentage threshold.",
     )
     align.add_argument(
         "--translation_table",
@@ -940,14 +940,14 @@ def parser_context(parser: argparse.ArgumentParser):
         required=False,
         type=str,
         default=Path(tempfile.gettempdir()),
-        help="directory for storing temporary files",
+        help="Directory for storing temporary files.",
     )
     align.add_argument(
         "--keep_tmp",
         required=False,
         default=False,
         action="store_true",
-        help="Keeping temporary files (useful for debugging).",
+        help="Keep temporary files (useful for debugging).",
     )
     align.add_argument(
         "-c",
@@ -955,7 +955,7 @@ def parser_context(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
 
 

--- a/ppanggolin/figures/drawing.py
+++ b/ppanggolin/figures/drawing.py
@@ -103,7 +103,11 @@ def parser_draw(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome.h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
 
     optional = parser.add_argument_group(title="Optional arguments")
@@ -113,7 +117,7 @@ def parser_draw(parser: argparse.ArgumentParser):
         required=False,
         type=Path,
         default=Path(f"ppanggolin_output{date}_PID{str(os.getpid())}"),
-        help="Output directory",
+        help="Output directory.",
     )
     optional.add_argument(
         "--tile_plot",

--- a/ppanggolin/formats/writeFlatGenomes.py
+++ b/ppanggolin/formats/writeFlatGenomes.py
@@ -876,14 +876,18 @@ def parser_flat(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     required.add_argument(
         "-o",
         "--output",
         required=True,
         type=Path,
-        help="Output directory where the file(s) will be written",
+        help="Output directory where the file(s) will be written.",
     )
     optional = parser.add_argument_group(title="Optional arguments")
 
@@ -956,7 +960,7 @@ def parser_flat(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
 
     context = parser.add_argument_group(
@@ -969,7 +973,7 @@ def parser_flat(parser: argparse.ArgumentParser):
         "--fasta",
         required=False,
         type=Path,
-        help="A tab-separated file listing the genome names, and the fasta filepath of its genomic "
+        help="A tab-separated file listing genome names and the FASTA file paths of their genomic "
         "sequence(s) (the fastas can be compressed with gzip). One line per genome.",
     )
 
@@ -977,7 +981,7 @@ def parser_flat(parser: argparse.ArgumentParser):
         "--anno",
         required=False,
         type=Path,
-        help="A tab-separated file listing the genome names, and the gff/gbff filepath of its "
+        help="A tab-separated file listing genome names and the GFF/GBFF file paths of their annotations "
         "annotations (the files can be compressed with gzip). One line per genome. "
         "If this is provided, those annotations will be used.",
     )

--- a/ppanggolin/formats/writeFlatMetadata.py
+++ b/ppanggolin/formats/writeFlatMetadata.py
@@ -205,14 +205,18 @@ def parser_flat(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     required.add_argument(
         "-o",
         "--output",
         required=True,
         type=Path,
-        help="Output directory where the file(s) will be written",
+        help="Output directory where the file(s) will be written.",
     )
     optional = parser.add_argument_group(title="Optional arguments")
 

--- a/ppanggolin/formats/writeFlatPangenome.py
+++ b/ppanggolin/formats/writeFlatPangenome.py
@@ -1703,14 +1703,18 @@ def parser_flat(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     required.add_argument(
         "-o",
         "--output",
         required=True,
         type=Path,
-        help="Output directory where the file(s) will be written",
+        help="Output directory where the file(s) will be written.",
     )
     optional = parser.add_argument_group(title="Optional arguments")
 
@@ -1851,7 +1855,7 @@ def parser_flat(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
 
 

--- a/ppanggolin/formats/writeMSA.py
+++ b/ppanggolin/formats/writeMSA.py
@@ -480,14 +480,18 @@ def parser_msa(parser: argparse.ArgumentParser):
         title="Required arguments", description="The following arguments are required :"
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     required.add_argument(
         "-o",
         "--output",
         required=True,
         type=Path,
-        help="Output directory where the file(s) will be written",
+        help="Output directory where the file(s) will be written.",
     )
 
     optional = parser.add_argument_group(
@@ -508,7 +512,7 @@ def parser_msa(parser: argparse.ArgumentParser):
         required=False,
         type=restricted_float,
         default=0.05,
-        help="minimum ratio of genomes in which the family must have multiple genes "
+        help="Minimum ratio of genomes in which the family must have multiple genes "
         "for it to be considered 'duplicated'",
     )
     optional.add_argument(
@@ -569,14 +573,14 @@ def parser_msa(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
     optional.add_argument(
         "--tmpdir",
         required=False,
         type=str,
         default=Path(tempfile.gettempdir()),
-        help="directory for storing temporary files",
+        help="Directory for storing temporary files.",
     )
 
 

--- a/ppanggolin/formats/writeSequences.py
+++ b/ppanggolin/formats/writeSequences.py
@@ -635,14 +635,18 @@ def parser_seq(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     required.add_argument(
         "-o",
         "--output",
         required=True,
         type=Path,
-        help="Output directory where the file(s) will be written",
+        help="Output directory where the file(s) will be written.",
     )
 
     context = parser.add_argument_group(
@@ -653,14 +657,14 @@ def parser_seq(parser: argparse.ArgumentParser):
         "--fasta",
         required=False,
         type=Path,
-        help="A tab-separated file listing the genome names, and the fasta filepath of its genomic "
+        help="A tab-separated file listing genome names and the FASTA file paths of their genomic "
         "sequence(s) (the fastas can be compressed with gzip). One line per genome.",
     )
     context.add_argument(
         "--anno",
         required=False,
         type=Path,
-        help="A tab-separated file listing the genome names, and the gff/gbff filepath of its "
+        help="A tab-separated file listing genome names and the GFF/GBFF file paths of their annotations "
         "annotations (the files can be compressed with gzip). One line per genome. "
         "If this is provided, those annotations will be used.",
     )
@@ -730,14 +734,18 @@ def parser_seq(parser: argparse.ArgumentParser):
         "This can be accessed using 'ppanggolin info'.",
     )
     optional.add_argument(
-        "--cpu", required=False, default=1, type=int, help="Number of available threads"
+        "--cpu",
+        required=False,
+        default=1,
+        type=int,
+        help="Number of available threads.",
     )
     optional.add_argument(
         "--tmpdir",
         required=False,
         type=Path,
         default=Path(tempfile.gettempdir()),
-        help="directory for storing temporary files",
+        help="Directory for storing temporary files.",
     )
     optional.add_argument(
         "--keep_tmp",

--- a/ppanggolin/graph/makeGraph.py
+++ b/ppanggolin/graph/makeGraph.py
@@ -188,7 +188,11 @@ def parser_graph(parser: argparse.ArgumentParser):
         title="Required arguments", description="Following arguments is required:"
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     optional = parser.add_argument_group(title="Optional arguments")
     optional.add_argument(

--- a/ppanggolin/info/info.py
+++ b/ppanggolin/info/info.py
@@ -146,7 +146,7 @@ def parser_info(parser: argparse.ArgumentParser):
         "--pangenome",
         required=True,
         type=Path,
-        help="Path to the pangenome .h5 file",
+        help="Path to the pangenome .h5 file.",
     )
 
     options = parser.add_argument_group(

--- a/ppanggolin/meta/meta.py
+++ b/ppanggolin/meta/meta.py
@@ -279,7 +279,11 @@ def parser_meta(parser: argparse.ArgumentParser):
         description="All of the following arguments are required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     required.add_argument(
         "-m",
@@ -331,7 +335,7 @@ if __name__ == "__main__":
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
     add_common_arguments(main_parser)
     set_verbosity_level(main_parser.parse_args())

--- a/ppanggolin/metrics/metrics.py
+++ b/ppanggolin/metrics/metrics.py
@@ -174,7 +174,7 @@ def parser_metrics(parser: argparse.ArgumentParser):
         "--pangenome",
         required=False,
         type=Path,
-        help="Path to the pangenome .h5 file",
+        help="Path to the pangenome .h5 file.",
     )
 
     onereq = parser.add_argument_group(

--- a/ppanggolin/mod/module.py
+++ b/ppanggolin/mod/module.py
@@ -223,7 +223,11 @@ def parser_module(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
     optional = parser.add_argument_group(title="Optional arguments")
     optional.add_argument(
@@ -266,7 +270,7 @@ def parser_module(parser: argparse.ArgumentParser):
         required=False,
         type=restricted_float,
         default=0.85,
-        help="minimum jaccard similarity used to filter edges between gene families. "
+        help="Minimum Jaccard similarity used to filter edges between gene families. "
         "Increasing it will improve precision but lower sensitivity a lot.",
     )
 
@@ -276,7 +280,7 @@ def parser_module(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
 
 

--- a/ppanggolin/nem/partition.py
+++ b/ppanggolin/nem/partition.py
@@ -960,7 +960,11 @@ def parser_partition(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome.h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
 
     optional = parser.add_argument_group(title="Optional arguments")
@@ -990,7 +994,7 @@ def parser_partition(parser: argparse.ArgumentParser):
             f"ppanggolin_output{time.strftime('DATE%Y-%m-%d_HOUR%H.%M.%S', time.localtime())}"
             f"_PID{str(os.getpid())}"
         ),
-        help="Output directory",
+        help="Output directory.",
     )
     optional.add_argument(
         "-fd",
@@ -1061,7 +1065,7 @@ def parser_partition(parser: argparse.ArgumentParser):
         "--seed",
         type=int,
         default=42,
-        help="seed used to generate random numbers",
+        help="Seed used to generate random numbers.",
     )
     optional.add_argument(
         "-c",
@@ -1069,14 +1073,14 @@ def parser_partition(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
     optional.add_argument(
         "--tmpdir",
         required=False,
         type=str,
         default=Path(tempfile.gettempdir()),
-        help="directory for storing temporary files",
+        help="Directory for storing temporary files.",
     )
 
 

--- a/ppanggolin/nem/rarefaction.py
+++ b/ppanggolin/nem/rarefaction.py
@@ -784,7 +784,11 @@ def parser_rarefaction(parser: argparse.ArgumentParser):
         description="One of the following arguments is required :",
     )
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome .h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
 
     optional = parser.add_argument_group(title="Optional arguments")
@@ -837,7 +841,7 @@ def parser_rarefaction(parser: argparse.ArgumentParser):
             f"ppanggolin_output{time.strftime('DATE%Y-%m-%d_HOUR%H.%M.%S', time.localtime())}"
             f"_PID{str(os.getpid())}"
         ),
-        help="Output directory",
+        help="Output directory.",
     )
     optional.add_argument(
         "-fd",
@@ -905,14 +909,14 @@ def parser_rarefaction(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
     optional.add_argument(
         "--tmpdir",
         required=False,
         type=str,
         default=Path(tempfile.gettempdir()),
-        help="directory for storing temporary files",
+        help="Directory for storing temporary files.",
     )
 
 

--- a/ppanggolin/projection/projection.py
+++ b/ppanggolin/projection/projection.py
@@ -1726,7 +1726,11 @@ def parser_projection(parser: argparse.ArgumentParser):
     required = parser.add_argument_group(title="Required arguments")
 
     required.add_argument(
-        "-p", "--pangenome", required=False, type=Path, help="The pangenome.h5 file"
+        "-p",
+        "--pangenome",
+        required=False,
+        type=Path,
+        help="Path to the pangenome .h5 file.",
     )
 
     required.add_argument(
@@ -1734,7 +1738,8 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         type=Path,
         help="Specify a FASTA file containing the genomic sequences of the genome(s) you wish to annotate, "
-        "or provide a tab-separated file listing genome names alongside their respective FASTA filepaths, with one line per genome.",
+        "or provide a tab-separated file listing genome names alongside their respective FASTA file paths, "
+        "with one line per genome.",
     )
 
     required.add_argument(
@@ -1742,7 +1747,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         type=Path,
         help="Specify an annotation file in GFF/GBFF format for the genome you wish to annotate. "
-        "Alternatively, you can provide a tab-separated file listing genome names alongside their respective annotation filepaths, "
+        "Alternatively, you can provide a tab-separated file listing genome names alongside their respective annotation file paths, "
         "with one line per genome. If both an annotation file and a FASTA file are provided, the annotation file will take precedence.",
     )
 
@@ -1757,7 +1762,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         type=str,
         default="input_genome",
-        help="Specify the name of the genome whose genome you want to annotate when providing a single FASTA or annotation file.",
+        help="Specify the name of the genome to annotate when providing a single FASTA or annotation file.",
     )
 
     required_single.add_argument(
@@ -1779,7 +1784,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         + time.strftime("_DATE%Y-%m-%d_HOUR%H.%M.%S", time.localtime())
         + "_PID"
         + str(os.getpid()),
-        help="Output directory",
+        help="Output directory.",
     )
 
     optional.add_argument(
@@ -1796,8 +1801,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         "--no_defrag",
         required=False,
         action="store_true",
-        help="DO NOT Realign gene families to link fragments with "
-        "their non-fragmented gene family. (default: False)",
+        help="Do not realign gene families to link fragments with their non-fragmented gene family. (Default: False)",
     )
 
     optional.add_argument(
@@ -1813,7 +1817,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         type=restricted_float,
         default=0.8,
-        help="min identity percentage threshold",
+        help="Minimum identity percentage threshold.",
     )
 
     optional.add_argument(
@@ -1821,7 +1825,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         type=restricted_float,
         default=0.8,
-        help="min coverage percentage threshold",
+        help="Minimum coverage percentage threshold.",
     )
 
     optional.add_argument(
@@ -1829,7 +1833,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         action="store_true",
         help="In the context of provided annotation, use this option to read pseudogenes. "
-        "(Default behavior is to ignore them)",
+        "(Default behavior is to ignore them).",
     )
 
     optional.add_argument(
@@ -1837,9 +1841,8 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         type=restricted_float,
         default=0.05,
-        help="minimum ratio of genomes in which the family must have multiple genes "
-        "for it to be considered 'duplicated'. "
-        "This metric is used to compute completeness and duplication of the input genomes",
+        help="Minimum ratio of genomes in which the family must have multiple genes for it to be considered 'duplicated'. "
+        "This metric is used to compute completeness and duplication of the input genomes.",
     )
 
     optional.add_argument(
@@ -1847,7 +1850,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         type=restricted_float,
         default=0.95,
-        help="Soft core threshold used when generating general statistics on the projected genome. "
+        help="Soft-core threshold used when generating general statistics on the projected genome. "
         "This threshold does not influence PPanGGOLiN's partitioning. "
         "The value determines the minimum fraction of genomes that must possess a gene family "
         "for it to be considered part of the soft core.",
@@ -1857,8 +1860,8 @@ def parser_projection(parser: argparse.ArgumentParser):
         "--spot_graph",
         required=False,
         action="store_true",
-        help="Write the spot graph to a file, with pairs of blocks of single copy markers flanking RGPs "
-        "as nodes. This graph can be used to visualize nodes that have RGPs from the input genome.",
+        help="Write the spot graph to a file, with pairs of blocks of single-copy markers flanking RGPs as nodes. "
+        "This graph can be used to visualize nodes that have RGPs from the input genome.",
     )
 
     optional.add_argument(
@@ -1889,14 +1892,14 @@ def parser_projection(parser: argparse.ArgumentParser):
         "--table",
         required=False,
         action="store_true",
-        help="Generate a tsv file for each input genome with pangenome annotations.",
+        help="Generate a TSV file for each input genome with pangenome annotations.",
     )
 
     optional.add_argument(
         "--compress",
         required=False,
         action="store_true",
-        help="Compress the files in .gz",
+        help="Compress the files in .gz.",
     )
 
     optional.add_argument(
@@ -1912,7 +1915,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
 
     optional.add_argument(
@@ -1920,7 +1923,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         type=Path,
         default=Path(tempfile.gettempdir()),
-        help="directory for storing temporary files",
+        help="Directory for storing temporary files.",
     )
 
     optional.add_argument(
@@ -1928,7 +1931,7 @@ def parser_projection(parser: argparse.ArgumentParser):
         required=False,
         default=False,
         action="store_true",
-        help="Keeping temporary files (useful for debugging).",
+        help="Keep temporary files (useful for debugging).",
     )
 
     optional.add_argument(

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -639,7 +639,7 @@ def add_common_arguments(subparser: argparse.ArgumentParser):
             type=int,
             default=1,
             choices=[0, 1, 2],
-            help="Indicate verbose level (0 for warning and errors only, 1 for info, 2 for debug)",
+            help="Verbose level: 0 = warnings and errors only, 1 = info, 2 = debug.",
         )
     else:
         logging.getLogger("PPanGGOLiN").warning(
@@ -653,7 +653,7 @@ def add_common_arguments(subparser: argparse.ArgumentParser):
             required=False,
             type=check_log,
             default="stdout",
-            help="log output file",
+            help="Log output file.",
         )
     else:
         logging.getLogger("PPanGGOLiN").warning(
@@ -667,7 +667,7 @@ def add_common_arguments(subparser: argparse.ArgumentParser):
             "--disable_prog_bar",
             required=False,
             action="store_true",
-            help="disables the progress bars",
+            help="Disable the progress bars.",
         )
     else:
         logging.getLogger("PPanGGOLiN").warning(
@@ -680,7 +680,7 @@ def add_common_arguments(subparser: argparse.ArgumentParser):
             "-f",
             "--force",
             action="store_true",
-            help="Force writing in output directory and in pangenome output file.",
+            help="Force overwrite in the output directory and pangenome output file.",
         )
     else:
         logging.getLogger("PPanGGOLiN").warning(

--- a/ppanggolin/workflow/all.py
+++ b/ppanggolin/workflow/all.py
@@ -554,27 +554,24 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         "--fasta",
         required=False,
         type=Path,
-        help="A tab-separated file listing the genome names, "
-        "and the fasta filepath of its genomic sequence(s) (the fastas can be compressed). "
-        "One line per genome. This option can be used alone.",
+        help="A tab-separated file listing genome names and the FASTA file paths of their genomic sequence(s) "
+        "(the FASTA files can be compressed). One line per genome. This option can be used alone.",
     )
 
     required.add_argument(
         "--anno",
         required=False,
         type=Path,
-        help="A tab-separated file listing the genome names, and the gff filepath of "
-        "its annotations (the gffs can be compressed). One line per genome. "
-        "This option can be used alone IF the fasta sequences are in the gff files, "
-        "otherwise --fasta needs to be used.",
+        help="A tab-separated file listing genome names and the GFF file paths of their annotations "
+        "(the GFF files can be compressed). One line per genome. This option can be used alone if the FASTA "
+        "sequences are already present in the GFF files; otherwise, --fasta must be used.",
     )
 
     required.add_argument(
         "--clusters",
         required=False,
         type=Path,
-        help="a tab-separated file listing the cluster names, the gene IDs, "
-        "and optionally whether they are a fragment or not.",
+        help="A tab-separated file listing cluster names, gene IDs, and optionally whether they are fragments.",
     )
 
     optional = parser.add_argument_group(title="Optional arguments")
@@ -585,14 +582,14 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         required=False,
         type=Path,
         default=Path(f"ppanggolin_output{date}_PID{str(os.getpid())}"),
-        help="Output directory",
+        help="Output directory.",
     )
 
     optional.add_argument(
         "--basename",
         required=False,
         default="pangenome",
-        help="basename for the output file",
+        help="Basename for the output file.",
     )
 
     optional.add_argument(
@@ -600,7 +597,7 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         required=False,
         action="store_true",
         dest="rarefaction_flag",
-        help="Use to compute the rarefaction curves (WARNING: can be time consuming)",
+        help="Compute the rarefaction curves. Warning: this can be time consuming.",
     )
 
     optional.add_argument(
@@ -609,7 +606,7 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         required=False,
         default=1,
         type=int,
-        help="Number of available cpus",
+        help="Number of available CPUs.",
     )
 
     optional.add_argument(
@@ -629,8 +626,7 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         type=str.lower,
         default="bacteria",
         choices=["bacteria", "archaea"],
-        help="Kingdom to which the prokaryota belongs to, "
-        "to know which models to use for rRNA annotation.",
+        help="Kingdom to which the prokaryote belongs, to determine which models to use for rRNA annotation.",
     )
 
     optional.add_argument(
@@ -638,8 +634,8 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         required=False,
         default="1",
         choices=["0", "1", "2", "3"],
-        help="the cluster mode of MMseqs2. 0: Setcover, 1: single linkage (or connected component),"
-        " 2: CD-HIT-like, 3: CD-HIT-like (lowmem)",
+        help="MMseqs2 clustering mode: 0 = Setcover, 1 = single linkage (or connected component), "
+        "2 = CD-HIT-like, 3 = CD-HIT-like (lowmem).",
     )
 
     optional.add_argument(
@@ -647,7 +643,7 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         required=False,
         type=restricted_float,
         default=0.8,
-        help="Minimal coverage of the alignment for two proteins to be in the same cluster",
+        help="Minimum coverage of the alignment for two proteins to be in the same cluster.",
     )
 
     optional.add_argument(
@@ -655,15 +651,14 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         required=False,
         type=restricted_float,
         default=0.8,
-        help="Minimal identity percent for two proteins to be in the same cluster",
+        help="Minimum identity percentage for two proteins to be in the same cluster.",
     )
 
     optional.add_argument(
         "--infer_singletons",
         required=False,
         action="store_true",
-        help="Use this option together with --clusters. "
-        "If a gene is not present in the provided clustering result file, "
+        help="Use this option together with --clusters. If a gene is not present in the provided clustering result file, "
         "it will be assigned to its own unique cluster as a singleton.",
     )
 
@@ -672,7 +667,7 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         required=False,
         action="store_true",
         help="In the context of provided annotation, use this option to read pseudogenes. "
-        "(Default behavior is to ignore them)",
+        "(Default behavior is to ignore them).",
     )
 
     optional.add_argument(
@@ -690,7 +685,7 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         "--no_defrag",
         required=False,
         action="store_true",
-        help="DO NOT Realign gene families to link fragments with their non-fragmented gene family.",
+        help="Do not realign gene families to link fragments with their non-fragmented gene family.",
     )
 
     optional.add_argument(
@@ -704,5 +699,5 @@ def add_workflow_args(parser: argparse.ArgumentParser):
         required=False,
         type=str,
         default=Path(tempfile.gettempdir()),
-        help="directory for storing temporary files",
+        help="Directory for storing temporary files.",
     )


### PR DESCRIPTION
This PR standardizes the help text across PPanGGOLiN commands to make the CLI more consistent and easier to read.

The changes focus on:
- consistent capitalization
- more uniform terminology across subcommands
- clearer phrasing for common options such as output directories, CPU count, temporary files, FASTA/GFF inputs, and thresholds

This is a text-only change: the meaning of each option is kept the same and no command behavior or defaults were modified.

### What changed
- Standardized wording for shared CLI options
- Harmonized help text style across commands
- Improved readability without altering functionality
