### PR TITLE
Support Python 3.10–3.13 and drop Python 3.9

### DIFF
--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest','macos-latest']
-        python-version: ['3.9','3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/check_recipes.yml
+++ b/.github/workflows/check_recipes.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest','macos-latest']
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest'] #['ubuntu-latest', 'macos-latest']
-        python-version: [3.14] # ['3.10', '3.12', '3.14']
+        os: ['ubuntu-latest', 'macos-latest']
+        python-version: ['3.10', '3.13']
     defaults:
       run:
         shell: conda run --no-capture-output -n ppanggolin bash -e {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
-        python-version: ['3.10', '3.12', '3.14']
+        os: ['ubuntu-latest'] #['ubuntu-latest', 'macos-latest']
+        python-version: [3.14] # ['3.10', '3.12', '3.14']
     defaults:
       run:
         shell: conda run --no-capture-output -n ppanggolin bash -e {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: ['3.9', '3.12']
+        python-version: ['3.10', '3.12', '3.14']
     defaults:
       run:
         shell: conda run --no-capture-output -n ppanggolin bash -e {0}

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -1,7 +1,7 @@
 # Installation
 
 ```{note}
-Supported Python versions are 3.9, 3.10, 3.11 and 3.12
+Supported Python versions are 3.10, 3.11, 3.12, 3.13 and 3.14
 ```
 
 ## Installing PPanGGOLiN with Conda (Recommended)

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -1,7 +1,8 @@
 # Installation
 
 ```{note}
-Supported Python versions are 3.10, 3.11, 3.12, 3.13 and 3.14
+Supported Python versions are 3.10, 3.11, 3.12 and 3.13.
+
 ```
 
 ## Installing PPanGGOLiN with Conda (Recommended)

--- a/ppanggolin/main.py
+++ b/ppanggolin/main.py
@@ -13,6 +13,7 @@ import argparse
 # local modules
 import ppanggolin.pangenome
 from ppanggolin.utils import (
+    RawTextHelpFormatterWithDefaults,
     check_input_files,
     set_verbosity_level,
     add_common_arguments,
@@ -96,10 +97,12 @@ def _build_command_summary(parser: argparse.ArgumentParser) -> str:
 def build_parser() -> argparse.ArgumentParser:
     """Build the PPanGGOLiN command-line parser without parsing user input."""
 
+    argparse.RawTextHelpFormatter = RawTextHelpFormatterWithDefaults
+
     parser = argparse.ArgumentParser(
         prog="ppanggolin",
         description="Depicting microbial species diversity via a Partitioned PanGenome Graph Of Linked Neighbors",
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=RawTextHelpFormatterWithDefaults,
         epilog=epilog + pan_epilog + rgp_epilog + mod_epilog,
     )
 

--- a/ppanggolin/main.py
+++ b/ppanggolin/main.py
@@ -1,48 +1,37 @@
-#!/usr/bin/env python3
-
 # default libraries
+import argparse
 import sys
 
-if sys.version_info < (3, 9):  # minimum is python3.9
-    raise AssertionError(
-        "Minimum python version to run PPanGGOLiN is 3.9. Your current python version is "
-        + ".".join(map(str, sys.version_info))
-    )
-import argparse
-
-# local modules
-import ppanggolin.pangenome
-from ppanggolin.utils import (
-    RawTextHelpFormatterWithDefaults,
-    check_input_files,
-    set_verbosity_level,
-    add_common_arguments,
-    manage_cli_and_config_args,
-)
-import ppanggolin.nem.partition
-import ppanggolin.nem.rarefaction
-import ppanggolin.graph
+import ppanggolin.align
 import ppanggolin.annotate
 import ppanggolin.cluster
+import ppanggolin.context
 import ppanggolin.figures
 import ppanggolin.formats
+import ppanggolin.graph
 import ppanggolin.info
-import ppanggolin.metrics
-import ppanggolin.align
-import ppanggolin.RGP
-import ppanggolin.mod
-import ppanggolin.context
-import ppanggolin.workflow
 import ppanggolin.meta
+import ppanggolin.metrics
+import ppanggolin.mod
+import ppanggolin.nem.partition
+import ppanggolin.nem.rarefaction
+import ppanggolin.RGP
 import ppanggolin.utility
-
+import ppanggolin.workflow
 from ppanggolin import (
     SUBCOMMAND_TO_SUBPARSER,
     epilog,
+    mod_epilog,
     pan_epilog,
     rgp_epilog,
-    mod_epilog,
     version,
+)
+from ppanggolin.utils import (
+    RawTextHelpFormatterWithDefaults,
+    add_common_arguments,
+    check_input_files,
+    manage_cli_and_config_args,
+    set_verbosity_level,
 )
 
 

--- a/ppanggolin/utils.py
+++ b/ppanggolin/utils.py
@@ -107,6 +107,12 @@ WRITE_GENOME_FLAG_DEFAULT_IN_WF = ["table", "proksee", "gff"]
 DRAW_FLAG_DEFAULT_IN_WF = ["tile_plot", "ucurve", "draw_spots"]
 
 
+class RawTextHelpFormatterWithDefaults(
+    argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelpFormatter
+):
+    """Preserve multiline formatting while appending default values to help text."""
+
+
 def check_log(log_file: str) -> TextIO:
     """
     Check if the output log is writable

--- a/ppanggolin_env.yaml
+++ b/ppanggolin_env.yaml
@@ -12,7 +12,7 @@ dependencies:
   - plotly>=5.0.0,<6.0.0
   - gmpy2>=2.0.0,<3.0.0
   - pandas>=2.0.0,<3.0.0
-  - numpy>1.24.0,<2.0.0
+  - numpy>1.24.0,<3.0.0
   - bokeh>=3.0.0,<3.4.0
   - graph-tool>=2
   # Tools that are not in Python 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers=[
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Bio-Informatics"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
     "numpy>1.24.0,<2.0.0",
@@ -61,9 +61,9 @@ doc = [
     "sphinxcontrib.mermaid==0.9.2",
 ]
 test = [
-    "pytest==7",
+    "pytest>=8.3.0,<9",
     "black==24.*",
-    "pytest-cov==6"
+    "pytest-cov>=6.0.0,<7"
 ]
 
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers=[
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Bio-Informatics"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 
 dependencies = [
     "numpy>1.24.0,<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers=[
 requires-python = ">=3.10,<3.14"
 
 dependencies = [
-    "numpy>1.24.0,<2.0.0",
+    "numpy>1.24.0,<3.0.0",
     "pandas>=2.0.0,<3.0.0",
     "tqdm>=4.0.0,<5.0.0",
     "tables>=3.8.0,<4.0.0",


### PR DESCRIPTION
### Summary
- Drop Python 3.9 support
- Add support for Python 3.13 on top of  3.10, 3.11 and 3.12 
- Update Python version checks and CI matrices to the supported Bioconda range
- Accept NumPy 2.x alongside recent NumPy 1.x releases in the package dependency constraints
- Upgrade pytest to a Python 3.13-compatible version

### Changes
- Updated the minimum supported Python version and dependency constraints in `pyproject.toml`, including the NumPy range to allow NumPy 2.x while keeping compatibility with supported scientific dependencies
- Updated installation docs in `docs/user/install.md`
- Updated GitHub Actions test matrices in:
  - `.github/workflows/main.yml`
  - `.github/workflows/check_recipes.yml`
- Removed the obsolete shebang from the CLI entry point as a harmless cleanup; the project is intended to be launched via the installed console script rather than by executing the module file directly
- Removed the Python version check in `main.py` because the package metadata already defines the supported Python range.

### Note
Python 3.14 is intentionally not included yet because the conda dependency graph used by PPanGGOLiN is not fully compatible with that version. 
