### PR TITLE
Automated release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,87 @@
+name: Create Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  create-release:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.title, 'Release ')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(cat VERSION)
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '$VERSION' in VERSION file."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release PR version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [[ ! "$PR_TITLE" =~ ^Release\ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release PR title: '$PR_TITLE'"
+            echo "::error::Expected: 'Release X.Y.Z'"
+            exit 1
+          fi
+
+          PR_VERSION="${PR_TITLE#Release }"
+
+          if [[ "$PR_VERSION" != "$VERSION" ]]; then
+            echo "::error::Release version mismatch."
+            echo "::error::PR title version: $PR_VERSION"
+            echo "::error::VERSION file: $VERSION"
+            exit 1
+          fi
+
+          echo "Release version confirmed: $VERSION"
+
+      - name: Check tag does not exist
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION already exists."
+            exit 1
+          fi
+
+      - name: Create tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "$VERSION" \
+            --title "PPanGGOLiN $VERSION" \
+            --draft \
+            --generate-notes

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,175 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 2.5.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '$VERSION'. Expected X.Y.Z."
+            exit 1
+          fi
+
+      - name: Check tag does not exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION already exists."
+            exit 1
+          fi
+
+      - name: Check release branch does not exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git ls-remote --exit-code --heads origin "release/$VERSION" >/dev/null 2>&1; then
+            echo "::error::Release branch release/$VERSION already exists."
+            exit 1
+          fi
+
+      - name: Check current VERSION
+        run: |
+          echo "Current VERSION:"
+          cat VERSION
+
+      - name: Update VERSION
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          printf '%s\n' "$VERSION" > VERSION
+
+      - name: Update expected files
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i \
+            "s/PPanGGOLiN_Version: [0-9]\+\.[0-9]\+\.[0-9]\+/PPanGGOLiN_Version: $VERSION/g" \
+            testingDataset/expected_info_files/*yaml
+
+      - name: Show release changes
+        run: |
+          git status --short
+          git diff -- VERSION testingDataset/expected_info_files/
+
+      - name: Generate PR body
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          PREVIOUS_TAG=$(git tag --list \
+            --sort=-version:refname \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | head -n 1)
+
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            echo "::error::Could not find a previous release tag."
+            exit 1
+          fi
+
+          echo "Previous release: $PREVIOUS_TAG"
+          echo "Preparing release: $VERSION"
+
+          COMMITS=$(gh api \
+            "repos/$GH_REPO/compare/$PREVIOUS_TAG...dev" \
+            --paginate \
+            --jq '.commits[].sha')
+
+          PRS=$(mktemp)
+
+          while read -r SHA; do
+            gh api \
+              "repos/$GH_REPO/commits/$SHA/pulls" \
+              --jq '.[] | "\(.number)\t\(.title)"' \
+              >> "$PRS"
+          done <<< "$COMMITS"
+
+          SORTED_PRS=$(mktemp)
+
+          sort -t $'\t' -k1,1n -u "$PRS" > "$SORTED_PRS"
+
+          {
+            echo "## Release $VERSION"
+            echo
+            echo "This PR prepares the **PPanGGOLiN $VERSION** release."
+            echo
+            echo "### Included PRs"
+            echo
+
+            if [[ -s "$SORTED_PRS" ]]; then
+              while IFS=$'\t' read -r NUMBER TITLE; do
+                echo "- #$NUMBER $TITLE"
+              done < "$SORTED_PRS"
+            else
+              echo "No pull requests found."
+            fi
+
+            echo
+            echo "### Release changes"
+            echo
+            echo "- Update \`VERSION\` to \`$VERSION\`"
+            echo "- Update expected files containing the PPanGGOLiN version"
+          } > release-pr-body.md
+
+          echo "Generated release PR body:"
+          cat release-pr-body.md
+
+          rm -f "$PRS" "$SORTED_PRS"
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release branch
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git switch -c "release/$VERSION"
+
+      - name: Commit release changes
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git add VERSION testingDataset/expected_info_files/
+          git commit -m "Release $VERSION"
+
+      - name: Push release branch
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git push origin "release/$VERSION"
+
+      - name: Create release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "release/$VERSION" \
+            --title "Release $VERSION" \
+            --body-file release-pr-body.md

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,130 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 2.5.0)"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run (do not commit, tag, push, or create release)"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Validate branch
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "::error::Release must be run from main."
+            exit 1
+          fi
+
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '$VERSION'. Expected X.Y.Z."
+            exit 1
+          fi
+
+      - name: Check tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION already exists."
+            exit 1
+          fi
+
+      - name: Check current version
+        run: |
+          echo "Current version:"
+          cat VERSION
+
+      - name: Update VERSION
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          printf '%s\n' "$VERSION" > VERSION
+
+      - name: Update expected files
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i \
+            "s/PPanGGOLiN_Version: [0-9]\+\.[0-9]\+\.[0-9]\+/PPanGGOLiN_Version: $VERSION/g" \
+            testingDataset/expected_info_files/*yaml
+
+      - name: Show release changes
+        run: |
+          git status --short
+          git diff -- VERSION testingDataset/expected_info_files/
+
+      - name: Run full test suite
+        env:
+          NUM_CPUS: 4
+        run: |
+          python -m pytest --cpu $NUM_CPUS --full
+
+      - name: Stop after dry run
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run completed successfully."
+          echo "The full test suite passed."
+          echo "No changes have been committed or pushed."
+
+      - name: Configure Git
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit release changes
+        if: ${{ !inputs.dry_run }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git add VERSION testingDataset/expected_info_files/
+          git commit -m "Release $VERSION"
+
+      - name: Create tag
+        if: ${{ !inputs.dry_run }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git tag "$VERSION"
+
+      - name: Push
+        if: ${{ !inputs.dry_run }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git push origin main
+          git push origin "$VERSION"
+
+      - name: Create draft release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh release create "$VERSION" \
+            --title "PPanGGOLiN $VERSION" \
+            --draft \
+            --generate-notes


### PR DESCRIPTION
This PR introduces two GitHub Actions to simplify the PPanGGOLiN release process.

### What is added

* **Prepare Release** — manually triggered from `dev` with the target version. It:

  * updates the `VERSION` file and expected files,
  * creates a release branch,
  * generates a list of PRs included since the previous release,
  * opens a PR against `main`.

* **Create Release** — automatically triggered when a release PR is merged into `main`. It:

  * validates the release version,
  * creates the version tag,
  * creates a draft GitHub Release with automatically generated release notes.

The draft release can then be reviewed and edited before being published.

### Release workflow

```text
dev
 │
 └─ Prepare Release
       │
       └─ Release PR → main
              │
              └─ CI + review
                    │
                    └─ merge
                         │
                         └─ Create Release
                              │
                              ├─ tag
                              └─ draft GitHub Release
```

The existing PyPI publishing workflow remains unchanged.

This keeps `main` as the latest stable release while removing most of the repetitive manual steps involved in preparing a release.
